### PR TITLE
Reformat README.md for script reference clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ posts = cl.user_medias(target_id, amount=10)
 for media in posts:
     # download photos to the current folder
     cl.photo_download(media.pk)
-
-See [examples/session_login.py](examples/session_login.py) for a standalone script demonstrating these login methods.
 ```
+See [examples/session_login.py](examples/session_login.py) for a standalone script demonstrating these login methods.
+
 
 <details>
     <summary>Additional example</summary>


### PR DESCRIPTION
Moved the reference to the standalone script to a new line for better formatting.