### PR TITLE
More features / missing / fixes

### DIFF
--- a/instagrapi/mixins/comment.py
+++ b/instagrapi/mixins/comment.py
@@ -152,6 +152,38 @@ class CommentMixin:
         )
         return extract_comment(result["comment"])
 
+    def media_check_offensive_comment(
+        self, media_id: str, text: str
+    ) -> bool:
+        """
+        Checks if a comment text is offensive
+
+        Parameters
+        ----------
+        media_id: str
+            Unique identifier of a Media
+        text: str
+            String to be posted on the media
+
+        Returns
+        -------
+        bool
+            If comment is offensive
+        """
+        assert self.user_id, "Login required"
+        media_id = self.media_id(media_id)
+        data = {
+            # _uid, comment_session_id are not in this body?
+            "media_id": media_id,
+            "comment_text": text,
+        }
+        result = self.private_request(
+            f"media/comment/check_offensive_comment/",
+            self.with_action_data(data),
+        )
+        return result["is_offensive"]
+
+
     def comment_like(self, comment_pk: int, revert: bool = False) -> bool:
         """
         Like a comment on a media

--- a/instagrapi/mixins/explore.py
+++ b/instagrapi/mixins/explore.py
@@ -10,7 +10,7 @@ class ExploreMixin:
         -------
         dict
         """
-        return self.private_request("discover/topical_explore")
+        return self.private_request("discover/topical_explore/")
 
     def report_explore_media(self, media_pk: int):
         """

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -249,9 +249,10 @@ class HashtagMixin:
         assert tab_key in (
             "top",
             "recent",
+            "clips"
         ), 'You must specify one of the options for "tab_key" ("top" or "recent")'
         data = {
-            "supported_tabs": dumps([tab_key]),
+            "supported_tabs": dumps(["top", "recent", "clips"]),
             # 'lat': 59.8626416,
             # 'lng': 30.5126682,
             "include_persistent": "true",

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -120,6 +120,7 @@ class Media(BaseModel):
     user: UserShort
     comment_count: Optional[int] = 0
     comments_disabled: Optional[bool] = False
+    commenting_disabled_for_viewer: Optional[bool] = False
     like_count: int
     play_count: Optional[int]
     has_liked: Optional[bool]


### PR DESCRIPTION
Hi, 

If wanted, you can review/merge our PR. 
We added some little things we found are different from instagrams app requests.

First of all, `comments_disabled` only works for some cases were comments are disabled. We added `comments_disabled_for_viewer`, which also needs to be checked.

There was a missing / after `discover/topical_explore` which instagram responded with a redirect. Might not matter, but still added it in case it would flag the account.

We added `check_offensive_comment`, which is a request that gets send before you comment on a media. So that one should probably be called before commenting.

`hashtag_medias_v1_chunk` requests to an endpoint which, according to the instagram app,  wants all keys in supported keys, not only the picked one. Also added the missing "clips" key