### PR TITLE
Closing the video in analyze_video()

### DIFF
--- a/instagrapi/mixins/igtv.py
+++ b/instagrapi/mixins/igtv.py
@@ -2,6 +2,7 @@ import json
 import random
 import time
 from pathlib import Path
+import contextlib
 from typing import Dict, List
 from uuid import uuid4
 
@@ -297,13 +298,15 @@ def analyze_video(path: Path, thumbnail: Path = None) -> tuple:
         raise Exception("Please install moviepy>=1.0.3 and retry")
 
     print(f'Analyzing IGTV file "{path}"')
-    video = mp.VideoFileClip(str(path))
-    width, height = video.size
-    if not thumbnail:
-        thumbnail = f"{path}.jpg"
-        print(f'Generating thumbnail "{thumbnail}"...')
-        video.save_frame(thumbnail, t=(video.duration / 2))
-        crop_thumbnail(thumbnail)
+    with contextlib.ExitStack() as stack:
+        video = mp.VideoFileClip(str(path))
+        width, height = video.size
+        if not thumbnail:
+            thumbnail = f"{path}.jpg"
+            print(f'Generating thumbnail "{thumbnail}"...')
+            video.save_frame(thumbnail, t=(video.duration / 2))
+            crop_thumbnail(thumbnail)
+        stack.enter_context(contextlib.closing(video))
     return thumbnail, width, height, video.duration
 
 


### PR DESCRIPTION
MoviePy actually does not close the video once opened, making it impossible to remove/move/make actions on it. This fixes that issue, it has been tested and works.