### PR TITLE
fix user_followers freeze

### DIFF
--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -540,7 +540,6 @@ class UserMixin:
                 f"friendships/{user_id}/following/",
                 params={
                     "max_id": max_id,
-                    "count": 10000,
                     "rank_token": self.rank_token,
                     "search_surface": "follow_list_page",
                     "query": "",
@@ -715,7 +714,6 @@ class UserMixin:
                 f"friendships/{user_id}/followers/",
                 params={
                     "max_id": max_id,
-                    "count": 10000,
                     "rank_token": self.rank_token,
                     "search_surface": "follow_list_page",
                     "query": "",


### PR DESCRIPTION
fix user_followers, user_followers does not work if you pass amount ( cl.user_followers(12345678, 5) )

https://github.com/adw0rd/instagrapi/issues/1280

tried it now and its ok
