### PR TITLE
added empty panavision_mode parameter and random is_dark_mode paramet…

### DIFF
--- a/instagrapi/mixins/highlight.py
+++ b/instagrapi/mixins/highlight.py
@@ -58,7 +58,9 @@ class HighlightMixin:
             "supported_capabilities_new": json.dumps(config.SUPPORTED_CAPABILITIES),
             "phone_id": self.phone_id,
             "battery_level": random.randint(25, 100),
+            "panavision_mode": "",
             "is_charging": random.randint(0, 1),
+            "is_dark_mode": random.randint(0, 1),
             "will_sound_on": random.randint(0, 1),
         }
         result = self.private_request(f"highlights/{user_id}/highlights_tray/", params=params)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26529935/178159483-584c2f13-e1d7-48f1-a465-1799e7382b13.png)
I noticed these url parameters where being used by the mobile api.