### PR TITLE
Fix to critical codebase breaking JSON parse error from public_a1_request

### DIFF
--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -166,9 +166,9 @@ class PublicRequestMixin:
     def public_a1_request(self, endpoint, data=None, params=None, headers=None):
         url = self.PUBLIC_API_URL + endpoint.lstrip("/")
         if params:
-            params.update({"__a": 1})
+            params.update({"__a": 1,'__d':'dis'})
         else:
-            params = {"__a": 1}
+            params = {"__a": 1,'__d':'dis'}
 
         response = self.public_request(
             url, data=data, params=params, headers=headers, return_json=True


### PR DESCRIPTION
The current public_a1_request() function in public.py is broken and causes crashes:

> Status 200: JSONDecodeError in public_request

public_a1_request() is a critical low level function used by a large amount of instagrapi high level functions. This is a tested and simple fix, please merge ASAP.

Fixes #752