### PR TITLE
Setup request strategy for private and public requests

### DIFF
--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -5,8 +5,8 @@ import time
 from json.decoder import JSONDecodeError
 
 import requests
-from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 from instagrapi import config
 from instagrapi.exceptions import (

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -5,6 +5,8 @@ import time
 from json.decoder import JSONDecodeError
 
 import requests
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 
 from instagrapi import config
 from instagrapi.exceptions import (
@@ -76,7 +78,20 @@ class PrivateRequestMixin:
     last_json = {}
 
     def __init__(self, *args, **kwargs):
-        self.private = requests.Session()
+        # setup request session with retries
+        session = requests.Session()
+        retry_strategy = Retry(
+            total=3,
+            status_forcelist=[429, 500, 502, 503, 504],
+            method_whitelist=["GET", "POST"],
+            backoff_factor=2,
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        self.private = session
+
+
         self.private.verify = False  # fix SSLError/HTTPSConnectionPool
         self.email = kwargs.pop("email", None)
         self.phone_number = kwargs.pop("phone_number", None)

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -8,8 +8,8 @@ except ImportError:
     from json.decoder import JSONDecodeError
 
 import requests
-from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 from instagrapi.exceptions import (
     ClientBadRequestError,


### PR DESCRIPTION
This adds a retry strategy to the public and private instagrapi requests that will retry a request up to 3 times if the server returns an error status code of 429, 500, 502, 503, or 504, and if the HTTP method is GET or POST. The wait time between each retry will increase x2 each time.

instead of users needing to handle retries downstream they can rely on the retries here 