### PR TITLE
Some updates

### DIFF
--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -482,6 +482,10 @@ class ChallengeResolveMixin:
             )
             self._send_private_request(challenge_url, {"security_code": code})
 
+            if self.last_json.get("action", "") == "close":
+                assert self.last_json.get("status", "") == "ok"
+                return True
+
             # last form to verify account details
             assert (
                 self.last_json["step_name"] == "review_contact_point_change"

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -98,7 +98,7 @@ class PrivateRequestMixin:
             retry_strategy = Retry(
                 total=3,
                 status_forcelist=[429, 500, 502, 503, 504],
-                allowed_methods=["GET", "POST"],
+                method_whitelist=["GET", "POST"],
                 backoff_factor=2,
             )
         adapter = HTTPAdapter(max_retries=retry_strategy)

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -91,7 +91,7 @@ class PrivateRequestMixin:
             retry_strategy = Retry(
                 total=3,
                 status_forcelist=[429, 500, 502, 503, 504],
-                method_whitelist=["GET", "POST"],
+                allowed_methods=["GET", "POST"],
                 backoff_factor=2,
             )
         except TypeError:

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -43,7 +43,7 @@ class PublicRequestMixin:
             retry_strategy = Retry(
                 total=3,
                 status_forcelist=[429, 500, 502, 503, 504],
-                method_whitelist=["GET", "POST"],
+                allowed_methods=["GET", "POST"],
                 backoff_factor=2,
             )
         except TypeError:

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -50,7 +50,7 @@ class PublicRequestMixin:
             retry_strategy = Retry(
                 total=3,
                 status_forcelist=[429, 500, 502, 503, 504],
-                allowed_methods=["GET", "POST"],
+                method_whitelist=["GET", "POST"],
                 backoff_factor=2,
             )
         adapter = HTTPAdapter(max_retries=retry_strategy)

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -396,3 +396,25 @@ class StoryMixin:
             A boolean value
         """
         return self.story_like(story_id, revert=True)
+    
+    def sticker_tray(self) -> dict:
+        '''
+        Getting a sticker tray from Instagram
+
+        Returns
+        -------
+        dict
+            Sticker Tray
+        '''
+        data = {
+            "_uid" : self.user_id,
+            "type" : "static_stickers",
+            "_uuid" : self.uuid
+        }
+        result = self.private_request(
+            "creatives/sticker_tray/", 
+            data=data,
+            with_signature=True,
+        )
+        assert result["status"] == "ok"
+        return result


### PR DESCRIPTION
Removing method "method_whitelist" from Retry, since it's gonna be deprecated in v2.
Adding sticker_tray loader request. This request is executed by Instagram application each time you want to add sticker to the story.
Closing challenge_resolve before verifying account details. Referenced to #1354 