### PR TITLE
feat/refactor: improve app version handling and settings split

### DIFF
--- a/instagrapi/config.py
+++ b/instagrapi/config.py
@@ -10,6 +10,31 @@ USER_AGENT_BASE = (
     "{dpi}; {resolution}; {manufacturer}; "
     "{model}; {device}; {cpu}; {locale}; {version_code})"
 )
+
+# Default device profile (hardware/system) and app version settings.
+DEVICE_SETTINGS = {
+    "android_version": 26,
+    "android_release": "8.0.0",
+    "dpi": "480dpi",
+    "resolution": "1080x1920",
+    "manufacturer": "OnePlus",
+    "device": "devitron",
+    "model": "6T Dev",
+    "cpu": "qcom",
+}
+APP_SETTINGS = {
+    "364.0.0.35.86": {
+        "app_version": "364.0.0.35.86",
+        "version_code": "374010953",
+        "bloks_versioning_id": "8ccf54aad76788a6ca03ddfc33afcdcf692f2f5a3ba814ea73d5facba7fa2c2d",
+    },
+    "385.0.0.47.74": {
+        "app_version": "385.0.0.47.74",
+        "version_code": "378906843",
+        "bloks_versioning_id": "a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221",
+    },
+}
+
 # Instagram 76.0.0.15.395 (iPhone9,2; iOS 10_0_2; en_US; en-US; scale=2.61; 1080x1920) AppleWebKit/420+
 # Instagram 208.0.0.32.135 (iPhone; iOS 14_7_1; en_US; en-US; scale=2.61; 1080x1920) AppleWebKit/605.1.15
 

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -166,7 +166,7 @@ class PrivateRequestMixin:
             "X-IG-Android-ID": self.android_device_id,
             "X-IG-Timezone-Offset": str(self.timezone_offset),
             "X-IG-Connection-Type": "WIFI",
-            "X-IG-Capabilities": "3brTvx0=",  # "3brTvwE=" in instabot
+            "X-IG-Capabilities": "3brTv10=",  # "3brTvwE=" in instabot
             "X-IG-App-ID": self.app_id,
             "Priority": "u=3",
             "User-Agent": self.user_agent,


### PR DESCRIPTION
  ## Summary
  - decouple default device/app settings into config and merge in set_device
  - keep bloks_versioning_id inside device_settings and sync attribute
  - select app settings from APP_SETTINGS, add 385.0.0.47.74, and support override_app_version
  - bump default app_version/version_code to 364.0.0.35.86/374010953 and update bloks id
  - rebuild UA when override is enabled; keep legacy bloks id when app_version is unknown
  - update default X-IG-Capabilities to 3brTv10=

  ## Motivation
  Some accounts fail login with the previous default (app_version 269.0.0.18.75 / version_code 314665256), so defaults and
  related parameters are refreshed.