### PR TITLE
Fix PyPI badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Package](https://github.com/adw0rd/instagrapi/actions/workflows/python-package.yml/badge.svg?branch=master)](https://github.com/adw0rd/instagrapi/actions/workflows/python-package.yml)
-![PyPI](https://img.shields.io/pypi/v/instagrapi)
+[![PyPI](https://img.shields.io/pypi/v/instagrapi)](https://pypi.org/project/instagrapi/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/instagrapi)
 ![Checked with mypy](https://img.shields.io/badge/mypy-checked-blue)
 


### PR DESCRIPTION
Before, clicking the badge just opened the image. Now, it opens the PyPI project.

I was trying to use it several times, so I thought, I'd just go ahead and finally fix it.