### PR TITLE
full size image when available

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -90,14 +90,15 @@ def extract_media_gql(data):
         media["media_type"] = 0
     if media.get("media_type") == 2 and not media.get("product_type"):
         media["product_type"] = "feed"
-    if "thumbnail_src" in media:
+    sorted_resources = sorted(
+        # display_resources - user feed, thumbnail_resources - hashtag feed
+        media.get("display_resources", media.get("thumbnail_resources", [])),
+        key=lambda o: o["config_width"] * o["config_height"],
+    )
+    if sorted_resources:
+        media["thumbnail_url"] = sorted_resources[-1]["src"]
+    elif "thumbnail_src" in media:
         media["thumbnail_url"] = media["thumbnail_src"]
-    else:
-        media["thumbnail_url"] = sorted(
-            # display_resources - user feed, thumbnail_resources - hashtag feed
-            media.get("display_resources", media.get("thumbnail_resources")),
-            key=lambda o: o["config_width"] * o["config_height"],
-        )[-1]["src"]
     if media.get("media_type") == 8:
         # remove thumbnail_url and video_url for albums
         # see resources


### PR DESCRIPTION
Using `user_medias` I noticed `thumbnail_url` was containing a cropped/low-quality image when the media type was a simple photo. I don't think it's very useful to return the actual thumbnail, the full size image is better imo.
It makes sense to keep "thumbnail" name because in case the media type is a video, `thumbnail_url` is still a thumbnail (because it's an image), but at least it's in its biggest size-format and highest quality.