### PR TITLE
Fixed issue causing ValidationError after clip_upload

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -304,7 +304,7 @@ class ClipsIgArtist(TypesBaseModel):
     full_name: str
     is_private: bool = False
     is_verified: bool = False
-    profile_pic_id: Optional[str]
+    profile_pic_id: Optional[str] = None
     profile_pic_url: str
     strong_id__: str
 


### PR DESCRIPTION
Fixes Issue #2263 

ValidationError when uploading reel due to the field profile_pic_id missing from response. Made the field optional in ClipsIgArtist.