### PR TITLE
Fix: Audio filter infos can be None

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -341,7 +341,7 @@ class ClipsOriginalSoundInfo(TypesBaseModel):
     overlap_duration_in_ms: Optional[int] = None
     audio_asset_start_time_in_ms: Optional[int] = None
     ig_artist: ClipsIgArtist
-    audio_filter_infos: List[dict] = []
+    audio_filter_infos: Optional[List[dict]] = []
     audio_parts: List[dict] = []
     audio_parts_by_filter: List[dict] = []
     consumption_info: ClipsConsumptionInfo


### PR DESCRIPTION
Pydantic was throwing error when getting hashtag medias because of this field.
Tried downgrading as per some issues resolvance but instagrapi 2.2.1 requires pydantic==2.11.7.