### PR TITLE
fix extact_media_v1 exception

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -71,7 +71,7 @@ def extract_media_v1(data):
     )
     media["like_count"] = media.get("like_count", 0)
     media["has_liked"] = media.get("has_liked", False)
-    media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags", [])]
+    media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags") or []]
     media["play_count"] = media.get("play_count", 0)
     media["coauthor_producers"] = media.get("coauthor_producers", [])
     return Media(


### PR DESCRIPTION
# Problem Description

While working with the library, I encountered an issue when trying to download an Instagram Story, for example:
`https://www.instagram.com/stories/goods.guru/3498103893726922555`

An exception is raised:

```python
TypeError: 'NoneType' object is not iterable
```

Full traceback:

```python
eacon  | 2025-06-03 08:24:35,222 - root - ERROR - 'NoneType' object is not iterable
warp_beacon  | Traceback (most recent call last):
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/warp_beacon/scraper/__init__.py", line 188, in do_work
warp_beacon  |     items = actor.download(job)
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/warp_beacon/scraper/instagram/instagram.py", line 383, in download
warp_beacon  |     story_info = self.cl.story_info(media_id)
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/instagrapi/mixins/story.py", line 92, in story_info
warp_beacon  |     story = self.story_info_v1(story_pk)
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/instagrapi/mixins/story.py", line 63, in story_info_v1
warp_beacon  |     story_id = self.media_id(story_pk)
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/instagrapi/mixins/media.py", line 57, in media_id
warp_beacon  |     user = self.media_user(media_id)
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/instagrapi/mixins/media.py", line 372, in media_user
warp_beacon  |     return self.media_info(media_pk).user
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/instagrapi/mixins/media.py", line 237, in media_info_v1
warp_beacon  |     return extract_media_v1(result["items"].pop())
warp_beacon  |   File "/usr/local/lib/python3.10/dist-packages/instagrapi/extractors.py", line 70, in extract_media_v1
warp_beacon  |     media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags", [])]
warp_beacon  | TypeError: 'NoneType' object is not iterable
```
The issue occurs when `media.get("sponsor_tags")` returns `None` instead of a list as expected.

# Proposed Solution
This PR proposes a simple fix: safely handle the case where `sponsor_tags` is `None` by replacing it with an empty list before iteration. This prevents the error and allows such stories to be processed correctly.
