### PR TITLE
Correction of an error related to session recovery.

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -292,6 +292,10 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         self.set_locale(self.settings.get("locale", self.locale))
         self.set_country(self.settings.get("country", self.country))
         self.mid = self.settings.get("mid", self.cookie_dict.get("mid"))
+        # init headers
+        headers = self.base_headers
+        headers.update({'Authorization': self.authorization})
+        self.private.headers.update(headers)
         return True
 
     def login_by_sessionid(self, sessionid: str) -> bool:


### PR DESCRIPTION
After the session is restored, only requests via the private_request() method will work, since the headers for the request are initialized there via _send_private_request().
in the same requests as, for example, in photo_upload(), requests to self.private() / requests.Session() go directly without initializing headers.

Unfortunately, we had to break the encapsulation rule and initialize the headers in auth.py, otherwise it would be necessary to change all the methods that send requests and work with requests.Session() directly without an intermediary.

Fix #367