### PR TITLE
Added MultipleAccountsMixin

### DIFF
--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -35,6 +35,7 @@ from instagrapi.mixins.timeline import ReelsMixin
 from instagrapi.mixins.totp import TOTPMixin
 from instagrapi.mixins.user import UserMixin
 from instagrapi.mixins.video import DownloadVideoMixin, UploadVideoMixin
+from instagrapi.mixins.multiple_accounts import MultipleAccountsMixin
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -74,6 +75,7 @@ class Client(
     ReelsMixin,
     BloksMixin,
     TOTPMixin,
+    MultipleAccountsMixin
 ):
     proxy = None
     logger = logging.getLogger("instagrapi")

--- a/instagrapi/mixins/multiple_accounts.py
+++ b/instagrapi/mixins/multiple_accounts.py
@@ -1,0 +1,16 @@
+class MultipleAccountsMixin:
+    """
+    Helpers for multiple accounts.
+    """
+
+    def featured_accounts_v1(self, target_user_id: int) -> dict:
+        target_user_id = str(target_user_id)
+        return self.private_request(
+            "multiple_accounts/get_featured_accounts/",
+            params={
+                "target_user_id": target_user_id
+            }
+        )
+
+    def get_account_family_v1(self) -> dict:
+        return self.private_request("multiple_accounts/get_account_family/")


### PR DESCRIPTION
These endpoints seem to be legacy since logging into multiple accounts with one set of credentials is no longer accessible. It should still work for people who used it in the past. https://help.instagram.com/615080698917740?__coig_restricted=1
The reason for this pull request is that the app still calls these endpoints.
A call to `multiple_accounts/get_account_family/`is being made after logging in. 
![image](https://user-images.githubusercontent.com/26529935/178952430-334934fb-f002-46be-acfa-76934ab03478.png)

And `multiple_accounts/get_featured_accounts/` when viewing an profile where the `target_user_id` parameter is the user id of the account you are viewing.
![image](https://user-images.githubusercontent.com/26529935/178953017-ac66c7dc-eeb8-4d74-a4e8-8d9078baa2ae.png)

Maybe somebody who has used this feature in the past can expand on these settings. I think its good to include them just to make your client look more like the legit app.