### PR TITLE
Update account.py

### DIFF
--- a/instagrapi/mixins/account.py
+++ b/instagrapi/mixins/account.py
@@ -58,6 +58,16 @@ class AccountMixin:
         result = self.private_request("accounts/current_user/?edit=true")
         return extract_account(result["user"])
 
+    
+    def set_external_url(self, external_url) -> dict:
+        """
+        Set new biography
+        """
+        
+        signed_body = f"signed_body=SIGNATURE.%7B%22updated_links%22%3A%22%5B%7B%5C%22url%5C%22%3A%5C%22{external_url}%5C%22%2C%5C%22title%5C%22%3A%5C%22%5C%22%2C%5C%22link_type%5C%22%3A%5C%22external%5C%22%7D%5D%22%2C%22_uid%22%3A%22{self.user_id}%22%2C%22_uuid%22%3A%22{self.uuid}%22%7D"
+        return self.private_request('accounts/update_bio_links/', data = signed_body, with_signature = False)
+
+    
     def account_set_private(self) -> bool:
         """
         Sets your account private


### PR DESCRIPTION
instagram do not put biography just in "edit account" anymore - so this new method has been created (cl.set_external_url) as new endpoints on instagram send additional request for changing biography , 