### PR TITLE
Fixed story viewers fetching api and included new properties

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -33,6 +33,7 @@ from .types import (
     User,
     UserShort,
     Usertag,
+    Viewer
 )
 from .utils import InstagramIdCodec, json_value
 
@@ -195,6 +196,14 @@ def extract_user_short(data):
     data["pk"] = data.get("id", data.get("pk", None))
     assert data["pk"], f'User without pk "{data}"'
     return UserShort(**data)
+
+
+def extract_viewer(data):
+    """Extract Viewer info"""
+    user = data.pop("user")
+    user["pk"] = user.get("id", user.get("pk", None))
+    assert user["pk"], f'User without pk "{user}"'
+    return Viewer(**user, **data)
 
 
 def extract_broadcast_channel(data):

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -305,6 +305,34 @@ class StoryMixin:
             shutil.copyfileobj(response.raw, f)
         return path.resolve()
 
+    def story_viewers_chunk(
+        self, story_pk: int, max_amount: int = 0, max_id: str = ""
+    ) -> tuple[list[UserShort], str]:
+        unique_set: set[str] = set()
+        users: list[UserShort] = []
+        story_pk = self.media_pk(story_pk)
+        params = {
+            "supported_capabilities_new": json.dumps(config.SUPPORTED_CAPABILITIES)
+        }
+
+        while True:
+            if max_id:
+                params["max_id"] = max_id
+            result = self.private_request(
+                f"media/{story_pk}/list_reel_media_viewer/", params=params
+            )
+            for item in result["users"]:
+                user = extract_user_short(item)
+                if user.pk in unique_set:
+                    continue
+                unique_set.add(user.pk)
+                users.append(user)
+
+            max_id = result.get("next_max_id")
+            if not max_id or (max_amount and len(users) >= max_amount):
+                break
+        return users, max_id
+
     def story_viewers(self, story_pk: int, amount: int = 0) -> List[UserShort]:
         """
         List of story viewers (Private API)
@@ -320,31 +348,9 @@ class StoryMixin:
         List[UserShort]
             A list of objects of UserShort
         """
-        users = []
-        next_max_id = None
-        story_pk = self.media_pk(story_pk)
-        params = {
-            "supported_capabilities_new": json.dumps(config.SUPPORTED_CAPABILITIES)
-        }
-        while True:
-            try:
-                if next_max_id:
-                    params["max_id"] = next_max_id
-                result = self.private_request(
-                    f"media/{story_pk}/list_reel_media_viewer/", params=params
-                )
-                for item in result["users"]:
-                    users.append(extract_user_short(item))
-                if amount and len(users) >= amount:
-                    break
-                next_max_id = result.get("next_max_id")
-                if not next_max_id:
-                    break
-            except Exception as e:
-                self.logger.exception(e)
-                break
+        users, _ = self.story_viewers_chunk(story_pk, amount)
         if amount:
-            users = users[: int(amount)]
+            users = users[:amount]
         return users
 
     def story_like(self, story_id: str, revert: bool = False) -> bool:

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -11,8 +11,9 @@ from instagrapi.extractors import (
     extract_story_gql,
     extract_story_v1,
     extract_user_short,
+    extract_viewer,
 )
-from instagrapi.types import Story, UserShort
+from instagrapi.types import Story, UserShort, Viewer
 
 
 class StoryMixin:
@@ -307,9 +308,9 @@ class StoryMixin:
 
     def story_viewers_chunk(
         self, story_pk: int, max_amount: int = 0, max_id: str = ""
-    ) -> tuple[list[UserShort], str]:
+    ) -> tuple[list[Viewer], str]:
         unique_set: set[str] = set()
