### PR TITLE
fix: harden story extraction, private 401/404, hashtag chunks

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -584,6 +584,12 @@ def extract_story_v1(data):
     story["user"] = extract_user_short(story.get("user"))
     story["sponsor_tags"] = [tag["sponsor"] for tag in story.get("sponsor_tags", [])]
     story["is_paid_partnership"] = story.get("is_paid_partnership")
+    if not story.get("code"):
+        story["code"] = InstagramIdCodec.encode(story["pk"])
+    if not story.get("taken_at"):
+        story["taken_at"] = story.get("device_timestamp") or story.get(
+            "taken_at_timestamp"
+        )
     return Story(**story)
 
 

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -188,7 +188,14 @@ class HashtagMixin:
                 for node in nodes:
                     if max_amount and len(medias) >= max_amount:
                         break
-                    media = extract_media_v1(node["media"])
+                    try:
+                        media = extract_media_v1(node["media"])
+                    except (KeyError, AttributeError, TypeError) as exc:
+                        # One malformed node would otherwise crash the whole
+                        # chunk and lose the rest of the page. Skip and keep
+                        # going.
+                        self.logger.warning("Skipping malformed hashtag node: %s", exc)
+                        continue
                     # media_pk = node["media"]["id"]
                     # if media_pk in unique_set:
                     #     continue
@@ -292,7 +299,11 @@ class HashtagMixin:
             for node in nodes:
                 if max_amount and len(medias) >= max_amount:
                     break
