### PR TITLE
Changed behavior of login if username and password have already been …

### DIFF
--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -166,6 +166,9 @@ class ProxyAddressIsBlocked(PrivateError):
 class BadPassword(PrivateError):
     pass
 
+class BadCredentials(PrivateError):
+    pass
+
 
 class PleaseWaitFewMinutes(PrivateError):
     pass

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -7,7 +7,7 @@ import re
 import time
 import uuid
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Union
 from uuid import uuid4
 
 import requests
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 from instagrapi import config
 from instagrapi.exceptions import (
+    BadCredentials,
     ClientThrottledError,
     PleaseWaitFewMinutes,
     PrivateError,
@@ -372,8 +373,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
 
     def login(
         self,
-        username: str,
-        password: str,
+        username: Union[str, None] = None,
+        password: Union[str, None] = None,
         relogin: bool = False,
         verification_code: str = "",
     ) -> bool:
@@ -396,8 +397,14 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         bool
             A boolean value
         """
-        self.username = username
-        self.password = password
+        
+        if not self.username or not self.password:
+            if username is None or password is None:
+                raise BadCredentials("Both username and password must be provided.")
+
+            self.username = username
+            self.password = password
+
         if relogin:
             self.authorization_data = {}
             self.private.headers.pop("Authorization", None)
@@ -416,7 +423,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             self.logger.warning("Ignore 429: Continue login")
             # The instagram application ignores this error
             # and continues to log in (repeat this behavior)
-        enc_password = self.password_encrypt(password)
+        enc_password = self.password_encrypt(self.password)
         data = {
             "jazoest": generate_jazoest(self.phone_id),
             "country_codes": '[{"country_code":"%d","source":["default"]}]'

--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 
 from instagrapi import Client
-from instagrapi.exceptions import DirectThreadNotFound
+from instagrapi.exceptions import BadCredentials, DirectThreadNotFound, ProxyAddressIsBlocked, BadPassword
 from instagrapi.story import StoryBuilder
 from instagrapi.types import (
     Account,
@@ -105,12 +105,21 @@ class FakeClientTestCase(BaseClientMixin, unittest.TestCase):
 
     def test_login(self):
         try:
-            self.cl.login(ACCOUNT_USERNAME, "fakepassword")
-        except Exception as e:
+            self.cl.login(ACCOUNT_USERNAME, ACCOUNT_PASSWORD)
+        except (ProxyAddressIsBlocked, BadPassword) as e:
             self.assertEqual(
-                str(e), "The username you entered doesn't appear to belong to an account. Please check your username and try again."
+                str(e), "The password you entered is incorrect. Please try again. If you are sure that the password is correct, then change your IP address, because it is added to the blacklist of the Instagram Server"
             )
 
+        try:
+            is_auth = self.cl.login()
+            self.assertEqual(is_auth, True)
+        except BadCredentials as e:
+            self.assertEqual(str(e), "Both username and password must be provided.")
+        except ProxyAddressIsBlocked as e:
+            self.assertEqual(
+                str(e), "Instagram has blocked your IP address, use a quality proxy provider (not free, not shared)"
+            )
 
 class ClientPrivateTestCase(BaseClientMixin, unittest.TestCase):
     cl = None


### PR DESCRIPTION
## Feature: Simplify Login Process

### Description

This pull request introduces a change that simplifies the login process for the `login` function, if username and password have previously been provided. The aim is to allow us to call `cl.login()` without explicitly passing the username and password again, provided they were previously set properly.

### Changes Made

Previously, the username and password were set using the attributes `self.username` and `self.password`. This pull request refactors the code to provide a more convenient way of logging in:

```python
if not self.username or not self.password:
    if username is None or password is None:
        raise BadCredentials("Both username and password must be provided.")
    
    self.username = username
    self.password = password
```

This change enables users to call cl.login() directly if the username and password have been set before.


### Additional Changes
Added the `BadCredentials` error class according to the existing standards in the repository.


### Example Usage
```python
username = "your_username"
password = "your_password"

cl.login(username, password)

...

# Somewhere else in the code
cl.login()
```

