### PR TITLE
feat(user): add chaining + fetch_suggestion_details

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -30,6 +30,8 @@ View a list of a user's medias, following and followers
 | disable_stories_notifications(user_id: str)   | bool                  | Disable stories notifications of user                        |
 | close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
+| chaining(user_id: str)                        | dict                  | Suggested users for a profile (`discover/chaining/`) — same surface as the app's "Suggested for you" carousel |
+| fetch_suggestion_details(user_id: str, chained_ids: str) | dict       | Expanded social-context fields for chained suggestion ids (`discover/fetch_suggestion_details/`) |
 
 Lookup helpers:
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -12,6 +12,8 @@ from instagrapi.exceptions import (
     ClientJSONDecodeError,
     ClientLoginRequired,
     ClientNotFoundError,
+    InvalidTargetUser,
+    UnknownError,
     UserNotFound,
 )
 from instagrapi.extractors import extract_user_gql, extract_user_short, extract_user_v1
@@ -1445,3 +1447,76 @@ class UserMixin:
         creator_info = result.get("user", {}).pop("creator_info", {})
         user = extract_user_short(result.get("user", {}))
         return (user, creator_info)
+
+    def chaining(self, user_id: str) -> dict:
+        """
+        Get suggested users for a target user_id.
+
+        Hits Instagram's private ``discover/chaining/`` endpoint — the
+        same surface the official app uses to render the "Suggested
+        for you" carousel under a profile. Returns the raw payload so
+        the caller can decide what shape it wants (typically passed
+        straight into :meth:`fetch_suggestion_details` for the
+        expanded form).
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk.
+
+        Returns
+        -------
+        dict
+            Raw ``discover/chaining/`` response.
+
+        Raises
+        ------
+        InvalidTargetUser
+            Instagram refused chaining for this target ("Not eligible
+            for chaining."). Common on locked-down / private accounts
+            and recently-flagged users.
+        """
+        params = {
+            "module": "profile",
+            "target_id": str(user_id),
+            "profile_chaining_check": "false",
+            "eligible_for_threads_cta": "false",
+        }
+        try:
+            return self.private_request("discover/chaining/", params=params)
+        except UnknownError as e:
+            if str(e) == "Not eligible for chaining.":
+                raise InvalidTargetUser("Not eligible for chaining.") from e
+            raise
+
+    def fetch_suggestion_details(self, user_id: str, chained_ids: str) -> dict:
+        """
+        Fetch expanded details for chained suggestion ids.
+
+        Companion to :meth:`chaining`. Pass a comma-separated list of
+        user pks (typically the ``pk`` field of every entry in
+        ``chaining()['users']``) and Instagram returns the same users
+        with social-context fields filled in (mutual followers,
+        verification, friendship state, etc.).
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk that produced the chained ids.
+        chained_ids: str
+            Comma-separated list of suggested user pks.
+
+        Returns
+        -------
+        dict
+            Raw ``discover/fetch_suggestion_details/`` response.
+        """
+        params = {
+            "target_id": str(user_id),
+            "chained_ids": chained_ids,
+            "include_social_context": "1",
+        }
+        return self.private_request(
+            "discover/fetch_suggestion_details/",
+            params=params,
+        )

--- a/tests.py
+++ b/tests.py
@@ -3133,6 +3133,71 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         params = private_request.call_args.kwargs["params"]
         self.assertNotIn("max_id", params)
 
+    def test_chaining_sends_expected_params_and_returns_payload(self):
+        client = Client()
+        expected = {"users": [{"pk": "9", "username": "suggested"}]}
+
+        with mock.patch.object(
+            client, "private_request", return_value=expected
+        ) as private_request:
+            result = client.chaining("123")
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "discover/chaining/",
+            params={
+                "module": "profile",
+                "target_id": "123",
+                "profile_chaining_check": "false",
+                "eligible_for_threads_cta": "false",
+            },
+        )
+
+    def test_chaining_promotes_not_eligible_unknown_error(self):
+        from instagrapi.exceptions import InvalidTargetUser
+
+        client = Client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            side_effect=UnknownError("Not eligible for chaining."),
+        ):
+            with self.assertRaises(InvalidTargetUser) as cm:
+                client.chaining("123")
+
+        self.assertIn("Not eligible for chaining.", str(cm.exception))
+
+    def test_chaining_reraises_other_unknown_errors(self):
+        client = Client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            side_effect=UnknownError("Some other failure"),
+        ):
+            with self.assertRaises(UnknownError):
+                client.chaining("123")
+
+    def test_fetch_suggestion_details_sends_expected_params(self):
+        client = Client()
+        expected = {"users": []}
+
+        with mock.patch.object(
+            client, "private_request", return_value=expected
+        ) as private_request:
+            result = client.fetch_suggestion_details("123", "9,10,11")
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "discover/fetch_suggestion_details/",
+            params={
+                "target_id": "123",
+                "chained_ids": "9,10,11",
+                "include_social_context": "1",
+            },
+        )
+
 
 class TimelineRegressionTestCase(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
## Summary

Two new \`discover/\` endpoints in \`UserMixin\` — a logged-in path to the "Suggested for you" carousel that doesn't depend on the gated public-graphql fallback chain.

### \`chaining(user_id) -> dict\`

Calls \`POST discover/chaining/\` — the same surface the official app uses to render the "Suggested for you" carousel under a profile. Returns the raw payload so the caller can decide what shape it wants (typically passed straight into \`fetch_suggestion_details\` for the expanded form).

\`UnknownError("Not eligible for chaining.")\` is promoted to \`InvalidTargetUser\` — common on locked-down / private / recently-flagged targets.

### \`fetch_suggestion_details(user_id, chained_ids) -> dict\`

Companion to \`chaining\`. Pass a comma-separated list of pks (typically from \`chaining()['users']\`) and IG returns the same users with social-context fields filled in (mutual followers, verification, friendship state, etc).

Ported from aiograpi [8193e3e](https://github.com/subzeroid/aiograpi/commit/8193e3e).

## Test plan

4 new cases in \`UserMixinRegressionTestCase\`:

- [x] \`test_chaining_sends_expected_params_and_returns_payload\` — verifies endpoint + module=profile, target_id, profile_chaining_check, eligible_for_threads_cta params + raw payload pass-through
- [x] \`test_chaining_promotes_not_eligible_unknown_error\` — \`UnknownError("Not eligible for chaining.")\` → \`InvalidTargetUser\`
- [x] \`test_chaining_reraises_other_unknown_errors\` — other \`UnknownError\` messages re-raised unchanged (regression check)
- [x] \`test_fetch_suggestion_details_sends_expected_params\` — verifies endpoint + target_id, chained_ids, include_social_context=1
- [x] All 12 \`UserMixinRegressionTestCase\` tests pass
- [x] flake8 + isort clean

## Documentation

\`docs/usage-guide/user.md\` — added 2 rows to the methods table for both new endpoints.

## Release plan

After merge: bump to \`2.5.4\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)