### PR TITLE
Add thread_message_limit param in direct_threads()

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -2,7 +2,7 @@
 
 | Method                                                                    | Return                  | Description
 | ------------------------------------------------------------------------- | ----------------------- | ----------------------------------
-| direct_threads(amount: int = 20)                                          | List[DirectThread]      | Get all threads from inbox
+| direct_threads(amount: int = 20, selected_filter: str = "", thread_message_limit: Optional[int] = None) <br> Note: selected_filter = "flagged" or "unread" | List[DirectThread] | Get all threads from inbox
 | direct_pending_inbox(amount: int = 20)                                    | List[DirectThread]      | Get all threads from pending inbox
 | direct_thread(thread_id: int, amount: int = 20)                           | DirectThread            | Get Thread with Messages
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -2,7 +2,7 @@ import random
 import re
 import time
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from instagrapi.exceptions import ClientNotFoundError, DirectThreadNotFound
 from instagrapi.extractors import (
@@ -34,7 +34,8 @@ class DirectMixin:
     Helpers for managing Direct Messaging
     """
 
-    def direct_threads(self, amount: int = 20, selected_filter: SELECTED_FILTER = "") -> List[DirectThread]:
+    def direct_threads(self, amount: int = 20, selected_filter: SELECTED_FILTER = "",
+                       thread_message_limit: Optional[int] = None) -> List[DirectThread]:
         """
         Get direct message threads
 
@@ -61,6 +62,10 @@ class DirectMixin:
             params.update({
                 "selected_filter": selected_filter,
                 "fetch_reason": "manual_refresh",
+            })
+        if thread_message_limit:
+            params.update({
+                "thread_message_limit": thread_message_limit
             })
         cursor = None
         threads = []


### PR DESCRIPTION
Hello!

I found your repository by chance and I really liked it.

Doing some tests in your lib, I noticed that the ```direct_threads()``` method doesn't set the limit of messages that will bring inside a thread. I believe this can make the request a little slower as it also has post-processing to transform the server's response to higher level objects.

So I added the optional ```thread_message_limit: int``` parameter to the method that brings up the threads. Since you have the ```direct_messages(thread.pk)``` method, I think the programmer might want to limit the amount of thread messages, I don't know, maybe to 5.

Do you think this modification makes sense for the project?

PS: I changed the documentation of the direct module. I added the ```selected_filter``` parameter and the ```thread_message_limit``` parameter.