### PR TITLE
fix: extract_location external_id — coerce to int or None

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -255,7 +255,11 @@ def extract_location(data):
         if place_location:
             data = place_location
     data["pk"] = data.get("id", data.get("pk", data.get("location_id", None)))
-    data["external_id"] = data.get("external_id", data.get("facebook_places_id"))
+    external_id = data.get("external_id") or data.get("facebook_places_id")
+    if external_id in (None, "", "None"):
+        data["external_id"] = None
+    else:
+        data["external_id"] = int(external_id)
     data["external_id_source"] = data.get(
         "external_id_source", data.get("external_source")
     )

--- a/tests.py
+++ b/tests.py
@@ -424,6 +424,44 @@ class LocationMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(locations[0].pk, 123)
         self.assertEqual(locations[0].external_id, 456)
 
+    def test_extract_location_coerces_external_id_to_int(self):
+        """IG sometimes ships external_id as a numeric string."""
+        from instagrapi.extractors import extract_location
+
+        location = extract_location(
+            {
+                "pk": "239130043",
+                "name": "Choroni",
+                "external_id": "108835465815492",
+            }
+        )
+        self.assertEqual(location.external_id, 108835465815492)
+
+    def test_extract_location_handles_missing_external_id(self):
+        """IG returns None / '' / the literal 'None' for degraded location
+        payloads — used to crash media_info_gql with a pydantic
+        int_parsing error. See issue #72."""
+        from instagrapi.extractors import extract_location
+
+        for raw in (None, "", "None"):
+            with self.subTest(external_id=raw):
+                location = extract_location(
+                    {"pk": "1", "name": "Nowhere", "external_id": raw}
+                )
+                self.assertIsNone(location.external_id)
+
+    def test_extract_location_falls_back_to_facebook_places_id(self):
+        from instagrapi.extractors import extract_location
+
+        location = extract_location(
+            {
+                "pk": "1",
+                "name": "Choroni",
+                "facebook_places_id": "456",
+            }
+        )
+        self.assertEqual(location.external_id, 456)
+
     def test_location_search_pk_returns_exact_match(self):
         client = Client()
         client.location_info = lambda pk: Location(pk=str(pk), name="Choroni")


### PR DESCRIPTION
## Summary

\`Location.external_id\` is typed \`Optional[int]\`, but \`extract_location\` was passing IG's raw value through. When IG returned the field as missing, \`None\`, \`''\` or the literal string \`'None'\`, pydantic raised:

\`\`\`
ValidationError: external_id
  Input should be a valid integer, unable to parse string as an
  integer [type=int_parsing, input_value='None']
\`\`\`

This bubbled up out of \`media_info_gql\` for any media whose location had a degraded payload — making the whole call fail.

Fix: take \`external_id\` or fall back to \`facebook_places_id\`; treat \`None / '' / 'None'\` as missing; otherwise \`int()\`.

Closes #72. Ported from aiograpi [7a9cf1f](https://github.com/subzeroid/aiograpi/commit/7a9cf1f).

## Test plan

3 new unit tests in \`LocationMixinRegressionTestCase\`:

- [x] \`test_extract_location_coerces_external_id_to_int\` — string → int
- [x] \`test_extract_location_handles_missing_external_id\` — None / '' / 'None' all → None (subtest)
- [x] \`test_extract_location_falls_back_to_facebook_places_id\` — preserved fallback path
- [x] All 5 \`LocationMixinRegressionTestCase\` tests pass (no regression on the 2 pre-existing)
- [x] flake8 + isort clean

## Release plan

After merge: bump to \`2.5.2\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)