### PR TITLE
Refactor: inconsistent type annotation for user_id

### DIFF
--- a/docs/usage-guide/highlight.md
+++ b/docs/usage-guide/highlight.md
@@ -4,7 +4,7 @@
 | ------------------------------------------------------------------------------ | ---------------- | ----------------------------------
 | highlight_pk_from_url(url: str)                                                | int              | Get Highlight PK from URL
 | highlight_info(highlight_pk: int)                                              | Highlight        | Get Highlight by pk or id
-| user_highlights(user_id: int, amount: int = 0)                                 | List[Highlight]  | Get a user's highlights
+| user_highlights(user_id: str, amount: int = 0)                                 | List[Highlight]  | Get a user's highlights
 | highlight_create(title: str, story_ids: List[str], cover_story_id: str = "", crop_rect: List[float] = [0.0, 0.21830457, 1.0, 0.78094524]) | Highlight | Create highlight
 | highlight_change_title(highlight_pk: str, title: str)                          | Highlight        | Change title for highlight
 | highlight_change_cover(highlight_pk: str, cover_path: Path)                    | Highlight        | Change cover for highlight

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -27,10 +27,10 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_pk(media_id: str)                                         | int                | Return media_pk by media_id (e.g. 2277033926878261772_1903424587 -> 2277033926878261772)
 | media_pk_from_code(code: str)                                   | int                | Return media_pk
 | media_pk_from_url(url: str)                                     | int                | Return media_pk
-| user_medias(user_id: int, amount: int = 20)                     | List\[Media]       | Get list of medias by user_id
-| user_medias_paginated(user_id: int, amount: int = 0, end_cursor: str = "")           | Tuple\[List\[Media], str] | Get one page of medias by user_id
-| user_clips(user_id: int, amount: int = 50)                      | List\[Media]       | Get list of clips (reels) by user_id
-| usertag_medias(user_id: int, amount: int = 20)                  | List\[Media]       | Get medias where a user is tagged
+| user_medias(user_id: str, amount: int = 20)                     | List\[Media]       | Get list of medias by user_id
+| user_medias_paginated(user_id: str, amount: int = 0, end_cursor: str = "")           | Tuple\[List\[Media], str] | Get one page of medias by user_id
+| user_clips(user_id: str, amount: int = 50)                      | List\[Media]       | Get list of clips (reels) by user_id
+| usertag_medias(user_id: str, amount: int = 20)                  | List\[Media]       | Get medias where a user is tagged
 | media_info(media_pk: int)                                       | Media              | Return media info
 | media_delete(media_pk: int)                                     | bool               | Delete media
 | media_edit(media_pk: int, caption: str, title: str, usertags: List[Usertag], location: Location) | dict | Change caption for media
@@ -52,16 +52,16 @@ Low level methods:
 | media_info_a1(media_pk: int, max_id: str = None)                | Media        | Get Media from PK by Public Web API
 | media_info_gql(media_pk: int)                                   | Media        | Get Media from PK by Public Graphql API
 | media_info_v1(media_pk: int)                                    | Media        | Get Media from PK by Private Mobile API
