### PR TITLE
feat(user): add discover_recommended_accounts + user_related_profiles_gql

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -20,6 +20,7 @@
 | ClientUnknownError        | ClientError | Occurs when Instagram returns an unknown error
 | WrongCursorError          | ClientError | Occurs when the cursor for pagination is passed in the wrong format
 | ClientStatusFail          | ClientError | Occurs when Instagram returns message with status=fail with details
+| RelatedProfileRequired    | ClientError | Raised by `user_related_profiles_gql` on empty results when caller has set `client.num_retry < 4` (opt-in retry signal)
 
 ## Proxy Exceptions
 

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -32,6 +32,8 @@ View a list of a user's medias, following and followers
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
 | chaining(user_id: str)                        | dict                  | Suggested users for a profile (`discover/chaining/`) — same surface as the app's "Suggested for you" carousel |
 | fetch_suggestion_details(user_id: str, chained_ids: str) | dict       | Expanded social-context fields for chained suggestion ids (`discover/fetch_suggestion_details/`) |
+| discover_recommended_accounts_for_category_v1(user_id: str) | dict | Business-category-similar accounts: extracts `category_id` from the target's stream payload, then calls `discover/recommended_accounts_for_category/` |
+| user_related_profiles_gql(user_id: str)       | List[UserShort]       | Related profiles via public GraphQL `edge_chaining` (legacy `query_hash`, gated by IG — prefer `chaining` for reliability) |
 
 Lookup helpers:
 

--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -349,9 +349,24 @@ class AgeEligibilityError(ClientError):
 
 class CaptchaChallengeRequired(ClientError):
     """Captcha challenge required, and no solver is configured or available."""
-    def __init__(self, message="Captcha challenge required, but no solver configured or available.", challenge_details=None, **kwargs):
+
+    def __init__(
+        self,
+        message="Captcha challenge required, but no solver configured or available.",
+        challenge_details=None,
+        **kwargs,
+    ):
         self.challenge_details = challenge_details if challenge_details else {}
         # Example of extracting common details:
         # self.site_key = self.challenge_details.get('site_key')
         # self.challenge_url = self.challenge_details.get('challenge_url') # URL where captcha is presented
         super().__init__(message, **kwargs)
+
+
+class RelatedProfileRequired(ClientError):
+    """Raised by user_related_profiles_gql when IG returns no related
+    profiles. Used as a retry signal — the method raises it only if
+    the caller has opted in by setting ``client.num_retry`` below 4;
+    otherwise it returns an empty list."""
+
+    pass

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -13,6 +13,7 @@ from instagrapi.exceptions import (
     ClientLoginRequired,
     ClientNotFoundError,
     InvalidTargetUser,
+    RelatedProfileRequired,
     UnknownError,
     UserNotFound,
 )
@@ -1702,3 +1703,91 @@ class UserMixin:
         if data := result.get("data", {}):
             return data
         raise UserNotFound("Username not found", username=username, **self.last_json)
+
+    def discover_recommended_accounts_for_category_v1(self, user_id: str) -> dict:
+        """
+        Get business-category-similar accounts for a target user.
+
+        Two-step call:
+
+        1. Fetch the target's profile via :meth:`user_stream_by_id_v1`
+           to extract ``category_id`` from the streamed payload.
+        2. Hit ``GET /discover/recommended_accounts_for_category/``
+           with that ``category_id`` to get IG's "similar businesses"
+           recommendations for that category.
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk.
+
+        Returns
+        -------
+        dict
+            Raw recommended-accounts payload. ``category_id`` will be
+            ``None`` if the target has no business category — IG
+            still returns a payload (typically with empty ``users``)
+            in that case.
+        """
+        user_info = self.user_stream_by_id_v1(user_id)
+        category_id = next(
+            (
+                cid
+                for row in user_info.get("stream_rows", [])
+                if (cid := row.get("user", {}).get("category_id")) is not None
+            ),
+            None,
+        )
+        return self.private_request(
+            "discover/recommended_accounts_for_category/",
+            params={"target_id": user_id, "category_id": category_id},
+        )
+
+    def user_related_profiles_gql(self, user_id: str) -> List[UserShort]:
+        """
+        Get related profiles for a target user via the public GraphQL
+        ``edge_chaining`` field.
+
+        Hits the legacy ``query_hash="ad99dd9d3646cc3c0dda65debcd266a7"``
+        — IG has been gating this query_hash more aggressively over
+        time; it may raise ``ClientGraphqlError`` on logged-out or
+        rate-limited callers. For a more reliable mobile-app-style
+        suggestion list, use :meth:`chaining` (private API).
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk.
+
+        Returns
+        -------
+        List[UserShort]
+            Related profiles. Empty list if IG returned no edges.
+
+        Raises
+        ------
+        UserNotFound
+            GraphQL response had no ``user`` block.
+        RelatedProfileRequired
+            Empty result and the caller had ``self.num_retry`` set
+            below 4 (opt-in retry signal — set ``client.num_retry``
+            yourself to enable).
+        """
+        variables = {
+            "user_id": str(user_id),
+            "include_chaining": True,
+        }
+        data = self.public_graphql_request(
+            variables, query_hash="ad99dd9d3646cc3c0dda65debcd266a7"
+        )
+        if not data.get("user"):
+            raise UserNotFound("User not found")
+        edges = json_value(data, "user", "edge_chaining", "edges", default=[])
+        res = [extract_user_short(e["node"]) for e in edges if "node" in e]
+        if (
+            not res
+            and getattr(self, "num_retry", None) is not None
+            and self.num_retry < 4
+        ):
+            raise RelatedProfileRequired
+        return res

