### PR TITLE
Fix issue with `set_proxy`

### DIFF
--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -295,10 +295,10 @@ class PrivateRequestMixin:
                     data = generate_signature(dumps(data))
                     if extra_sig:
                         data += "&".join(extra_sig)
-                response = self.private.post(api_url, data=data, params=params)
+                response = self.private.post(api_url, data=data, params=params, proxies=self.private.proxies)
             else:  # GET
                 self.private.headers.pop("Content-Type", None)
-                response = self.private.get(api_url, params=params)
+                response = self.private.get(api_url, params=params, proxies=self.private.proxies)
             self.logger.debug(
                 "private_request %s: %s (%s)",
                 response.status_code,

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -107,9 +107,9 @@ class PublicRequestMixin:
             time.sleep(self.request_timeout)
         try:
             if data is not None:  # POST
-                response = self.public.data(url, data=data, params=params)
+                response = self.public.data(url, data=data, params=params, proxies=self.public.proxies)
             else:  # GET
-                response = self.public.get(url, params=params)
+                response = self.public.get(url, params=params, proxies=self.public.proxies)
 
             expected_length = int(response.headers.get("Content-Length") or 0)
             actual_length = response.raw.tell()


### PR DESCRIPTION
Proxies were not being applied correctly in requests when a user would set them

This was brought up recently by https://github.com/adw0rd/instagrapi/issues/1193

## To reproduce

Here's a script you can use to test before and after my changes

```
import requests as req
from instagrapi import Client

cl = Client()
user_ip = cl._send_public_request("https://tools.adw0rd.com/ip/")
print("User IP: ", user_ip)

proxy = "http://xxxxxxxxx:wifi;cz;;;prague@proxy.soax.com:9138"
cl.set_proxy(proxy)
proxy_ip = cl._send_public_request("https://tools.adw0rd.com/ip/")
print("Proxy IP: ", proxy_ip)
```

And the bad result I got
```
User IP:  70.77.xx.xx
Proxy IP:  70.77.xx.xx
```

The result I got after my changes
```
User IP:  70.77.xx.xx
Proxy IP:  88.103.xx.xx
```