-| user_medias_gql(user_id: int, amount: int = 50, sleep: int = 2) | List\[Media] | Get a user's media by Public Graphql API
-| user_medias_paginated_gql(user_id: int, amount: int = 50, sleep: int = 2, end_cursor=None) | Tuple\[List\[Media], str] | Get a page of user's media by Public Graphql API
-| user_medias_v1(user_id: int, amount: int = 18)                  | List\[Media] | Get a user's media by Private Mobile API
-| user_medias_paginated_v1(user_id: int, amount: int = 0, end_cursor="") | Tuple\[List\[Media], str] | Get a page of user's media by Private Mobile API
-| user_clips_v1(user_id: int, amount: int = 50)                  | List\[Media] | Get a user's clip by Private Mobile API
-| user_clips_paginated_v1(user_id: int, amount: int = 50, end_cursor="") | Tuple\[List\[Media], str] | Get a page of user's clip by Private Mobile API
-| user_videos_v1(user_id: int, amount: int = 50)                  | List\[Media] | Get a user's video by Private Mobile API
+| user_medias_gql(user_id: str, amount: int = 50, sleep: int = 2) | List\[Media] | Get a user's media by Public Graphql API
+| user_medias_paginated_gql(user_id: str, amount: int = 50, sleep: int = 2, end_cursor=None) | Tuple\[List\[Media], str] | Get a page of user's media by Public Graphql API
+| user_medias_v1(user_id: str, amount: int = 18)                  | List\[Media] | Get a user's media by Private Mobile API
+| user_medias_paginated_v1(user_id: str, amount: int = 0, end_cursor="") | Tuple\[List\[Media], str] | Get a page of user's media by Private Mobile API
+| user_clips_v1(user_id: str, amount: int = 50)                  | List\[Media] | Get a user's clip by Private Mobile API
+| user_clips_paginated_v1(user_id: str, amount: int = 50, end_cursor="") | Tuple\[List\[Media], str] | Get a page of user's clip by Private Mobile API
+| user_videos_v1(user_id: str, amount: int = 50)                  | List\[Media] | Get a user's video by Private Mobile API
 | user_videos_paginated_v1(ser_id: int, amount: int = 50, end_cursor="") | Tuple\[List\[Media], str] | Get a page of user's video by Private Mobile API
-| usertag_medias_gql(user_id: int, amount: int = 20)              | List\[Media] | Get medias where a user is tagged by Public Graphql API
-| usertag_medias_v1(user_id: int, amount: int = 20)               | List\[Media] | Get medias where a user is tagged by Private Mobile API
+| usertag_medias_gql(user_id: str, amount: int = 20)              | List\[Media] | Get medias where a user is tagged by Public Graphql API
+| usertag_medias_v1(user_id: str, amount: int = 20)               | List\[Media] | Get medias where a user is tagged by Private Mobile API
 
 ### Example:
 

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -2,7 +2,7 @@
 
 | Method                                                                 | Return          | Description
 | ---------------------------------------------------------------------- | --------------- | ----------------------------------
-| user_stories(user_id: int, amount: int = None)                         | List[Story]     | Get list of stories by user_id
+| user_stories(user_id: str, amount: int = None)                         | List[Story]     | Get list of stories by user_id
 | story_info(story_pk: int, use_cache: bool = True)                      | Story           | Return story info
 | story_delete(story_pk: int)                                            | bool            | Delete story
 | story_seen(story_pks: List[int], skipped_story_pks: List[int])         | bool            | Mark a story as seen

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -6,43 +6,43 @@ View a list of a user's medias, following and followers
 
 | Method                                        | Return                | Description                                                  |
 |-----------------------------------------------|-----------------------|--------------------------------------------------------------|
-| user_followers(user_id: int, amount: int = 0) | Dict\[int, UserShort] | Get dict of followers users (amount=0 - fetch all followers) |
-| user_following(user_id: int, amount: int = 0) | Dict\[int, UserShort] | Get dict of following users (amount=0 - fetch all)           |
-| search_followers(user_id: int, query: str)    | List[UserShort]       | Search by followers                                          |
-| search_following(user_id: int, query: str)    | List[UserShort]       | Search by following                                          |
-| user_info(user_id: int)                       | User                  | Get user info                                                |
+| user_followers(user_id: str, amount: int = 0) | Dict\[int, UserShort] | Get dict of followers users (amount=0 - fetch all followers) |
+| user_following(user_id: str, amount: int = 0) | Dict\[int, UserShort] | Get dict of following users (amount=0 - fetch all)           |
+| search_followers(user_id: str, query: str)    | List[UserShort]       | Search by followers                                          |
+| search_following(user_id: str, query: str)    | List[UserShort]       | Search by following                                          |
+| user_info(user_id: str)                       | User                  | Get user info                                                |
 | user_info_by_username(username: str)          | User                  | Get user info by username                                    |