--- a/tests.py
+++ b/tests.py
@@ -3401,6 +3401,118 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             with self.assertRaises(UserNotFound):
                 client.user_web_profile_info_v1("missing")
 
+    def test_discover_recommended_accounts_extracts_category_id_from_stream(self):
+        client = Client()
+        stream_resp = {
+            "stream_rows": [
+                {"user": {"username": "alice"}},
+                {"user": {"category_id": 42, "is_business": True}},
+            ]
+        }
+
+        with mock.patch.object(
+            client, "user_stream_by_id_v1", return_value=stream_resp
+        ) as stream:
+            with mock.patch.object(
+                client, "private_request", return_value={"users": []}
+            ) as private_request:
+                client.discover_recommended_accounts_for_category_v1("9")
+
+        stream.assert_called_once_with("9")
+        private_request.assert_called_once_with(
+            "discover/recommended_accounts_for_category/",
+            params={"target_id": "9", "category_id": 42},
+        )
+
+    def test_discover_recommended_accounts_falls_through_with_none_category(self):
+        client = Client()
+        stream_resp = {
+            "stream_rows": [
+                {"user": {"username": "alice"}},
+                {"user": {"is_private": False}},
+            ]
+        }
+
+        with mock.patch.object(
+            client, "user_stream_by_id_v1", return_value=stream_resp
+        ):
+            with mock.patch.object(
+                client, "private_request", return_value={"users": []}
+            ) as private_request:
+                client.discover_recommended_accounts_for_category_v1("9")
+
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(params["target_id"], "9")
+        self.assertIsNone(params["category_id"])
+
+    def test_user_related_profiles_gql_extracts_edge_chaining_nodes(self):
+        client = Client()
+        gql_resp = {
+            "user": {
+                "edge_chaining": {
+                    "edges": [
+                        {
+                            "node": {
+                                "pk": "1",
+                                "username": "alice",
+                                "profile_pic_url": "https://example.com/a.jpg",
+                                "is_private": False,
+                            }
+                        },
+                        {
+                            "node": {
+                                "pk": "2",
+                                "username": "bob",
+                                "profile_pic_url": "https://example.com/b.jpg",
+                                "is_private": False,
+                            }
+                        },
+                    ]
+                }
+            }
+        }
+
+        with mock.patch.object(client, "public_graphql_request", return_value=gql_resp):
+            users = client.user_related_profiles_gql("9")
+
+        self.assertEqual(len(users), 2)
+        self.assertEqual([u.username for u in users], ["alice", "bob"])
+
+    def test_user_related_profiles_gql_raises_user_not_found_on_empty_response(self):
+        from instagrapi.exceptions import UserNotFound
+
+        client = Client()
+        with mock.patch.object(
+            client, "public_graphql_request", return_value={"user": None}
+        ):
+            with self.assertRaises(UserNotFound):
+                client.user_related_profiles_gql("9")
+
+    def test_user_related_profiles_gql_returns_empty_list_when_no_edges(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            return_value={"user": {"edge_chaining": {"edges": []}}},
+        ):
+            users = client.user_related_profiles_gql("9")
+
+        self.assertEqual(users, [])
+
+    def test_user_related_profiles_gql_raises_when_num_retry_under_threshold(self):
+        from instagrapi.exceptions import RelatedProfileRequired
+
+        client = Client()
+        # Opt into retry semantics by setting num_retry < 4.
+        client.num_retry = 0
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            return_value={"user": {"edge_chaining": {"edges": []}}},
+        ):
+            with self.assertRaises(RelatedProfileRequired):
+                client.user_related_profiles_gql("9")
+
 
 class TimelineRegressionTestCase(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
## Summary

Two recommendation / discovery endpoints under \`UserMixin\` and a new \`RelatedProfileRequired\` exception class.

| Method | What |
|--------|------|
| \`discover_recommended_accounts_for_category_v1(user_id)\` | Two-step: \`user_stream_by_id_v1\` → extract \`category_id\` → \`GET discover/recommended_accounts_for_category/\`. \`category_id\` falls through as \`None\` if the target has no business category. |
| \`user_related_profiles_gql(user_id)\` | Public GraphQL via legacy \`query_hash=ad99dd9d3646cc3c0dda65debcd266a7\` + \`edge_chaining\`. Returns \`List[UserShort]\`. IG has been gating this query_hash more aggressively — prefer \`chaining()\` (private API) for reliability. |

### New exception: \`RelatedProfileRequired\`

A `ClientError` subclass. Raised by \`user_related_profiles_gql\` as a retry signal when \`edge_chaining\` returns empty **and** the caller has opted in by setting \`client.num_retry < 4\`. Otherwise the method returns an empty list. Documented in \`docs/exceptions.md\`.

Ported from aiograpi [54e9750](https://github.com/subzeroid/aiograpi/commit/54e9750).

## Test plan

6 new cases in \`UserMixinRegressionTestCase\`:

- [x] \`discover_recommended_accounts\` extracts \`category_id\` from stream rows + propagates \`target_id\` + \`category_id\`
- [x] missing \`category_id\` falls through as \`None\`
- [x] \`user_related_profiles_gql\` extracts \`edge_chaining\` nodes → \`List[UserShort]\`
- [x] \`user\` missing → \`UserNotFound\`
- [x] empty edges + no \`num_retry\` → return \`[]\`
- [x] empty edges + \`num_retry=0\` → raise \`RelatedProfileRequired\`
- [x] All 25 \`UserMixinRegressionTestCase\` tests pass
- [x] flake8 + isort clean
- [x] \`mkdocs build --strict\` passes

## Documentation

- \`docs/usage-guide/user.md\` — two new rows in the main methods table
- \`docs/exceptions.md\` — new \`RelatedProfileRequired\` row

## Release plan

After merge: bump to \`2.5.7\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)