### PR TITLE
add next_max_id to get_clips_paginated_v1 params

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -809,6 +809,7 @@ class MediaMixin:
                 "clips/user/",
                 data={
                     "target_user_id": user_id,
+                    "max_id": next_max_id,
                     "page_size": amount,  # default from app: 12
                     "include_feed_video": "true",
                 },


### PR DESCRIPTION
The clips function wasn't using the cursor so it would never get more pages.