-| user_follow(user_id: int)                     | bool                  | Follow user                                                  |
-| user_unfollow(user_id: int)                   | bool                  | Unfollow user                                                |
+| user_follow(user_id: str)                     | bool                  | Follow user                                                  |
+| user_unfollow(user_id: str)                   | bool                  | Unfollow user                                                |
 | user_id_from_username(username: str)          | int                   | Get user_id by username                                      |
-| username_from_user_id(user_id: int)           | str                   | Get username by user_id                                      |
-| user_remove_follower(user_id: int)            | bool                  | Remove your follower                                         |
-| mute_posts_from_follow(user_id: int)          | bool                  | Mute posts from following user                               |
-| unmute_posts_from_follow(user_id: int)        | bool                  | Unmute posts from following user                             |
-| mute_stories_from_follow(user_id: int)        | bool                  | Mute stories from following user                             |
-| enable_posts_notifications(user_id: int)      | bool                  | Enable post notifications of user                            |
-| disable_posts_notifications(user_id: int)     | bool                  | Disable post notifications of user                           |
-| enable_videos_notifications(user_id: int)     | bool                  | Enable videos notifications of user                          |
-| disable_videos_notifications(user_id: int)    | bool                  | Disable videos notifications of user                         |
-| enable_reels_notifications(user_id: int)      | bool                  | Enable reels notifications of user                           |
-| disable_reels_notifications(user_id: int)     | bool                  | Disable reels notifications of user                          |
-| enable_stories_notifications(user_id: int)    | bool                  | Enable stories notifications of user                         |
-| disable_stories_notifications(user_id: int)   | bool                  | Disable stories notifications of user                        |
-| close_friend_add(user_id: int)                | bool                  | Add to Close Friends List                                    |
-| close_friend_remove(user_id: int)             | bool                  | Remove from Close Friends List                               |
+| username_from_user_id(user_id: str)           | str                   | Get username by user_id                                      |
+| user_remove_follower(user_id: str)            | bool                  | Remove your follower                                         |
+| mute_posts_from_follow(user_id: str)          | bool                  | Mute posts from following user                               |
+| unmute_posts_from_follow(user_id: str)        | bool                  | Unmute posts from following user                             |
+| mute_stories_from_follow(user_id: str)        | bool                  | Mute stories from following user                             |
+| enable_posts_notifications(user_id: str)      | bool                  | Enable post notifications of user                            |
+| disable_posts_notifications(user_id: str)     | bool                  | Disable post notifications of user                           |
+| enable_videos_notifications(user_id: str)     | bool                  | Enable videos notifications of user                          |
+| disable_videos_notifications(user_id: str)    | bool                  | Disable videos notifications of user                         |
+| enable_reels_notifications(user_id: str)      | bool                  | Enable reels notifications of user                           |
+| disable_reels_notifications(user_id: str)     | bool                  | Disable reels notifications of user                          |
+| enable_stories_notifications(user_id: str)    | bool                  | Enable stories notifications of user                         |
+| disable_stories_notifications(user_id: str)   | bool                  | Disable stories notifications of user                        |
+| close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
+| close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
 
 Low level methods:
 
 | Method                                                                              | Return                      | Description                                                                |
 |-------------------------------------------------------------------------------------|-----------------------------|----------------------------------------------------------------------------|
