### PR TITLE
fix: relax DirectThread fields that IG sometimes omits

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -925,11 +925,11 @@ class DirectThread(TypesBaseModel):
     mentions_muted: bool
     approval_required_for_new_members: bool
     input_mode: int
-    business_thread_folder: int
-    read_state: int
+    business_thread_folder: Optional[int] = None
+    read_state: Optional[int] = None
     is_close_friend_thread: bool = False
-    assigned_admin_id: int
-    shh_mode_enabled: bool
+    assigned_admin_id: Optional[int] = None
+    shh_mode_enabled: Optional[bool] = None
     last_seen_at: Dict[str, LastSeenInfo] = {}
 
     def is_seen(self, user_id: str):

--- a/tests.py
+++ b/tests.py
@@ -2648,6 +2648,47 @@ class DirectExtractorRegressionTestCase(unittest.TestCase):
 
         self.assertFalse(thread.is_close_friend_thread)
 
+    def test_direct_thread_parses_when_optional_fields_missing(self):
+        """IG omits business_thread_folder / read_state / assigned_admin_id /
+        shh_mode_enabled in older inbox shapes and Threads-app threads.
+        Parser must not raise ValidationError on those payloads."""
+        thread = extract_direct_thread(
+            {
+                "thread_v2_id": "1",
+                "thread_id": "2",
+                "items": [],
+                "users": [
+                    {
+                        "pk": "3",
+                        "username": "example",
+                        "profile_pic_url": "https://example.com/pic.jpg",
+                    }
+                ],
+                "left_users": [],
+                "admin_user_ids": [],
+                "last_activity_at": 1761953663000000,
+                "muted": False,
+                "named": False,
+                "canonical": False,
+                "pending": False,
+                "archived": False,
+                "thread_type": "private",
+                "thread_title": "",
+                "folder": 0,
+                "vc_muted": False,
+                "is_group": False,
+                "mentions_muted": False,
+                "approval_required_for_new_members": False,
+                "input_mode": 0,
+                "last_seen_at": {},
+            }
+        )
+
+        self.assertIsNone(thread.business_thread_folder)
+        self.assertIsNone(thread.read_state)
+        self.assertIsNone(thread.assigned_admin_id)
+        self.assertIsNone(thread.shh_mode_enabled)
+
 
 class DirectMixinRegressionTestCase(unittest.TestCase):
     def build_client(self):


### PR DESCRIPTION
## Summary

- `business_thread_folder`, `read_state`, `assigned_admin_id`, `shh_mode_enabled` on `DirectThread` were declared as required scalars — but IG returns them inconsistently (older inbox shapes, Threads-app threads). Parsing such payloads raised `ValidationError: Field required`.
- Made all four `Optional[...] = None`, matching the pattern already used for other Direct fields.
- Added regression test in \`DirectExtractorRegressionTestCase\` that constructs a payload without any of the four fields and asserts they parse to \`None\`.

Closes #7. Ported from aiograpi [a785385](https://github.com/subzeroid/aiograpi/commit/a785385).

## Test plan

- [x] \`pytest tests.py::DirectExtractorRegressionTestCase::test_direct_thread_parses_when_optional_fields_missing\` — passes
- [x] Existing \`test_direct_thread_defaults_missing_is_close_friend_thread\` still passes (no regression)
- [x] \`flake8 instagrapi --select=E9,F63,F7,F82\` clean
- [x] \`isort --check-only instagrapi\` clean

## Release plan

After merge: bump to \`2.5.1\`, tag, auto-publish via \`publish.yml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)