### PR TITLE
feat(user): add user_stream_* + user_web_profile_info_v1

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -40,6 +40,16 @@ Lookup helpers:
 | user_short_gql(user_id: str, use_cache: bool = True) | UserShort      | Short user info with current GraphQL/web-profile fallback chain |
 | username_from_user_id_gql(user_id: str)       | str                   | Resolve username from user id using the same fallback chain  |
 
+Streamed profile fetch (raw payloads, app-side surface):
+
+| Method                                        | Return                | Description                                                  |
+|-----------------------------------------------|-----------------------|--------------------------------------------------------------|
+| user_stream_by_id_v1(user_id: str)            | dict                  | Streamed profile envelope by pk (`users/{user_id}/info_stream/`) |
+| user_stream_by_username_v1(username: str)     | dict                  | Streamed profile envelope by username (`users/{username}/usernameinfo_stream/`) |
+| user_stream_by_id_flat(user_id: str)          | dict                  | Same as `_v1` but `stream_rows[*].user` partials merged into a single dict |
+| user_stream_by_username_flat(username: str)   | dict                  | Same as `_v1` but `stream_rows[*].user` partials merged into a single dict |
+| user_web_profile_info_v1(username: str)       | dict                  | `users/web_profile_info/?username=...` via the private host (logged-in session, bypasses public-side rate limiting) |
+
 Low level methods:
 
 | Method                                                                              | Return                      | Description                                                                |

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1520,3 +1520,185 @@ class UserMixin:
             "discover/fetch_suggestion_details/",
             params=params,
         )
+
+    def user_stream_by_username_v1(self, username: str) -> dict:
+        """
+        Get the streamed profile envelope by username.
+
+        ``POST /users/{username}/usernameinfo_stream/`` — IG's app-side
+        surface for a profile fetch keyed by username. Returns the
+        streamed envelope (typically with ``stream_rows``).
+
+        Parameters
+        ----------
+        username: str
+            Target IG username.
+
+        Returns
+        -------
+        dict
+            Parsed JSON response.
+
+        Raises
+        ------
+        UserNotFound
+            On 404 / unknown ClientError.
+        """
+        username = str(username).lower()
+        data = {
+            "is_prefetch": False,
+            "entry_point": "profile",
+            "from_module": "feed_timeline",
+        }
+        try:
+            return self.private_request(
+                f"users/{username}/usernameinfo_stream/", data=data
+            )
+        except ClientNotFoundError as e:
+            raise UserNotFound(e, username=username, **self.last_json)
+        except ClientError as e:
+            raise UserNotFound(e, username=username, **self.last_json)
+
+    def user_stream_by_id_v1(self, user_id: str) -> dict:
+        """
+        Get the streamed profile envelope by pk (mirror of
+        :meth:`user_stream_by_username_v1`).
+
+        ``POST /users/{user_id}/info_stream/`` — IG's app-side surface
+        for a profile fetch initiated from within the feed-timeline
+        flow. Returns the same streamed envelope as the username
+        variant.
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk.
+
+        Returns
+        -------
+        dict
+            Parsed JSON response (typically with ``stream_rows``).
+
+        Raises
+        ------
+        UserNotFound
+            On 404 / unknown ClientError.
+        """
+        data = {
+            "is_prefetch": False,
+            "entry_point": "profile",
+            "from_module": "feed_timeline",
+        }
+        try:
+            return self.private_request(f"users/{user_id}/info_stream/", data=data)
+        except (ClientNotFoundError, ClientError) as e:
+            logger.exception(
+                "Client error user_stream_by_id_v1, exception: %r, user_id %r",
+                e,
+                user_id,
+            )
+            raise UserNotFound("User not found")
+
+    def _user_stream_collector(self, resp, id=None, username=None):
+        """
+        Collapse a ``stream_rows`` envelope into a single flat user dict.
+
+        Each row in ``stream_rows`` carries a partial ``user`` payload;
+        this merges them in order so later rows override earlier ones.
+        Falls back to one extra fetch if the first response was empty
+        (defensive behaviour matching observed IG quirks).
+        """
+        data = {}
+        for urow in resp.get("stream_rows", []):
+            data.update(urow.get("user", {}))
+        if data:
+            data["pk"] = data.get("pk", data.get("pk_id"))
+            return data
+        logger.error("user_stream_collector: empty stream_rows, falling back: %r", resp)
+        if username:
+            self.user_stream_by_username_v1(username)
+        elif id:
+            self.user_stream_by_id_v1(id)
+        else:
+            raise UserNotFound(code_error=1257)
+        return self.last_json
+
+    def user_stream_by_id_flat(self, user_id: str) -> dict:
+        """
+        Flatten the streamed profile envelope for a target user pk
+        into a single user dict.
+
+        Convenience wrapper: calls :meth:`user_stream_by_id_v1` and
+        merges all ``stream_rows[*].user`` partial payloads in order.
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk.
+
+        Returns
+        -------
+        dict
+            Merged user dict (with ``pk`` resolved from ``pk`` or
+            ``pk_id`` whichever IG provided).
+        """
+        resp = self.user_stream_by_id_v1(user_id)
+        return self._user_stream_collector(resp, id=user_id)
+
+    def user_stream_by_username_flat(self, username: str) -> dict:
+        """
+        Flatten the streamed profile envelope for a target username
+        into a single user dict.
+
+        Convenience wrapper: calls :meth:`user_stream_by_username_v1`
+        and merges all ``stream_rows[*].user`` partial payloads in
+        order.
+
+        Parameters
+        ----------
+        username: str
+            Target IG username.
+
+        Returns
+        -------
+        dict
+            Merged user dict.
+        """
+        resp = self.user_stream_by_username_v1(username)
+        return self._user_stream_collector(resp, username=username)
+
+    def user_web_profile_info_v1(self, username: str) -> dict:
+        """
+        Web-scraper-style profile fetch via the private API.
+
+        ``GET /users/web_profile_info/?username={username}`` — the same
+        payload shape as the public ``api/v1/users/web_profile_info/``
+        endpoint, but routed through the private host so it can carry
+        a logged-in session and bypass some of the public-side rate
+        limiting. Returns the inner ``data`` block (already unwrapped).
+
+        Parameters
+        ----------
+        username: str
+            Target IG username.
+
+        Returns
+        -------
+        dict
+            The user payload (from ``response['data']``).
+
+        Raises
+        ------
+        UserNotFound
+            ``data`` is missing from the response or the request 404'd.
+        """
+        try:
+            result = self.private_request(
+                "users/web_profile_info/",
+                params={"username": username},
+            )
+        except (ClientNotFoundError, ClientError) as e:
+            raise UserNotFound(e, username=username, **self.last_json)
+        if data := result.get("data", {}):
+            return data
+        raise UserNotFound("Username not found", username=username, **self.last_json)

