### PR TITLE
distinct logger

### DIFF
--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -69,7 +69,7 @@ class PrivateRequestMixin:
     handle_exception = None
     challenge_code_handler = manual_input_code
     change_password_handler = manual_change_password
-    request_logger = logging.getLogger("private_request")
+    private_request_logger = logging.getLogger("private_request")
     request_timeout = 1
     last_response = None
     last_json = {}
@@ -395,7 +395,7 @@ class PrivateRequestMixin:
         return last_json
 
     def request_log(self, response):
-        self.request_logger.info(
+        self.private_request_logger.info(
             "%s [%s] %s %s (%s)",
             self.username,
             response.status_code,

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -31,7 +31,7 @@ class PublicRequestMixin:
     GRAPHQL_PUBLIC_API_URL = "https://www.instagram.com/graphql/query/"
     last_public_response = None
     last_public_json = {}
-    request_logger = logging.getLogger("public_request")
+    public_request_logger = logging.getLogger("public_request")
     request_timeout = 1
 
     def __init__(self, *args, **kwargs):
@@ -115,11 +115,11 @@ class PublicRequestMixin:
                     response=response,
                 )
 
-            self.request_logger.debug(
+            self.public_request_logger.debug(
                 "public_request %s: %s", response.status_code, response.url
             )
 
-            self.request_logger.info(
+            self.public_request_logger.info(
                 "[%s] [%s] %s %s",
                 self.public.proxies.get("https"),
                 response.status_code,
@@ -137,7 +137,7 @@ class PublicRequestMixin:
             if "/login/" in response.url:
                 raise ClientLoginRequired(e, response=response)
 
-            self.request_logger.error(
+            self.public_request_logger.error(
                 "Status %s: JSONDecodeError in public_request (url=%s) >>> %s",
                 response.status_code,
                 response.url,


### PR DESCRIPTION
`request_logger` was always "public_request" even when it should be "private_request"