### PR TITLE
This is already being called, calling it again breaks the changes set…

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -357,7 +357,6 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         """
         self.username = username
         self.password = password
-        self.init()
         if relogin:
             self.private.cookies.clear()
             if self.relogin_attempt > 1:


### PR DESCRIPTION
Hi. Since the init method has already been called, it breaks the changes made when it is called again during login. For example;
`cl = Client()
 cl.set_country("TR")
 cl.set_locale("tr_TR")
 cl.set_country_code(90)
 cl.set_user_agent("Instagram 245.0.0.13.110 (iPhone9,4; iOS 15_6; tr_TR; tr-TR; scale=2.88; 1080x1920; 384816942)")
 cl.login("username", "pass")`

`user agent result: Instagram 203.0.0.29.118 Android (26/8.0.0; 480dpi; 1080x1920; Xiaomi; MI 5s; capricorn; qcom; tr_TR; 314665256)`

Actually there is something to fix this problem but it is commented out.
instagrapi.mixins.auth.py:635 ;
`# self.settings["user_agent"] = self.user_agent`

But I solved it differently as I don't need to call the init method 2nd time.