-        users: list[UserShort] = []
+        viewers: list[Viewer] = []
         story_pk = self.media_pk(story_pk)
         params = {
             "supported_capabilities_new": json.dumps(config.SUPPORTED_CAPABILITIES)
@@ -321,19 +322,19 @@ class StoryMixin:
             result = self.private_request(
                 f"media/{story_pk}/list_reel_media_viewer/", params=params
             )
-            for item in result["users"]:
-                user = extract_user_short(item)
-                if user.pk in unique_set:
+            for item in result["viewers"]:
+                viewer = extract_viewer(item)
+                if viewer.pk in unique_set:
                     continue
-                unique_set.add(user.pk)
-                users.append(user)
+                unique_set.add(viewer.pk)
+                viewers.append(viewer)
 
             max_id = result.get("next_max_id")
-            if not max_id or (max_amount and len(users) >= max_amount):
+            if not max_id or (max_amount and len(viewers) >= max_amount):
                 break
-        return users, max_id
+        return viewers, max_id
 
-    def story_viewers(self, story_pk: int, amount: int = 0) -> List[UserShort]:
+    def story_viewers(self, story_pk: int, amount: int = 0) -> List[Viewer]:
         """
         List of story viewers (Private API)
 
@@ -345,13 +346,13 @@ class StoryMixin:
 
         Returns
         -------
-        List[UserShort]
-            A list of objects of UserShort
+        List[Viewer]
+            A list of objects of Viewer
         """
-        users, _ = self.story_viewers_chunk(story_pk, amount)
+        viewers, _ = self.story_viewers_chunk(story_pk, amount)
         if amount:
-            users = users[:amount]
-        return users
+            viewers = viewers[:amount]
+        return viewers
 
     def story_like(self, story_id: str, revert: bool = False) -> bool:
         """

--- a/instagrapi/mixins/totp.py
+++ b/instagrapi/mixins/totp.py
@@ -129,7 +129,8 @@ class TOTPMixin:
         )
         return result["status"] == "ok"
 
-    def totp_generate_code(self, seed: str) -> str:
+    @staticmethod
+    def totp_generate_code(seed: str) -> str:
         """
         Generate 2FA TOTP code
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -535,24 +535,9 @@ class UserMixin:
         """
         return self.search_following_v1(user_id, query)
 
-    def user_following_gql(self, user_id: str, amount: int = 0) -> List[UserShort]:
-        """
-        Get user's following users information by Public Graphql API
-
-        Parameters
-        ----------
-        user_id: str
-            User id of an instagram account
-        amount: int, optional
-            Maximum number of media to return, default is 0
-
-        Returns
-        -------
-        List[UserShort]
-            List of objects of User type
-        """
-        user_id = str(user_id)
-        end_cursor = None
+    def user_following_gql_chunk(
+        self, user_id: str, max_amount: int = 0, end_cursor: str = None
+    ) -> tuple[list[UserShort], str]:
         users = []
         variables = {
             "id": user_id,
@@ -576,9 +561,28 @@ class UserMixin:
             end_cursor = page_info.get("end_cursor")
             if not page_info.get("has_next_page") or not end_cursor:
                 break
-            if amount and len(users) >= amount:
+            if max_amount and len(users) >= max_amount:
                 break
             # time.sleep(sleep)
+        return users, end_cursor
+
+    def user_following_gql(self, user_id: str, amount: int = 0) -> List[UserShort]:
+        """
+        Get user's following users information by Public Graphql API
+
+        Parameters
+        ----------
+        user_id: str
+            User id of an instagram account
+        amount: int, optional
+            Maximum number of media to return, default is 0
+
+        Returns
+        -------
+        List[UserShort]
+            List of objects of User type
+        """
+        users, _ = self.user_following_gql_chunk(str(user_id), amount)
         if amount:
             users = users[:amount]
         return users

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -144,9 +144,9 @@ class UserShort(TypesBaseModel):
 
 
 class Viewer(UserShort):
-    has_liked: bool
-    reply_text: str
-    is_spam_viewer: bool
+    has_liked: bool = False
+    reply_text: str = ""
+    is_spam_viewer: bool = False
 
 
 class Usertag(TypesBaseModel):

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -143,6 +143,12 @@ class UserShort(TypesBaseModel):
     # stories: List = [] # not found in fbsearch_suggested_profiles
 
 
+class Viewer(UserShort):
+    has_liked: bool
+    reply_text: str
+    is_spam_viewer: bool
+
+
 class Usertag(TypesBaseModel):
     user: UserShort
     x: float


### PR DESCRIPTION
Main change here is the update of the `story_viewers` function.
It used to work before but now it doesn't so I fixed it, accounting for the changes in the layout of the variables returned from the instagram api.
Also since the api returns stuff such as whether the viewer liked the story or not I decided to add an additional type entry named `Viewer` which include those extra properties that don't exist in the regular `UserShort`.
The rest of the changes are really small bugs (or lack of api e.g. `user_following_gql_chunk` which I needed) here and there and some formatting I may have applied (sorry if this made things worse).