### PR TITLE
Active presence and Notes update

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -18,7 +18,6 @@ from .types import (
     Media,
     MediaXma,
     MediaOembed,
-    NoteRequest,
     ReplyMessage,
     Resource,
     Story,
@@ -465,8 +464,3 @@ def extract_track(data):
     data["uri"] = html.unescape(items[0]) if items else None
     return Track(**data)
 
-
-def extract_note(data):
-    data["text"] = data.get("text") or None
-    data["uuid"] = data.get("uuid") or None
-    return NoteRequest(**data)

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -16,6 +16,7 @@ from instagrapi.extractors import (
 from instagrapi.types import (
     DirectMessage,
     DirectResponse,
+    DirectShortThread,
     DirectThread,
     Media,
     UserShort,
@@ -487,7 +488,12 @@ class DirectMixin:
         Parameters
         ----------
         user_ids: List[int]
-            List of unique identifier of Users id
+            List of unique identifier of Users ID
+
+        Returns
+        -------
+        Dict
+            Dict with User's presences
         """
         assert self.user_id, "Login Required"
         data = {
@@ -504,6 +510,29 @@ class DirectMixin:
             result.get("status") == "ok"
         ), f"Failed to retrieve presence of user_id={user_ids}"
         return result
+
+    def direct_active_presence(self) -> Dict:
+        '''
+        Getting active presences in Direct
+
+        Returns
+        -------
+        Dict
+            Dict with active presences
+        '''
+        params = {
+            "recent_thread_limit" : 0,
+            "suggested_followers_limit" : 100
+        }
+        result = self.private_request(
+            "direct_v2/get_presence_active_now/",
+            params=params
+        )
+        assert (
+            result.get("status") == "ok"
+        ), f"Failed to retrieve active presences"
+
+        return result.get("user_presence", {})
 
     def direct_send_seen(self, thread_id: int) -> DirectResponse:
         """
@@ -568,7 +597,7 @@ class DirectMixin:
             != ""  # Check to exclude suggestions from FB
         ]
 
-    def direct_message_search(self, query: str) -> List[Tuple[DirectMessage, DirectThread]]:
+    def direct_message_search(self, query: str) -> List[Tuple[DirectMessage, DirectShortThread]]:
         '''
         Search query mentions in direct messages
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1153,3 +1153,34 @@ class UserMixin:
         }
         result = self.private_request("friendships/set_besties/", data)
         return json_value(result, "friendship_statuses", user_id, "is_bestie") == False
+
+    def creator_info(self, user_id: str, entry_point: str = "direct_thread") -> Tuple[UserShort, Dict]:
+        """
+        Retrieves Creator's information
+
+        Parameters
+        ----------
+        user_id: str
+            Unique identifier of a User
+        entry_point: str, optional
+            Entry point for retrieving, default - direct_thread
+            When passing self_profile, own user_id must be provided
+
+        Returns
+        -------
+        Tuple[UserShort, Dict]
+            Retrieved User and his Creator's Info
+        """
+        assert self.user_id, "Login required"
+        params = {
+            "entry_point" : entry_point,
+            "surface_type" : "android",
+            "user_id" : user_id
+        }
+
+        result = self.private_request("creator/creator_info/", params=params)
+        assert result.get("status", "") == "ok"
+
+        creator_info = result.get("user", {}).pop("creator_info", {})
+        user = extract_user_short(result.get("user", {}))
+        return (user, creator_info)

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -467,7 +467,7 @@ class Track(BaseModel):
     territory_validity_periods: dict
 
 
-class NoteResponse(BaseModel):
+class Note(BaseModel):
     id: str
     text: str
     user_id: int
@@ -478,9 +478,3 @@ class NoteResponse(BaseModel):
     is_emoji_only: bool
     has_translation: bool
     note_style: int
-    status: str
-
-
-class NoteRequest(BaseModel):
-    text: str
-    uuid: str


### PR DESCRIPTION
Minor changes in PR:
1. Fixed type hint of the recently added direct_message_search() (#1521)
2. Added Return description in direct_users_presence() (#1482)
3. Added creator_info() (probably, separated CreatorMixin needed as there are some more /creator/ methods unexplored)

Major changes done in NoteMixin and related:
1. Removed NoteRequest and NoteResponse from types.py. Instead, left just Note class (status field removed as it's only received on creation, indicating success of the action).
2. Remove extract_note() as not a single method requires an extractor.
3. Removed uuid import, as no need in generating one for requesting.
4. Added docs to every single method.
5. Added response parsing: create_note(), get_notes() returning Note and List[Note]; delete_note() + last_seen_update_note() - bool
6. last_seen_update_note() added.
7. Renamed existing methods, previos naming didn't reflect the functionality and looked a bit ugly :) xD