### PR TITLE
Add an exception handler for parse_authorization function

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -827,6 +827,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         """Parse authorization header"""
         try:
             b64part = authorization.rsplit(":", 1)[-1]
+            if not b64part:
+                return {}
             return json.loads(base64.b64decode(b64part))
         except Exception as e:
             self.logger.exception(e)


### PR DESCRIPTION
Since b64part can be empty `""` when trying re login, We need an if statement to prevent runtime exception
<img width="1223" alt="스크린샷 2023-03-02 오후 4 02 18" src="https://user-images.githubusercontent.com/23733661/222356592-ee0dd964-a6cd-4ac1-9a10-ed81b3f673e4.png">