-                media = extract_media_v1(node["media"])
+                try:
+                    media = extract_media_v1(node["media"])
+                except (KeyError, AttributeError, TypeError) as exc:
+                    self.logger.warning("Skipping malformed hashtag node: %s", exc)
+                    continue
                 # check contains hashtag in caption
                 # if f"#{name}" not in media.caption_text:
                 #     continue

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -20,6 +20,7 @@ from instagrapi.exceptions import (
     ClientNotFoundError,
     ClientRequestTimeout,
     ClientThrottledError,
+    ClientUnauthorizedError,
     FeedbackRequired,
     InvalidMediaId,
     InvalidTargetUser,
@@ -494,7 +495,18 @@ class PrivateRequestMixin:
             elif e.response.status_code == 429:
                 self.logger.warning("Status 429: Too many requests")
                 raise ClientThrottledError(e, response=e.response, **last_json)
+            elif e.response.status_code == 401:
+                self.logger.warning("Status 401: Unauthorized %s", endpoint)
+                raise ClientUnauthorizedError(e, response=e.response, **last_json)
             elif e.response.status_code == 404:
+                if e.response.content == b"Not Found":
+                    # Masked challenge (often on /media/.../comments/) — IG
+                    # returns the bare body "Not Found" instead of a JSON
+                    # challenge envelope. Surface it as ChallengeRequired so
+                    # callers can resolve it instead of treating the resource
+                    # as missing.
+                    self.logger.warning("Status 404 (masked challenge): %s", endpoint)
+                    raise ChallengeRequired(**last_json)
                 self.logger.warning("Status 404: Endpoint %s does not exist", endpoint)
                 raise ClientNotFoundError(e, response=e.response, **last_json)
             elif e.response.status_code == 408:

--- a/tests.py
+++ b/tests.py
@@ -486,6 +486,163 @@ class LocationMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(location.external_id, 108835465815492)
 
 
+class HikerNextHardeningTestCase(unittest.TestCase):
+    """Hardening fixes ported from the hiker-next instagrapi fork:
+    extract_story_v1 fallbacks, _send_private_request 401/404 handling,
+    and hashtag-chunk malformed-node skipping."""
+
+    # --- extract_story_v1 fallbacks ---
+
+    @staticmethod
+    def _minimal_story_payload(**overrides):
+        payload = {
+            "pk": "3613500067578544892",
+            "id": "3613500067578544892_25025320",
+            "code": "Cabc123",
+            "taken_at": 1710000000,
+            "media_type": 1,
+            "user": {
+                "pk": "25025320",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_extract_story_v1_falls_back_to_codec_when_code_missing(self):
+        payload = self._minimal_story_payload()
+        del payload["code"]
+
+        story = extract_story_v1(payload)
+
+        # InstagramIdCodec.encode("3613500067578544892") is deterministic.
+        from instagrapi.utils import InstagramIdCodec
+
+        self.assertEqual(story.code, InstagramIdCodec.encode("3613500067578544892"))
+
+    def test_extract_story_v1_falls_back_to_device_timestamp_when_taken_at_missing(
+        self,
+    ):
+        payload = self._minimal_story_payload()
+        del payload["taken_at"]
+        payload["device_timestamp"] = 1710000000
+
+        story = extract_story_v1(payload)
+
+        self.assertEqual(int(story.taken_at.timestamp()), 1710000000)
+
+    def test_extract_story_v1_falls_back_to_taken_at_timestamp_when_taken_at_missing(
+        self,
+    ):
+        payload = self._minimal_story_payload()
+        del payload["taken_at"]
+        payload["taken_at_timestamp"] = 1710000000
+
+        story = extract_story_v1(payload)
+
+        self.assertEqual(int(story.taken_at.timestamp()), 1710000000)
+
+    # --- _send_private_request: 401 / 404 b"Not Found" ---
+
+    def _make_http_error_response(self, status_code, content=b"", json_body=None):
+        response = Mock()
+        response.status_code = status_code
+        response.content = content
+        response.headers = {}
+        response.url = "https://i.instagram.com/api/v1/test/"
+        response.text = content.decode("utf-8", errors="replace") if content else ""
+        response.request = Mock(method="GET")
+        if json_body is not None:
+            response.json.return_value = json_body
+        else:
+            response.json.side_effect = JSONDecodeError("", "", 0)
+        error = requests.HTTPError(response=response)
+        response.raise_for_status.side_effect = error
+        return response
+
+    def _build_private_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        client.last_response = None
+        return client
+
+    def test_send_private_request_raises_unauthorized_on_401(self):
+        client = self._build_private_client()
+        response = self._make_http_error_response(401, content=b"unauthorized")
+
+        with mock.patch.object(client.private, "get", return_value=response):
+            with self.assertRaises(ClientUnauthorizedError):
+                client._send_private_request("test/")
+
+    def test_send_private_request_promotes_404_not_found_body_to_challenge(self):
+        client = self._build_private_client()
+        response = self._make_http_error_response(404, content=b"Not Found")
+
+        with mock.patch.object(client.private, "get", return_value=response):
+            with self.assertRaises(ChallengeRequired):
+                client._send_private_request("media/123/comments/")
+
+    def test_send_private_request_keeps_regular_404_as_not_found(self):
+        from instagrapi.exceptions import ClientNotFoundError
+
+        client = self._build_private_client()
+        # Different body (not the exact "Not Found" sentinel) → standard
+        # ClientNotFoundError, not promoted to ChallengeRequired.
+        response = self._make_http_error_response(
+            404,
+            content=b'{"message":"endpoint not found"}',
+            json_body={"message": "endpoint not found"},
+        )
+
+        with mock.patch.object(client.private, "get", return_value=response):
+            with self.assertRaises(ClientNotFoundError):
+                client._send_private_request("nonexistent/")
+
+    # --- hashtag chunk: skip malformed nodes ---
+
+    def test_hashtag_medias_top_v1_chunk_skips_malformed_nodes(self):
+        client = Client()
+        good_node = {
+            "media": {
+                "pk": "1",
+                "id": "1_2",
+                "code": "abc",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": "https://example.com/x.jpg",
+                            "width": 100,
+                            "height": 100,
+                        }
+                    ]
+                },
+            }
+        }
+        # Missing "media" key → KeyError when extractor accesses node["media"].
+        malformed_node = {"unexpected_shape": True}
+
+        client.private_request = lambda *a, **kw: {
+            "sections": [{"layout_content": {"medias": [malformed_node, good_node]}}],
+            "more_available": False,
+            "next_max_id": None,
+        }
+
+        medias, next_max_id = client.hashtag_medias_v1_chunk("example", 0, "top")
+
+        # Bad node skipped, good one survives — chunk doesn't lose the page.
+        self.assertEqual(len(medias), 1)
+        self.assertEqual(medias[0].pk, "1")
+        self.assertIsNone(next_max_id)
+
+
 class ChallengeRegressionTestCase(unittest.TestCase):
     def test_auth_platform_challenge_raises_clear_manual_verification_error(self):
         client = Client()

