### PR TITLE
Adding explore page media info

### DIFF
--- a/instagrapi/mixins/explore.py
+++ b/instagrapi/mixins/explore.py
@@ -31,3 +31,14 @@ class ExploreMixin:
         result = self.private_request("discover/explore_report/", params=params)
         return result['explore_report_status'] == "OK"
 
+    def explore_page_media_info(self, media_pk: int):
+        """
+        Returns media information for a media item on the explore page
+
+        This is the API call that happens when you're on the explore page
+        and you click into a media item. It returns information about that media item
+        like comments, likes, etc.
+        """
+        return self.private_request(
+            f"/v1/discover/media_metadata/" f"?media_id={media_pk}",
+        )["media_or_ad"]

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -114,6 +114,7 @@ class Media(BaseModel):
     code: str
     taken_at: datetime
     media_type: int
+    image_versions2: Optional[dict] = {}
     product_type: Optional[str] = ""  # igtv or feed
     thumbnail_url: Optional[HttpUrl]
     location: Optional[Location] = None


### PR DESCRIPTION
Adding a method for getting media info from the explore page. 

I noticed that while using Proxyman on the explore page of my instagram, that it was calling this endpoint instead of the normal media_info endpoint to get details about media. 