-| user_followers_gql_chunk(user_id: int, max_amount: int = 0, end_cursor: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Public Graphql API and end_cursor      |
-| user_followers_gql(user_id: int, amount: int = 0)                                   | List[UserShort]             | Get user's followers information by Public Graphql API                     |
-| user_followers_v1_chunk(user_id: int, max_amount: int = 0, max_id: str = "")        | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor) |
-| user_followers_v1(user_id: int, amount: int = 0)                                    | List[UserShort]             | Get user's followers information by Private Mobile API                     |
-| user_following_v1(user_id: int, amount: int = 0)                                    | List[UserShort]             | Get user's following users information by Private Mobile API               |
-| user_following_gql(user_id: int, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
-| search_followers_v1(user_id: int, query: str)                                       | List[UserShort]             | Search by followers by Private Mobile API                                  |
-| search_following_v1(user_id: int, query: str)                                       | List[UserShort]             | Search by following by Private Mobile API                                  |
+| user_followers_gql_chunk(user_id: str, max_amount: int = 0, end_cursor: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Public Graphql API and end_cursor      |
+| user_followers_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's followers information by Public Graphql API                     |
+| user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "")        | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor) |
+| user_followers_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's followers information by Private Mobile API                     |
+| user_following_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's following users information by Private Mobile API               |
+| user_following_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
+| search_followers_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by followers by Private Mobile API                                  |
+| search_following_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by following by Private Mobile API                                  |
 
 Example:
 

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -273,7 +273,7 @@ class PostLoginFlowMixin:
         if reason == "cold_start":
             data["reel_tray_impressions"] = {}
         else:
-            data["reel_tray_impressions"] = {self.user_id: int(time.time())}
+            data["reel_tray_impressions"] = {self.user_id: str(time.time())}
         return self.private_request("feed/reels_tray/", data)
 
 
@@ -474,12 +474,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             return True
         return False
 
-    def one_tap_app_login(self, user_id: int, nonce: str) -> bool:
+    def one_tap_app_login(self, user_id: str, nonce: str) -> bool:
         """One tap login emulation
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
             User ID
         nonce: str
             Login nonce (from Instagram, e.g. in /logout/)

--- a/instagrapi/mixins/fundraiser.py
+++ b/instagrapi/mixins/fundraiser.py
@@ -3,7 +3,7 @@ class FundraiserMixin:
     Helpers for the fundraisers.
     """
 
-    def standalone_fundraiser_info_v1(self, user_id: int):
+    def standalone_fundraiser_info_v1(self, user_id: str):
         """
         Get fundraiser info.
 

--- a/instagrapi/mixins/highlight.py
+++ b/instagrapi/mixins/highlight.py
@@ -36,13 +36,13 @@ class HighlightMixin:
         parts = [p for p in path.split("/") if p and p.isdigit()]
         return str(parts[0])
 
-    def user_highlights_v1(self, user_id: int, amount: int = 0) -> List[Highlight]:
+    def user_highlights_v1(self, user_id: str, amount: int = 0) -> List[Highlight]:
         """
         Get a user's highlight
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of highlight to return, default is 0 (all highlights)
 
@@ -67,13 +67,13 @@ class HighlightMixin:
         )
         return [extract_highlight_v1(highlight) for highlight in result.get("tray", [])]
 
-    def user_highlights(self, user_id: int, amount: int = 0) -> List[Highlight]:
+    def user_highlights(self, user_id: str, amount: int = 0) -> List[Highlight]:
         """
         Get a user's highlights
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of highlight to return, default is 0 (all highlights)
 

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -436,14 +436,14 @@ class MediaMixin:
         return self.media_like(media_id, revert=True)
 
     def user_medias_paginated_gql(
-        self, user_id: int, amount: int = 0, sleep: int = 2, end_cursor=None
+        self, user_id: str, amount: int = 0, sleep: int = 2, end_cursor=None
     ) -> Tuple[List[Media], str]:
         """
         Get a page of a user's media by Public Graphql API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         sleep: int, optional
@@ -481,14 +481,14 @@ class MediaMixin:
         return ([extract_media_gql(media) for media in medias], end_cursor)
 
     def user_medias_gql(
-        self, user_id: int, amount: int = 0, sleep: int = 0
+        self, user_id: str, amount: int = 0, sleep: int = 0
     ) -> List[Media]:
         """
         Get a user's media by Public Graphql API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         sleep: int, optional
@@ -531,14 +531,14 @@ class MediaMixin:
         return medias
 
     def user_videos_paginated_v1(
-        self, user_id: int, amount: int = 50, end_cursor: str = ""
+        self, user_id: str, amount: int = 50, end_cursor: str = ""
     ) -> Tuple[List[Media], str]:
         """
         Get a page of user's video by Private Mobile API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         end_cursor: str, optional
