### PR TITLE
feat(fbsearch): add v2 SERP endpoints + flat typeahead

### DIFF
--- a/docs/usage-guide/search.md
+++ b/docs/usage-guide/search.md
@@ -1,0 +1,45 @@
+# Search
+
+Helpers for the Facebook Search (`fbsearch/`) surface — user search, blended top results, hashtag/place lookups, and typeahead suggestions.
+
+## v2 SERP endpoints
+
+The `*_v2` methods hit the same `fbsearch/<tab>_serp/` endpoints the official Instagram app uses to render the Search → Top / Accounts / Reels tabs. They return raw payloads so callers can drive their own pagination.
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `fbsearch_accounts_v2(query: str, page_token: str = None)` | `dict` | "Accounts" tab — `fbsearch/account_serp/`. Pagination via `next_page_token`. |
+| `fbsearch_reels_v2(query: str, reels_max_id: str = None, rank_token: str = None)` | `dict` | "Reels" tab — `fbsearch/reels_serp/`. |
+| `fbsearch_topsearch_v2(query: str, next_max_id: str = None, reels_max_id: str = None, rank_token: str = None)` | `dict` | Default "Top" blended tab — `fbsearch/top_serp/`. |
+| `fbsearch_typehead(query: str)` | `List[dict]` | Typeahead user suggestions, flattened from the `stream_rows` envelope returned by `fbsearch/typeahead_stream/`. |
+
+Example:
+
+```python
+# Top tab — first page
+top = cl.fbsearch_topsearch_v2("python")
+
+# Accounts — paginate
+page1 = cl.fbsearch_accounts_v2("python")
+page2 = cl.fbsearch_accounts_v2("python", page_token=page1["next_page_token"])
+
+# Reels — paginate
+page1 = cl.fbsearch_reels_v2("python")
+page2 = cl.fbsearch_reels_v2("python", reels_max_id=page1["reels_max_id"])
+
+# Typeahead — flat list of user dicts
+users = cl.fbsearch_typehead("py")
+```
+
+## Other search helpers
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `search_users(query: str)` | `List[UserShort]` | User search via `users/search/`. |
+| `search_hashtags(query: str)` | `List[Hashtag]` | Hashtag search via `tags/search/`. |
+| `search_music(query: str)` | `List[Track]` | Music/audio search via `music/audio_global_search/`. |
+| `fbsearch_topsearch_flat(query: str)` | `List[dict]` | Legacy flat top-search via `fbsearch/topsearch_flat/`. |
+| `fbsearch_suggested_profiles(user_id: str)` | `List[UserShort]` | Suggested profiles via `fbsearch/accounts_recs/`. |
+| `fbsearch_recent()` | `List[Tuple[int, ...]]` | Recently searched items. |
+
+For places, see [Location](location.md).

