### PR TITLE
fix: prevent exception in extract_user_v1 when no hd profile pic exists

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -188,7 +188,8 @@ def extract_user_v1(data):
     """For Private API"""
     data["external_url"] = data.get("external_url") or None
     pic_hd = data.get("hd_profile_pic_url_info") or data.get("hd_profile_pic_versions")
-    data["profile_pic_url_hd"] = pic_hd.get("url")
+    if pic_hd:
+        data["profile_pic_url_hd"] = pic_hd.get("url")
     return User(**data)
 
 


### PR DESCRIPTION
This prevents an exception that sometimes occurs when is neither `hd_profile_pic_url_info` nor `hd_profile_pic_versions`.