### PR TITLE
 General or Primary box for direct_threads()

### DIFF
--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1,5 +1,6 @@
 import random
 import re
+from sre_constants import LITERAL
 import time
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -22,14 +23,17 @@ from instagrapi.types import (
 from instagrapi.utils import dumps
 
 SELECTED_FILTERS = ("flagged", "unread")
+BOXES = ("general", "primary")
 
 try:
     from typing import Literal
 
     SELECTED_FILTER = Literal[SELECTED_FILTERS]
+    BOX = Literal[BOXES]
 except ImportError:
     # python <= 3.8
     SELECTED_FILTER = str
+    BOX = str
 
 
 class DirectMixin:
@@ -41,6 +45,7 @@ class DirectMixin:
         self,
         amount: int = 20,
         selected_filter: SELECTED_FILTER = "",
+        box: BOX = "",
         thread_message_limit: Optional[int] = None,
     ) -> List[DirectThread]:
         """
@@ -78,6 +83,7 @@ class DirectMixin:
     def direct_threads_chunk(
         self,
         selected_filter: SELECTED_FILTER = "",
+        box: BOX = "",
         thread_message_limit: Optional[int] = None,
         cursor: str = None
     ) -> Tuple[List[DirectThread], str]:
@@ -114,6 +120,15 @@ class DirectMixin:
             params.update(
                 {
                     "selected_filter": selected_filter
+                }
+            )
+        if box:
+            assert (
+                box in BOXES
+            ), f'Unsupported box="{box}" {BOXES}'
+            params.update(
+                {
+                    "folder" : '1' if box == "general" else '0'
                 }
             )
         if thread_message_limit:

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1,6 +1,5 @@
 import random
 import re
-from sre_constants import LITERAL
 import time
 from pathlib import Path
 from typing import List, Optional, Tuple

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -57,6 +57,8 @@ class DirectMixin:
             Maximum number of media to return, default is 20
         selected_filter: str, optional
             Filter to apply to threads (flagged or unread)
+        box: str, optional
+            Box to gather threads from (primary or general) (business accounts only)
         thread_message_limit: int, optional
             Thread message limit, deafult is 10
 
@@ -70,7 +72,7 @@ class DirectMixin:
         threads = []
         # self.private_request("direct_v2/get_presence/")
         while True:
-            threads_chunk, cursor = self.direct_threads_chunk(selected_filter, thread_message_limit, cursor)
+            threads_chunk, cursor = self.direct_threads_chunk(selected_filter, box, thread_message_limit, cursor)
             for thread in threads_chunk:
                 threads.append(thread)
                 
@@ -96,6 +98,8 @@ class DirectMixin:
             Filter to apply to threads (flagged or unread)
         thread_message_limit: int, optional
             Thread message limit, deafult is 10
+        box: str, optional
+            Box to gather threads from (primary or general) (business accounts only)
         cursor: str, optional
             Cursor from the previous chunk request
         


### PR DESCRIPTION
Opportunity to choose box (general or primary) to get threads from (only applies to business accs). Not passing a parameter does not affect behavior for non-business accounts. 
![image](https://github.com/adw0rd/instagrapi/assets/79993557/0f72852b-51c6-4004-a7e4-3efe0af73cc0)