--- a/instagrapi/mixins/fbsearch.py
+++ b/instagrapi/mixins/fbsearch.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from instagrapi.extractors import (
     extract_hashtag_v1,
@@ -99,3 +99,147 @@ class FbSearchMixin:
             if "keyword" in item.keys():
                 data.append((item.get("client_time", None), item["keyword"]))
         return data
+
+    def fbsearch_accounts_v2(
+        self, query: str, page_token: Optional[str] = None
+    ) -> dict:
+        """
+        Search accounts via the v2 SERP endpoint.
+
+        ``GET /fbsearch/account_serp/`` — the surface IG's app uses for
+        the "Accounts" tab inside search. Returns the raw payload with
+        the full ``users`` list plus pagination cursor.
+
+        Parameters
+        ----------
+        query: str
+            Search query.
+        page_token: Optional[str], default None
+            Pagination cursor from a previous response.
+
+        Returns
+        -------
+        dict
+            Raw account-serp payload (``users``, ``has_more``,
+            ``next_page_token``, etc.).
+        """
+        params = {
+            "search_surface": "account_serp",
+            "timezone_offset": self.timezone_offset,
+            "query": query,
+        }
+        if page_token:
+            params["page_token"] = page_token
+        return self.private_request("fbsearch/account_serp/", params=params)
+
+    def fbsearch_reels_v2(
+        self,
+        query: str,
+        reels_max_id: Optional[str] = None,
+        rank_token: Optional[str] = None,
+    ) -> dict:
+        """
+        Search reels via the v2 SERP endpoint.
+
+        ``GET /fbsearch/reels_serp/`` — the surface IG's app uses for
+        the "Reels" tab inside search.
+
+        Parameters
+        ----------
+        query: str
+            Search query.
+        reels_max_id: Optional[str], default None
+            Pagination cursor for the next page of reels.
+        rank_token: Optional[str], default None
+            Optional client-side ranking token (forwarded to IG to
+            keep ordering stable across paginated calls).
+
+        Returns
+        -------
+        dict
+            Raw reels-serp payload.
+        """
+        params = {
+            "search_surface": "clips_search_page",
+            "timezone_offset": self.timezone_offset,
+            "query": query,
+        }
+        if reels_max_id:
+            params["reels_max_id"] = reels_max_id
+        if rank_token:
+            params["rank_token"] = rank_token
+        return self.private_request("fbsearch/reels_serp/", params=params)
+
+    def fbsearch_topsearch_v2(
+        self,
+        query: str,
+        next_max_id: Optional[str] = None,
+        reels_max_id: Optional[str] = None,
+        rank_token: Optional[str] = None,
+    ) -> dict:
+        """
+        Blended search (accounts + hashtags + media + reels) via the
+        v2 SERP endpoint.
+
+        ``GET /fbsearch/top_serp/`` — the surface IG's app uses for the
+        default "Top" tab inside search.
+
+        Parameters
+        ----------
+        query: str
+            Search query.
+        next_max_id: Optional[str], default None
+            Pagination cursor for the next page of results.
+        reels_max_id: Optional[str], default None
+            Pagination cursor for the embedded reels carousel.
+        rank_token: Optional[str], default None
+            Optional client-side ranking token. When provided overrides
+            the default ``self.rank_token``.
+
+        Returns
+        -------
+        dict
+            Raw top-serp payload.
+        """
+        params = {
+            "search_surface": "top_serp",
+            "timezone_offset": self.timezone_offset,
+            "query": query,
+            "rank_token": self.rank_token,
+        }
+        if next_max_id:
+            params["next_max_id"] = next_max_id
+        if rank_token:
+            params["rank_token"] = rank_token
+        if reels_max_id:
+            params["reels_max_id"] = reels_max_id
+        return self.private_request("fbsearch/top_serp/", params=params)
+
+    def fbsearch_typehead(self, query: str) -> List[dict]:
+        """
+        Typeahead user suggestions via the streaming endpoint.
+
+        ``GET /fbsearch/typeahead_stream/`` — convenience wrapper that
+        flattens the ``stream_rows`` envelope into a flat list of user
+        dicts (each row contains a list of users; rows are
+        concatenated).
+
+        Parameters
+        ----------
+        query: str
+            Partial query string.
+
+        Returns
+        -------
+        List[dict]
+            Flat list of suggested user dicts.
+        """
+        params = {
+            "search_surface": "typeahead_search_page",
+            "timezone_offset": self.timezone_offset,
+            "query": query,
+            "context": "blended",
+        }
+        res = self.private_request("fbsearch/typeahead_stream/", params=params)
+        rows = res.get("stream_rows", []) or []
+        return [user for row in rows for user in row.get("users", [])]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - Location: usage-guide/location.md
     - Media: usage-guide/media.md
     - Notes: usage-guide/notes.md
+    - Search: usage-guide/search.md
     - Story: usage-guide/story.md
     - Track: usage-guide/track.md
     - User: usage-guide/user.md

--- a/tests.py
+++ b/tests.py
@@ -486,6 +486,118 @@ class LocationMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(location.external_id, 108835465815492)
 
 
+class FbSearchRegressionTestCase(unittest.TestCase):
+    """Offline regression tests for FbSearchMixin v2 SERP endpoints
+    and the typeahead-stream flattener."""
+
+    def _build_client(self):
+        client = Client()
+        client.__dict__["timezone_offset"] = 10800
+        return client
+
+    def test_fbsearch_accounts_v2_omits_page_token_when_absent(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client, "private_request", return_value={"users": []}
+        ) as private_request:
+            client.fbsearch_accounts_v2("alice")
+
+        private_request.assert_called_once_with(
+            "fbsearch/account_serp/",
+            params={
+                "search_surface": "account_serp",
+                "timezone_offset": 10800,
+                "query": "alice",
+            },
+        )
+
+    def test_fbsearch_accounts_v2_forwards_page_token(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client, "private_request", return_value={"users": []}
+        ) as private_request:
+            client.fbsearch_accounts_v2("alice", page_token="abc==")
+
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(params["page_token"], "abc==")
+
+    def test_fbsearch_reels_v2_forwards_optional_cursors(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client, "private_request", return_value={}
+        ) as private_request:
+            client.fbsearch_reels_v2(
+                "dance", reels_max_id="next-page", rank_token="rt-x"
+            )
+
+        private_request.assert_called_once_with(
+            "fbsearch/reels_serp/",
+            params={
+                "search_surface": "clips_search_page",
+                "timezone_offset": 10800,
+                "query": "dance",
+                "reels_max_id": "next-page",
+                "rank_token": "rt-x",
+            },
+        )
+
+    def test_fbsearch_topsearch_v2_uses_self_rank_token_by_default(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client, "private_request", return_value={}
+        ) as private_request:
+            client.fbsearch_topsearch_v2("alice")
+
+        params = private_request.call_args.kwargs["params"]
+        # Default rank_token mirrors self.rank_token (computed from
+        # user_id + uuid). Just assert the wiring, not a specific value.
+        self.assertEqual(params["rank_token"], client.rank_token)
+        self.assertEqual(params["search_surface"], "top_serp")
+        self.assertNotIn("next_max_id", params)
+        self.assertNotIn("reels_max_id", params)
+
+    def test_fbsearch_topsearch_v2_explicit_rank_token_overrides_default(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client, "private_request", return_value={}
+        ) as private_request:
+            client.fbsearch_topsearch_v2(
+                "alice",
+                next_max_id="cursor-1",
+                reels_max_id="cursor-2",
+                rank_token="custom-rt",
+            )
+
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(params["rank_token"], "custom-rt")
+        self.assertEqual(params["next_max_id"], "cursor-1")
+        self.assertEqual(params["reels_max_id"], "cursor-2")
+
+    def test_fbsearch_typehead_flattens_stream_rows(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={
+                "stream_rows": [
+                    {"users": [{"pk": "1"}, {"pk": "2"}]},
+                    {"users": [{"pk": "3"}]},
+                    {"users": []},
+                ]
+            },
+        ):
+            users = client.fbsearch_typehead("ali")
+
+        self.assertEqual([u["pk"] for u in users], ["1", "2", "3"])
+
+    def test_fbsearch_typehead_handles_missing_stream_rows(self):
+        client = self._build_client()
+        with mock.patch.object(client, "private_request", return_value={}):
+            users = client.fbsearch_typehead("ali")
+
+        self.assertEqual(users, [])
+
+
 class HardeningRegressionTestCase(unittest.TestCase):
     """Hardening fixes for malformed / edge-case IG responses:
     extract_story_v1 fallbacks, _send_private_request 401/404 handling,


### PR DESCRIPTION
## Summary

Four search-surface endpoints under \`FbSearchMixin\`. All return raw payloads so callers drive their own pagination/extraction.

| Method | Endpoint | What |
|--------|----------|------|
| \`fbsearch_accounts_v2(query, page_token=None)\` | \`fbsearch/account_serp/\` | "Accounts" tab. Paginate via \`next_page_token\`. |
| \`fbsearch_reels_v2(query, reels_max_id=None, rank_token=None)\` | \`fbsearch/reels_serp/\` | "Reels" tab. |
| \`fbsearch_topsearch_v2(query, next_max_id=None, reels_max_id=None, rank_token=None)\` | \`fbsearch/top_serp/\` | Default "Top" blended tab. Defaults \`rank_token\` to \`self.rank_token\`; explicit arg overrides. |
| \`fbsearch_typehead(query)\` | \`fbsearch/typeahead_stream/\` | Convenience wrapper that flattens \`stream_rows\` into a flat list of suggested-user dicts. |

Ported from aiograpi [65fcb13](https://github.com/subzeroid/aiograpi/commit/65fcb13).

## Test plan

7 new cases in \`FbSearchRegressionTestCase\`:

- [x] \`accounts_v2\` omits \`page_token\` when absent
- [x] \`accounts_v2\` forwards \`page_token\` when provided
- [x] \`reels_v2\` forwards both optional cursors
- [x] \`topsearch_v2\` uses \`self.rank_token\` by default
- [x] \`topsearch_v2\` explicit \`rank_token\` overrides default
- [x] \`typehead\` flattens \`stream_rows\` (3 rows → flat list)
- [x] \`typehead\` returns \`[]\` when envelope omits \`stream_rows\` (regression guard)
- [x] flake8 + isort clean
- [x] \`mkdocs build --strict\` passes

## Documentation

- New \`docs/usage-guide/search.md\` page documenting both the new v2 SERP methods and the existing search helpers (\`search_users\`, \`search_hashtags\`, \`search_music\`, \`fbsearch_topsearch_flat\`, \`fbsearch_suggested_profiles\`, \`fbsearch_recent\`)
- mkdocs nav entry under "Usage Guide" → "Search"
- Cross-link to \`location.md\` for places search

## Release plan

After merge: bump to \`2.5.5\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)