--- a/tests.py
+++ b/tests.py
@@ -3310,6 +3310,97 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             },
         )
 
+    def test_user_stream_by_id_v1_sends_expected_endpoint_and_data(self):
+        client = Client()
+        with mock.patch.object(
+            client, "private_request", return_value={"stream_rows": []}
+        ) as private_request:
+            client.user_stream_by_id_v1("123")
+
+        private_request.assert_called_once_with(
+            "users/123/info_stream/",
+            data={
+                "is_prefetch": False,
+                "entry_point": "profile",
+                "from_module": "feed_timeline",
+            },
+        )
+
+    def test_user_stream_by_id_v1_promotes_not_found_to_user_not_found(self):
+        from instagrapi.exceptions import ClientNotFoundError, UserNotFound
+
+        client = Client()
+        client.last_json = {}
+        with mock.patch.object(
+            client,
+            "private_request",
+            side_effect=ClientNotFoundError("404", response=Mock(status_code=404)),
+        ):
+            with self.assertRaises(UserNotFound):
+                client.user_stream_by_id_v1("123")
+
+    def test_user_stream_by_username_v1_sends_expected_endpoint(self):
+        client = Client()
+        with mock.patch.object(
+            client, "private_request", return_value={"stream_rows": []}
+        ) as private_request:
+            client.user_stream_by_username_v1("Example")
+
+        endpoint = private_request.call_args.args[0]
+        self.assertEqual(endpoint, "users/example/usernameinfo_stream/")
+
+    def test_user_stream_by_id_flat_merges_rows_and_promotes_pk_id(self):
+        client = Client()
+        envelope = {
+            "stream_rows": [
+                {"user": {"pk_id": "9", "username": "alice", "is_private": False}},
+                {"user": {"full_name": "Alice Example"}},
+                {"user": {"username": "alice2"}},
+            ]
+        }
+        with mock.patch.object(client, "user_stream_by_id_v1", return_value=envelope):
+            user = client.user_stream_by_id_flat("9")
+
+        self.assertEqual(user["username"], "alice2")
+        self.assertEqual(user["full_name"], "Alice Example")
+        self.assertEqual(user["pk"], "9")
+        self.assertEqual(user["pk_id"], "9")
+
+    def test_user_stream_by_username_flat_falls_back_when_empty(self):
+        client = Client()
+        client.last_json = {"sentinel": True}
+        with mock.patch.object(
+            client, "user_stream_by_username_v1", return_value={"stream_rows": []}
+        ) as stream_call:
+            result = client.user_stream_by_username_flat("alice")
+
+        # First call from _flat → empty → collector triggers second.
+        self.assertEqual(stream_call.call_count, 2)
+        self.assertEqual(result, {"sentinel": True})
+
+    def test_user_web_profile_info_v1_unwraps_data(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"data": {"pk": "9", "username": "alice"}},
+        ) as private_request:
+            user = client.user_web_profile_info_v1("alice")
+
+        private_request.assert_called_once_with(
+            "users/web_profile_info/", params={"username": "alice"}
+        )
+        self.assertEqual(user, {"pk": "9", "username": "alice"})
+
+    def test_user_web_profile_info_v1_raises_user_not_found_on_empty_data(self):
+        from instagrapi.exceptions import UserNotFound
+
+        client = Client()
+        client.last_json = {}
+        with mock.patch.object(client, "private_request", return_value={"data": {}}):
+            with self.assertRaises(UserNotFound):
+                client.user_web_profile_info_v1("missing")
+
 
 class TimelineRegressionTestCase(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
## Summary

Six methods + one helper for fetching profile data via the streamed profile envelope and the private-host \`web_profile_info\` endpoint.

| Method | Endpoint | Description |
|--------|----------|-------------|
| \`user_stream_by_username_v1(username)\` | \`POST users/{username}/usernameinfo_stream/\` | Streamed profile envelope by username. |
| \`user_stream_by_id_v1(user_id)\` | \`POST users/{user_id}/info_stream/\` | Mirror, keyed by pk. |
| \`user_stream_by_id_flat(user_id)\` | calls \`_v1\` + helper | Merges \`stream_rows[*].user\` partials → single dict. |
| \`user_stream_by_username_flat(username)\` | calls \`_v1\` + helper | Same, username-keyed. |
| \`user_web_profile_info_v1(username)\` | \`GET users/web_profile_info/?username=...\` | Private-host variant — carries logged-in session, bypasses public-side rate limiting. Returns \`data\` already unwrapped. |

Plus internal \`_user_stream_collector\` helper: merges in order (later rows override earlier), promotes \`pk_id → pk\` when \`pk\` is absent, falls back to one extra fetch + \`last_json\` if rows empty.

Ported from aiograpi [288ace6](https://github.com/subzeroid/aiograpi/commit/288ace6).

## Test plan

7 new cases in \`UserMixinRegressionTestCase\`:

- [x] \`user_stream_by_id_v1\` endpoint URL + data payload shape
- [x] \`user_stream_by_id_v1\` \`ClientNotFoundError\` → \`UserNotFound\`
- [x] \`user_stream_by_username_v1\` lowercases username + endpoint URL
- [x] \`user_stream_by_id_flat\` merges 3 rows (later wins) + promotes \`pk_id → pk\`
- [x] \`user_stream_by_username_flat\` empty-rows triggers second call + returns \`last_json\`
- [x] \`user_web_profile_info_v1\` unwraps \`data\` block + endpoint shape
- [x] \`user_web_profile_info_v1\` empty \`data\` → \`UserNotFound\`
- [x] All 19 \`UserMixinRegressionTestCase\` tests pass
- [x] flake8 + isort clean
- [x] \`mkdocs build --strict\` passes

## Documentation

\`docs/usage-guide/user.md\` — new "Streamed profile fetch" table with all five public methods.

## Release plan

After merge: bump to \`2.5.6\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)