### PR TITLE
Added an OPTIONAL delay_range parameter to the client class. If set, random_delay will be triggered before every public_request and private_request. Helps prevent account locks.

### DIFF
--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -80,9 +80,10 @@ class Client(
     proxy = None
     logger = logging.getLogger("instagrapi")
 
-    def __init__(self, settings: dict = {}, proxy: str = None, **kwargs):
+    def __init__(self, settings: dict = {}, proxy: str = None, delay_range: list = None, **kwargs):
         super().__init__(**kwargs)
         self.settings = settings
+        self.delay_range = delay_range
         self.set_proxy(proxy)
         self.init()
 

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -27,7 +27,7 @@ from instagrapi.exceptions import (
     UnknownError,
     VideoTooLongException,
 )
-from instagrapi.utils import dumps, generate_signature
+from instagrapi.utils import dumps, generate_signature, random_delay
 
 
 def manual_input_code(self, username: str, choice=None):
@@ -428,6 +428,8 @@ class PrivateRequestMixin:
             extra_sig=extra_sig,
         )
         try:
+            if self.delay_range:
+                random_delay(delay_range=self.delay_range)
             self.private_requests_count += 1
             self._send_private_request(endpoint, **kwargs)
         except ClientRequestTimeout:

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -22,7 +22,7 @@ from instagrapi.exceptions import (
     ClientThrottledError,
     GenericRequestError,
 )
-from instagrapi.utils import json_value
+from instagrapi.utils import json_value, random_delay
 
 
 class PublicRequestMixin:
@@ -69,6 +69,8 @@ class PublicRequestMixin:
         assert retries_timeout <= 600, "Retries timeout is too high"
         for iteration in range(retries_count):
             try:
+                if self.delay_range:
+                    random_delay(delay_range=self.delay_range)
                 return self._send_public_request(url, **kwargs)
             except (ClientLoginRequired, ClientNotFoundError, ClientBadRequestError) as e:
                 raise e  # Stop retries

--- a/instagrapi/utils.py
+++ b/instagrapi/utils.py
@@ -107,3 +107,9 @@ def generate_jazoest(symbols: str) -> str:
 def date_time_original(localtime):
     # return time.strftime("%Y:%m:%d+%H:%M:%S", localtime)
     return time.strftime("%Y%m%dT%H%M%S.000Z", localtime)
+
+
+def random_delay(delay_range: list):
+    """Trigger sleep of a random floating number in range min_sleep to max_sleep
+    """
+    return time.sleep(random.uniform(delay_range[0], delay_range[1]))


### PR DESCRIPTION
- delay_range is now an OPTIONAL variable that can be set in the client class
- if delay_range is set, random_delay() is called before EVERY public_request() and private_request()
- if delay_range is NOT set, public_request() and private_request() will perform as usual with no delay

**Example:**
```
cl = Client()
cl.delay_range = [1, 3]
cl.hashtag_medias_top("foryou", amount=50)
```
**Explanation:**
This will now trigger a randomized float sleep between 1-3 seconds before EVERY low level public_request() and private_request() which are used by higher level functions. For example, the above  "cl.hashtag_medias_top("foryou", amount=50)" usually makes about 1 low level public/private request per 10 "amounts" requested. Thus a 1-3 second delay will be triggered about 5 different times in this specific request. This helps prevent account locks. It can be set dynamically by the user between calling different functions. User can delay_range back to "None" or increase/decrease values before calling any subsequent functions to edit delay.

This is the requested improvement to closed PR #776 .