### PR TITLE
Note functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ dmypy.json
 
 # VSCode
 .vscode
+ig_settings.json

--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -15,6 +15,7 @@ from instagrapi.mixins.comment import CommentMixin
 from instagrapi.mixins.direct import DirectMixin
 from instagrapi.mixins.fbsearch import FbSearchMixin
 from instagrapi.mixins.fundraiser import FundraiserMixin
+from instagrapi.mixins.note import NoteMixin
 from instagrapi.mixins.hashtag import HashtagMixin
 from instagrapi.mixins.highlight import HighlightMixin
 from instagrapi.mixins.igtv import DownloadIGTVMixin, UploadIGTVMixin
@@ -82,6 +83,7 @@ class Client(
     BloksMixin,
     TOTPMixin,
     MultipleAccountsMixin,
+    NoteMixin,
     FundraiserMixin
 ):
     proxy = None

--- a/instagrapi/config.py
+++ b/instagrapi/config.py
@@ -10,7 +10,7 @@ USER_AGENT_BASE = (
     "{dpi}; {resolution}; {manufacturer}; "
     "{model}; {device}; {cpu}; {locale}; {version_code})"
 )
-# Instagram 76.0.0.15.395 (iPhone9,2; iOS 10_0_2; en_US; en-US; scale=2.61; 1080x1920) AppleWebKit/420+
+#Instagram 76.0.0.15.395 (iPhone9,2; iOS 10_0_2; en_US; en-US; scale=2.61; 1080x1920) AppleWebKit/420+
 # Instagram 208.0.0.32.135 (iPhone; iOS 14_7_1; en_US; en-US; scale=2.61; 1080x1920) AppleWebKit/605.1.15
 
 SOFTWARE = "{model}-user+{android_release}+OPR1.170623.032+V10.2.3.0.OAGMIXM+release-keys"

--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -269,3 +269,7 @@ class TwoFactorRequired(PrivateError):
 
 class HighlightNotFound(NotFoundError, PrivateError):
     pass
+
+class NoteNotFound(NotFoundError):
+    reason = "Not found"
+

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -27,6 +27,8 @@ from .types import (
     User,
     UserShort,
     Usertag,
+    NoteRequest,
+    NoteResponse,
 )
 from .utils import InstagramIdCodec, json_value
 
@@ -437,3 +439,8 @@ def extract_track(data):
     items = re.findall(r"<BaseURL>(.+?)</BaseURL>", data['dash_manifest'])
     data['uri'] = html.unescape(items[0]) if items else None
     return Track(**data)
