### PR TITLE
media_like without media_user

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -30,7 +30,7 @@ class MediaMixin:
 
     _medias_cache = {}  # pk -> object
 
-    def media_id(self, media_pk: int, with_user_pk: bool = True) -> str:
+    def media_id(self, media_pk: int) -> str:
         """
         Get full media id
 
@@ -53,9 +53,8 @@ class MediaMixin:
             assert media_id.isdigit(), (
                 "media_id must been contain digits, now %s" % media_id
             )
-            if with_user_pk:
-                user = self.media_user(media_id)
-                media_id = "%s_%s" % (media_id, user.pk)
+            user = self.media_user(media_id)
+            media_id = "%s_%s" % (media_id, user.pk)
         return media_id
 
     @staticmethod
@@ -404,7 +403,7 @@ class MediaMixin:
             A boolean value
         """
         assert self.user_id, "Login required"
-        media_id = self.media_id(media_id, with_user_pk=False)
+        media_id = self.media_pk(media_id)
         data = {
             "inventory_source": "media_or_ad",
             "media_id": media_id,

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -30,7 +30,7 @@ class MediaMixin:
 
     _medias_cache = {}  # pk -> object
 
-    def media_id(self, media_pk: int) -> str:
+    def media_id(self, media_pk: int, with_user_pk: bool = True) -> str:
         """
         Get full media id
 
@@ -53,8 +53,9 @@ class MediaMixin:
             assert media_id.isdigit(), (
                 "media_id must been contain digits, now %s" % media_id
             )
-            user = self.media_user(media_id)
-            media_id = "%s_%s" % (media_id, user.pk)
+            if with_user_pk:
+                user = self.media_user(media_id)
+                media_id = "%s_%s" % (media_id, user.pk)
         return media_id
 
     @staticmethod
@@ -403,7 +404,7 @@ class MediaMixin:
             A boolean value
         """
         assert self.user_id, "Login required"
-        media_id = self.media_id(media_id)
+        media_id = self.media_id(media_id, with_user_pk=False)
         data = {
             "inventory_source": "media_or_ad",
             "media_id": media_id,


### PR DESCRIPTION
Liking a media doesn't seem to require a "full" media_id with the user pk appended to it.
In other term `2277033926878261772` is enough and work as much as `2277033926878261772_1903424587`.
With this PR, liking a media is much quicker and requires less data fetching.