### PR TITLE
File Format Validation and Error Handling Enhancements Solves #1456

### DIFF
--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -139,7 +139,7 @@ class UploadPhotoMixin:
         tuple
             (Upload ID for the media, width, height)
         """
-        assert isinstance(path, Path), f"Path must be Path, not {type(path)}"
+        assert isinstance(path, Path), f"Path must been Path, now {path} ({type(path)})"
         valid_extensions = ['.jpg', '.jpeg']
         if path.suffix.lower() not in valid_extensions:
             raise ValueError("Invalid file format. Only JPG/JPEG files are supported.")

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -121,8 +121,8 @@ class UploadPhotoMixin:
     """
 
     def photo_rupload(
-        self, path: Path, upload_id: str = "", to_album: bool = False
-    ) -> tuple:
+            self, path: Path, upload_id: str = "", to_album: bool = False
+        ) -> tuple:
         """
         Upload photo to Instagram
 
@@ -139,7 +139,11 @@ class UploadPhotoMixin:
         tuple
             (Upload ID for the media, width, height)
         """
-        assert isinstance(path, Path), f"Path must been Path, now {path} ({type(path)})"
+        assert isinstance(path, Path), f"Path must be Path, not {type(path)}"
+        valid_extensions = ['.jpg', '.jpeg']
+        if path.suffix.lower() not in valid_extensions:
+            raise ValueError("Invalid file format. Only JPG/JPEG files are supported.")
+            
         # upload_id = 516057248854759
         upload_id = upload_id or str(int(time.time() * 1000))
         assert path, "Not specified path to photo"
@@ -225,6 +229,10 @@ class UploadPhotoMixin:
             An object of Media class
         """
         path = Path(path)
+        valid_extensions = ['.jpg', '.jpeg']
+        if path.suffix.lower() not in valid_extensions:
+            raise ValueError("Invalid file format. Only JPG/JPEG files are supported.")
+
         upload_id, width, height = self.photo_rupload(path, upload_id)
         for attempt in range(10):
             self.logger.debug(f"Attempt #{attempt} to configure Photo: {path}")


### PR DESCRIPTION
This pull request introduces enhancements to the Instagram API functions related to photo uploads, specifically photo_rupload and photo_upload. The changes are aimed at preventing potential errors and ensuring compatibility with Instagram's allowed file formats. Solving #1456

The key enhancements include:

File Format Validation: A file format validation check has been implemented in the photo_rupload function. It verifies that the provided file is in either JPG or JPEG format, which are the only formats supported by Instagram. This validation helps prevent errors during the upload process and ensures that only compatible files are processed.

Error Handling Improvement: The error handling mechanism in photo_rupload has been improved. If an invalid file format is detected, a ValueError is raised, providing a clear error message indicating that only JPG and JPEG files are allowed. This change helps users identify and rectify the issue promptly, minimizing potential confusion and troubleshooting time.

Updated photo_upload Function: The photo_upload function has been updated to utilize the enhanced photo_rupload function. The file format validation step has been integrated into photo_upload, ensuring that only valid file formats are attempted to be uploaded. By performing this check before the upload, it helps prevent errors and unsuccessful uploads due to unsupported file formats.

These changes proactively address potential errors and improve the overall reliability of the photo upload process. By validating the file format and providing clear error messages, users can avoid uploading incompatible files, thereby reducing frustration and enhancing the user experience.

Please review the changes and consider merging this pull request to improve the stability and compatibility of the Instagram API functions related to photo uploads.