+
+def extract_note(data):
+    data['text'] = data.get('text') or None
+    data['uuid'] = data.get('uuid') or None
+    return NoteRequest(**data)

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -595,14 +595,14 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             A boolean value
         """
         self.device_settings = device or {
-            "app_version": "203.0.0.29.118",
+            "app_version": "269.0.0.18.75",
             "android_version": 26,
             "android_release": "8.0.0",
             "dpi": "480dpi",
             "resolution": "1080x1920",
-            "manufacturer": "Xiaomi",
-            "device": "capricorn",
-            "model": "MI 5s",
+            "manufacturer": "OnePlus",
+            "device": "devitron",
+            "model": "6T Dev",
             "cpu": "qcom",
             "version_code": "314665256",
         }

--- a/instagrapi/mixins/note.py
+++ b/instagrapi/mixins/note.py
@@ -1,0 +1,29 @@
+import uuid
+from instagrapi.extractors import (
+   extract_note,
+)
+from instagrapi.types import (
+    NoteRequest,
+)
+from instagrapi.utils import dumps
+
+
+class NoteMixin:
+
+    def send_note(self, note_content: str, audience: int) -> NoteRequest:
+    
+        assert self.user_id, "Login required"
+        method = "text"
+
+        data = {
+            "text": note_content,
+            "uuid": uuid.uuid4(),
+            "audience":audience
+        }
+
+        self.private_request(
+            f"notes/create_note",
+            data = self.with_default_data(data),
+            with_signature=False
+        )
+

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -446,3 +446,21 @@ class Track(BaseModel):
     dark_message: Optional[str]
     allows_saving: bool
     territory_validity_periods: dict
+
+class NoteResponse(BaseModel):
+    id: str
+    text: str
+    user_id: int
+    user: UserShort
+    audience: int
+    created_at: datetime
+    expires_at: datetime
+    is_emoji_only: bool
+    has_translation: bool
+    note_style: int
+    status: str
+
+class NoteRequest(BaseModel):
+    text: str
+    uuid: str
+

--- a/tests.py
+++ b/tests.py
@@ -29,13 +29,15 @@ from instagrapi.types import (
     StorySticker,
     User,
     UserShort,
+    NoteRequest,
+    NoteResponse,
     Usertag,
 )
 from instagrapi.utils import generate_jazoest
 from instagrapi.zones import UTC
 
-ACCOUNT_USERNAME = os.environ.get("IG_USERNAME", "instagrapi2")
-ACCOUNT_PASSWORD = os.environ.get("IG_PASSWORD", "yoa5af6deeRujeec")
+ACCOUNT_USERNAME = os.environ.get("IG_USERNAME", "username")
+ACCOUNT_PASSWORD = os.environ.get("IG_PASSWORD", "password*")
 ACCOUNT_SESSIONID = os.environ.get("IG_SESSIONID", "")
 
 REQUIRED_MEDIA_FIELDS = [
@@ -191,14 +193,14 @@ class ClientTestCase(unittest.TestCase):
                 "model": "h1",
                 "device": "RS988",
                 "resolution": "1440x2392",
-                "app_version": "117.0.0.28.123",
+                "app_version": "269.0.0.19.301",
                 "manufacturer": "LGE/lge",
                 "version_code": "168361634",
                 "android_release": "6.0.1",
                 "android_version": 23
             },
             # "user_agent": "Instagram 117.0.0.28.123 Android (23/6.0.1; US; 168361634)"
-            "user_agent": "Instagram 117.1.0.29.119 Android (27/8.1.0; 480dpi; 1080x1776; motorola; Moto G (5S); montana; qcom; ru_RU; 253447809)",
+            "user_agent": "Instagram 269.0.0.19.301 Android (27/8.1.0; 480dpi; 1080x1776; motorola; Moto G (5S); montana; qcom; ru_RU; 253447809)",
             "country": "RU",
             "locale": "ru_RU",
             "timezone_offset": 10800,  # Moscow, GMT+3
@@ -226,7 +228,7 @@ class ClientTestCase(unittest.TestCase):
             },
             "mid": "YA1YMAACAAGtxxnZ1p4AYc8ufNMn",
             "device_settings": {
-                "app_version": "194.0.0.36.172",
+                "app_version": "269.0.0.19.301",
                 "android_version": 26,
                 "android_release": "8.0.0",
                 "dpi": "480dpi",
@@ -237,7 +239,7 @@ class ClientTestCase(unittest.TestCase):
                 "cpu": "qcom",
                 "version_code": "301484483"
             },
-            "user_agent": "Instagram 194.0.0.36.172 Android (26/8.0.0; 480dpi; 1080x1920; Xiaomi; MI 5s; capricorn; qcom; en_US; 301484483)",
+            "user_agent": "Instagram 269.0.0.19.301 Android (26/8.0.0; 480dpi; 1080x1920; Xiaomi; MI 5s; capricorn; qcom; en_US; 301484483)",
             "country": "UK",
             "locale": "en_US",
             "timezone_offset": 3600,  # London, GMT+1
@@ -363,8 +365,10 @@ class ClientUserTestCase(ClientPrivateTestCase):
         self.assertEqual(followers[user_id].username, "asphalt_kings_lb")
 
     def test_user_followers_amount(self):
-        user_id = self.cl.user_id_from_username("adw0rd")
+        user_id = self.cl.user_id_from_username("certified.nil")
+        print(user_id)
         followers = self.cl.user_followers(user_id, amount=10)
+        print(followers)
         self.assertTrue(len(followers) == 10)
         self.assertIsInstance(list(followers.values())[0], UserShort)
 
@@ -381,7 +385,7 @@ class ClientUserTestCase(ClientPrivateTestCase):
         self.assertIsInstance(list(following.values())[0], UserShort)
 
     def test_user_follow_unfollow(self):
-        user_id = self.cl.user_id_from_username("bmxtravel")
+        user_id = self.cl.user_id_from_username("certified.nil")
         self.cl.user_follow(user_id)
         following = self.cl.user_following(self.cl.user_id)
         self.assertIn(user_id, following)
@@ -422,6 +426,8 @@ class ClientUserTestCase(ClientPrivateTestCase):
         self.assertEqual(user.full_name, "Philippe Jury")
         self.assertFalse(user.is_private)
 
+    def test_send_new_note(self):
+        self._cl.send_note("Hello from Instagrapi !",0);
 
 class ClientMediaTestCase(ClientPrivateTestCase):
     def test_media_id(self):


### PR DESCRIPTION

# Added the possibility to send note

You can now send Note using Instagrapi !

To use it juste import NoteMixin and use the function send_note it will require two arguments :

## Function send_note

#### Send note to the Instagram Private API

```python
    send_note(note_content, audience)
```

| Parameter | Type     | Description                |
| :-------- | :------- | :------------------------- |
| `note_content` | `string` | The content of your note. **Max size : 60** |
| `audience`      | `int` | The type of audience you want you note to be visible |

In order to use this, you should set your Instagram version in the user agent as `265.0.0.19.301` this is the version where Notes has been implemented.

## What are note ? 

You can learn more about the new Note functionality [here](https://about.instagram.com/blog/announcements/updates-to-instagram-messenger-and-stories/)

## Contributing

This code is highly experimental being my first time to reverse-engineer a Private API any optimization or better ways to do this it's more than welcome

## Missing functionalities

- The possibility to remove a note after beign posted.
- Error handling
- Checking provided note len to avoid errors.