### PR TITLE
Fixed 2FA authentication

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -408,11 +408,14 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 "username": username,
                 "trust_this_device": "0",
                 "guid": self.uuid,
-                "device_id": self.uuid,
+                "device_id": self.android_device_id,
                 "waterfall_id": str(uuid4()),
                 "verification_method": "3"
             }
             logged = self.private_request("accounts/two_factor_login/", data, login=True)
+            self.authorization_data = self.parse_authorization(
+                self.last_response.headers.get('ig-set-authorization')
+            )
         if logged:
             self.login_flow()
             self.last_login = time.time()


### PR DESCRIPTION
Hi, @adw0rd.

Currently `master` branch has multiple issues with 2FA authentication.
## Fixed issues
### Incorrect `device_id` field value in the second stage of 2FA
**Description**: Currently 2FA always fails with `This code is no longer valid. Please request a new one.` error.

**What's wrong**: You're send `uuid` in the second request to  `api/v1/accounts/two_factor_login/` in the `device_id` field, instead of expected `android_device_id`, but in the first login request you sent correct `android_device_id` in this field to `api/v1/accounts/login/` path.

**Referenced issues**: #276, #362
First login request `device_id` field:
https://github.com/adw0rd/instagrapi/blob/d78529939c5611ae030ecdec4d6e93fc01888906/instagrapi/mixins/auth.py#L388
Second 2FA request `device_id` field:
https://github.com/adw0rd/instagrapi/blob/d78529939c5611ae030ecdec4d6e93fc01888906/instagrapi/mixins/auth.py#L411


### The authorization header after the completion of the 2FA request is not synchronized with the requests.
**Description**: After passing 2FA we get error at `self.loginflow()` function call
**What's wrong**: We don't sync `Authorization` header after 2FA request complete.
**Referenced issues**: None
https://github.com/adw0rd/instagrapi/blob/d78529939c5611ae030ecdec4d6e93fc01888906/instagrapi/mixins/auth.py#L415