@@ -570,13 +570,13 @@ class MediaMixin:
             medias = medias[:amount]
         return ([extract_media_v1(media) for media in medias], next_max_id)
 
-    def user_videos_v1(self, user_id: int, amount: int = 0) -> List[Media]:
+    def user_videos_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get a user's video by Private Mobile API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
 
@@ -609,14 +609,14 @@ class MediaMixin:
         return medias
 
     def user_medias_paginated_v1(
-        self, user_id: int, amount: int = 33, end_cursor: str = ""
+        self, user_id: str, amount: int = 33, end_cursor: str = ""
     ) -> Tuple[List[Media], str]:
         """
         Get a page of user's media by Private Mobile API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         end_cursor: str, optional
@@ -654,13 +654,13 @@ class MediaMixin:
             medias = medias[:amount]
         return ([extract_media_v1(media) for media in medias], next_max_id)
 
-    def user_medias_v1(self, user_id: int, amount: int = 0) -> List[Media]:
+    def user_medias_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get a user's media by Private Mobile API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
 
@@ -693,14 +693,14 @@ class MediaMixin:
         return medias
 
     def user_medias_paginated(
-        self, user_id: int, amount: int = 0, end_cursor: str = ""
+        self, user_id: str, amount: int = 0, end_cursor: str = ""
     ) -> Tuple[List[Media], str]:
         """
         Get a page of user's media
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         end_cursor: str, optional
@@ -747,7 +747,7 @@ class MediaMixin:
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
 
         Returns
         -------
@@ -772,13 +772,13 @@ class MediaMixin:
         self.base_headers["X-IG-Nav-Chain"] = default_nav
         return pinned_medias
 
-    def user_medias(self, user_id: int, amount: int = 0, sleep: int = 0) -> List[Media]:
+    def user_medias(self, user_id: str, amount: int = 0, sleep: int = 0) -> List[Media]:
         """
         Get a user's media
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         sleep: int, optional
@@ -811,14 +811,14 @@ class MediaMixin:
         return medias
 
     def user_clips_paginated_v1(
-        self, user_id: int, amount: int = 50, end_cursor: str = ""
+        self, user_id: str, amount: int = 50, end_cursor: str = ""
     ) -> Tuple[List[Media], str]:
         """
         Get a page of user's clip (reels) by Private Mobile API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         end_cursor: str, optional
@@ -854,13 +854,13 @@ class MediaMixin:
             medias = medias[:amount]
         return ([extract_media_v1(media["media"]) for media in medias], next_max_id)
 
-    def user_clips_v1(self, user_id: int, amount: int = 0) -> List[Media]:
+    def user_clips_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get a user's clip (reels) by Private Mobile API
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
 
@@ -892,13 +892,13 @@ class MediaMixin:
             medias = medias[:amount]
         return medias
 
