### PR TITLE
Fix for "coauthor_producers" being none

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -68,6 +68,7 @@ def extract_media_v1(data):
     media["has_liked"] = media.get("has_liked", False)
     media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags", [])]
     media["play_count"] = media.get("play_count", 0)
+    media["coauthor_producers"] = media.get("coauthor_producers", [])
     return Media(
         caption_text=(media.get("caption") or {}).get("text", ""),
         resources=[


### PR DESCRIPTION
A simple fix for `coauthor_producers` being returned as none/null while exploring reels.