### PR TITLE
fix for ChallengeUnknownStep error "select_contact_point_recovery"

### DIFF
--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -435,6 +435,70 @@ class ChallengeResolveMixin:
             return self.bloks_change_password(pwd, self.last_json["challenge_context"])
         elif step_name == "selfie_captcha":
             raise ChallengeSelfieCaptcha(self.last_json)
+        elif step_name == "select_contact_point_recovery":
+            """
+                {
+                    'step_name': 'select_contact_point_recovery',
+                    'step_data': {'choice': '0',
+                        'phone_number': '+62 ***-****-**11',
+                        'email': 'g*******b@w**.de',
+                        'hl_co_enabled': False,
+                        'sigp_to_hl': False
+                    },
+                    'flow_render_type': 3,
+                    'bloks_action': 'com.instagram.challenge.navigation.take_challenge',
+                    'cni': 178623487724,
+                    'challenge_context': '{"step_name": "select_contact_point_recovery",
+                    "cni": 178623487724,
+                    "is_stateless": false,
+                    "challenge_type_enum": "HACKED_LOCK",
+                    "present_as_modal": false}',
+                    'challenge_type_enum_str': 'HACKED_LOCK',
+                    'status': 'ok'
+                }
+                """
+            steps = self.last_json["step_data"].keys()
+            challenge_url = challenge_url[1:]
+            if "email" in steps:
+                self._send_private_request(
+                    challenge_url, {"choice": ChallengeChoice.EMAIL})
+            elif "phone_number" in steps:
+                self._send_private_request(
+                    challenge_url, {"choice": ChallengeChoice.SMS})
+            else:
+                raise ChallengeError(
+                    f'ChallengeResolve: Choice "email" or "phone_number" (sms) not available to this account {self.last_json}')
+            wait_seconds = 5
+            for attempt in range(24):
+                code = self.challenge_code_handler(self.username, ChallengeChoice.EMAIL)
+                if code:
+                    break
+                time.sleep(wait_seconds)
+            print(f'Code entered "{code}" for {self.username} ({attempt} attempts by {wait_seconds} seconds)')
+            self._send_private_request(challenge_url, {"security_code": code})
+
+            # last form to verify account details
+            assert self.last_json["step_name"] == "review_contact_point_change", \
+                  f"Unexpected step_name {self.last_json['step_name']}"
+
+            details = self.last_json["step_data"]
+
+            # TODO: add validation of account details
+            # assert self.username == details['username'], \
+            #     f"Data invalid: {self.username} does not match {details['username']}"
+            # assert self.email == details['email'], \
+            #     f"Data invalid: {self.email} does not match {details['email']}"
+            # assert self.phone_number == details['phone_number'], \
+            #     f"Data invalid: {self.phone_number} does not match {details['phone_number']}"
+
+            # "choice": 0 ==> details look good
+            self._send_private_request(challenge_url, {"choice": 0})
+            
+            # TODO: assert that the user is now logged in.
+            # # assert 'logged_in_user' in client.last_json
+            # assert self.last_json.get("action", "") == "close"
+            # assert self.last_json.get("status", "") == "ok"
+            return True
         else:
             raise ChallengeUnknownStep(
                 f'ChallengeResolve: Unknown step_name "{step_name}" for "{self.username}" in challenge resolver: {self.last_json}'


### PR DESCRIPTION
This `elif` statement in `challenge.py` will handle the `ChallengeUnknownStep` error that was occurring due to a new challenge type `select_contact_point_recovery` which was previously unhandled. Some extra todo comments are left if that functionality wants to be added in the future.