### PR TITLE
Settings getting overridden + spelling mistake

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -285,11 +285,11 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         self.last_login = self.settings.get("last_login")
         self.set_timezone_offset(self.settings.get("timezone_offset_offset", self.timezone_offset))
         self.set_device(self.settings.get("device_settings"))
-        self.set_user_agent(self.settings.get("user_agent"))
-        self.set_uuids(self.settings.get("uuids", {}))
         self.set_country(self.settings.get("country", self.country))
         self.set_locale(self.settings.get("locale", self.locale))
         self.mid = self.settings.get("mid", self.cookie_dict.get("mid"))
+        self.set_user_agent(self.settings.get("user_agent"))
+        self.set_uuids(self.settings.get("uuids", {}))
         return True
 
     def login_by_sessionid(self, sessionid: str) -> bool:

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -283,7 +283,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             )
         self.authorization_data = self.settings.get('authorization_data', {})
         self.last_login = self.settings.get("last_login")
-        self.set_timezone_offset(self.settings.get("timezone_offset_offset", self.timezone_offset))
+        self.set_timezone_offset(self.settings.get("timezone_offset", self.timezone_offset))
         self.set_device(self.settings.get("device_settings"))
         self.set_country(self.settings.get("country", self.country))
         self.set_locale(self.settings.get("locale", self.locale))


### PR DESCRIPTION
Settings passed by the user were getting overridden when "set_user_agent" and "set_uuids" were called.

https://t.me/instagrapi/6719

UUIDs also get reset but I didn't know if this was intentional.