--- a/tests.py
+++ b/tests.py
@@ -486,8 +486,8 @@ class LocationMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(location.external_id, 108835465815492)
 
 
-class HikerNextHardeningTestCase(unittest.TestCase):
-    """Hardening fixes ported from the hiker-next instagrapi fork:
+class HardeningRegressionTestCase(unittest.TestCase):
+    """Hardening fixes for malformed / edge-case IG responses:
     extract_story_v1 fallbacks, _send_private_request 401/404 handling,
     and hashtag-chunk malformed-node skipping."""
 


### PR DESCRIPTION
## Summary

Four small hardening fixes for malformed / edge-case IG responses. Bundled because they share a single test class and a single \`aiograpi\` source commit.

### 1. \`extract_story_v1\` fallbacks for \`code\` / \`taken_at\`

IG occasionally ships story payloads missing \`code\` and/or \`taken_at\`. \`Story.code\` and \`Story.taken_at\` are required, so a missing field used to raise \`ValidationError\` on otherwise legitimate stories. Now:

- missing \`code\` → \`InstagramIdCodec.encode(pk)\`
- missing \`taken_at\` → \`device_timestamp\` or \`taken_at_timestamp\`

### 2. \`_send_private_request\`: 401 → \`ClientUnauthorizedError\`

The exception class has existed (and is documented in \`docs/exceptions.md:11\`) — but \`401\` was never actually raised; it fell through to a generic \`ClientError\`. Now mapped explicitly.

### 3. \`_send_private_request\`: 404 + body \`b\"Not Found\"\` → \`ChallengeRequired\`

IG sometimes returns the bare body \`Not Found\` (no JSON envelope) for masked challenges, often on \`/media/.../comments/\`. Treating that as a missing endpoint led callers to mark the resource as gone instead of entering challenge resolution. Promoted to \`ChallengeRequired\`. Vanilla 404s with other bodies remain \`ClientNotFoundError\` (regression-tested).

### 4. \`hashtag_medias_a1_chunk\` / \`hashtag_medias_v1_chunk\`: skip malformed nodes

One malformed \`node[\"media\"]\` would crash \`extract_media_v1\` and abort the whole chunk, losing the rest of the page. Now wrapped in \`try/except (KeyError, AttributeError, TypeError)\` with a warning log.

Ported from aiograpi [d286061](https://github.com/subzeroid/aiograpi/commit/d286061).

## Test plan

7 new cases in \`HardeningRegressionTestCase\`:

- [x] \`test_extract_story_v1_falls_back_to_codec_when_code_missing\`
- [x] \`test_extract_story_v1_falls_back_to_device_timestamp_when_taken_at_missing\`
- [x] \`test_extract_story_v1_falls_back_to_taken_at_timestamp_when_taken_at_missing\`
- [x] \`test_send_private_request_raises_unauthorized_on_401\`
- [x] \`test_send_private_request_promotes_404_not_found_body_to_challenge\`
- [x] \`test_send_private_request_keeps_regular_404_as_not_found\` (regression check)
- [x] \`test_hashtag_medias_top_v1_chunk_skips_malformed_nodes\`
- [x] flake8 + isort clean

## Documentation

\`docs/exceptions.md\` already documents \`ClientUnauthorizedError\` (HTTP 401) and \`ChallengeRequired\` — this PR makes the docs honest by actually wiring them up to the right paths. No doc changes required.

## Release plan

After merge: bump to \`2.5.3\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)