-    def user_clips(self, user_id: int, amount: int = 0) -> List[Media]:
+    def user_clips(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get a user's clip (reels)
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
 
@@ -1005,14 +1005,14 @@ class MediaMixin:
         return self.media_archive(media_id, revert=True)
 
     def usertag_medias_gql(
-        self, user_id: int, amount: int = 0, sleep: int = 2
+        self, user_id: str, amount: int = 0, sleep: int = 2
     ) -> List[Media]:
         """
         Get medias where a user is tagged (by Public GraphQL API)
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
         sleep: int, optional
@@ -1056,13 +1056,13 @@ class MediaMixin:
             medias = medias[:amount]
         return [extract_media_gql(media) for media in medias]
 
-    def usertag_medias_v1(self, user_id: int, amount: int = 0) -> List[Media]:
+    def usertag_medias_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get medias where a user is tagged (by Private Mobile API)
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
 
@@ -1095,13 +1095,13 @@ class MediaMixin:
             medias = medias[:amount]
         return [extract_media_v1(media) for media in medias]
 
-    def usertag_medias(self, user_id: int, amount: int = 0) -> List[Media]:
+    def usertag_medias(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get medias where a user is tagged
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of media to return, default is 0 (all medias)
 

--- a/instagrapi/mixins/multiple_accounts.py
+++ b/instagrapi/mixins/multiple_accounts.py
@@ -3,7 +3,7 @@ class MultipleAccountsMixin:
     Helpers for multiple accounts.
     """
 
-    def featured_accounts_v1(self, target_user_id: int) -> dict:
+    def featured_accounts_v1(self, target_user_id: str) -> dict:
         target_user_id = str(target_user_id)
         return self.private_request(
             "multiple_accounts/get_featured_accounts/",

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -156,13 +156,13 @@ class StoryMixin:
             users.append(user)
         return users
 
-    def user_stories_gql(self, user_id: int, amount: int = None) -> List[Story]:
+    def user_stories_gql(self, user_id: str, amount: int = None) -> List[Story]:
         """
         Get a user's stories (Public API)
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of story to return, default is all
 
@@ -177,13 +177,13 @@ class StoryMixin:
             stories = stories[:amount]
         return stories
 
-    def user_stories_v1(self, user_id: int, amount: int = None) -> List[Story]:
+    def user_stories_v1(self, user_id: str, amount: int = None) -> List[Story]:
         """
         Get a user's stories (Private API)
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of story to return, default is all
 
@@ -209,13 +209,13 @@ class StoryMixin:
             stories = stories[: int(amount)]
         return stories
 
-    def user_stories(self, user_id: int, amount: int = None) -> List[Story]:
+    def user_stories(self, user_id: str, amount: int = None) -> List[Story]:
         """
         Get a user's stories
 
         Parameters
         ----------
-        user_id: int
+        user_id: str
         amount: int, optional
             Maximum number of story to return, default is all
 

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -313,7 +313,7 @@ class DirectMedia(BaseModel):
 
 class ReplyMessage(BaseModel):
     id: str
-    user_id: Optional[int]
+    user_id: Optional[str]
     timestamp: datetime
     item_type: Optional[str]
     is_sent_by_viewer: Optional[bool]
@@ -334,7 +334,7 @@ class ReplyMessage(BaseModel):
 
 class DirectMessage(BaseModel):
     id: str  # e.g. 28597946203914980615241927545176064
-    user_id: Optional[int]
+    user_id: Optional[str]
     thread_id: Optional[int]  # e.g. 340282366841710300949128531777654287254
     timestamp: datetime
     item_type: Optional[str]
@@ -478,7 +478,7 @@ class Track(BaseModel):
 class Note(BaseModel):
     id: str
     text: str
-    user_id: int
+    user_id: str
     user: UserShort
     audience: int
     created_at: datetime


### PR DESCRIPTION
## Refactor: user_id type annotation

### Description

This pull request addresses an inconsistency in the type annotation for the `user_id` parameter across the codebase. Currently, the functions that interact with a user's ID use different type expectations, leading to potential inconveniences when handling the `user_id` parameter.

### Problem Statement

Throughout the codebase, the user's ID is fetched using `user_id_from_username`, which returns a string. However, other functions that accept `user_id` as an argument expect it to be an integer.

```python
    def user_id_from_username(self, username: str) -> str: ...
```

### Proposed Solution

To enhance consistency and improve code readability, this pull request introduces a uniform type annotation for the `user_id` parameter. We will ensure that all functions that take `user_id` as an argument will accept either a string or an integer, allowing developers to use the type that best fits their use case.

### Example

Previously, when dealing with user followers and their media:
```python
user_id = client.user_id_from_username(username)
followers = client.user_followers(user_id)

for user_id in list(followers.keys())[::followers_step]:
    client.user_follow(user_id)
    if not followers[user_id].is_private:
        medias = client.user_medias(int(user_id)) # we are forced to cast user_id to int

```
