### PR TITLE
Add method for getting all media from DM thread

### DIFF
--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -10,12 +10,14 @@ from instagrapi.extractors import (
     extract_direct_response,
     extract_direct_short_thread,
     extract_direct_thread,
+    extract_direct_media,
 )
 from instagrapi.types import (
     DirectMessage,
     DirectResponse,
     DirectShortThread,
     DirectThread,
+    Media,
 )
 from instagrapi.utils import dumps
 
@@ -708,3 +710,47 @@ class DirectMixin:
             with_signature=False,
         )
         return extract_direct_message(result["payload"])
+
+    def direct_media(self, thread_id: int, amount: int = 20) -> List[Media]:
+        """
+        Get all the media from a thread
+
+        Parameters
+        ----------
+        thread_id: int
+            Unique identifier of a Direct Message thread
+
+        amount: int, optional
+            Maximum number of media to return, default is 20
+
+        Returns
+        -------
+        List[Media]
+            A list of objects of Media
+        """
+        assert self.user_id, "Login required"
+        params = {
+            "limit": 20,
+            "media_type": "photos_and_videos"
+        }
+        max_timestamp = None
+        items = []
+        while True:
+            if max_timestamp:
+                params["max_timestamp"] = max_timestamp
+            try:
+                result = self.private_request(
+                    f"direct_v2/threads/{thread_id}/media/", params=params
+                )
+            except ClientNotFoundError as e:
+                raise DirectThreadNotFound(e, thread_id=thread_id, **self.last_json)
+            for item in result["items"]:
+                media = item.get("media")
+                items.append(extract_direct_media(media))
+                max_timestamp = item.get("timestamp")
+            more_available = result.get("more_available")
+            if not more_available or (amount and len(items) >= amount):
+                break
+        if amount:
+            items = items[:amount]
+        return items


### PR DESCRIPTION
This method uses the endpoint for getting all media from a DM thread. Much faster for getting all media than direct_thread method.