### PR TITLE
feat(public,track): add public_head + track_stream_info_by_id

### DIFF
--- a/docs/usage-guide/track.md
+++ b/docs/usage-guide/track.md
@@ -6,6 +6,7 @@ Viewing and downloading tracks
 | --- | --- | --- |
 | track_info_by_canonical_id(music_canonical_id: str) | Track | Get track by `music_canonical_id` |
 | track_info_by_id(track_id: str, max_id: str = "") | dict | Get raw track payload by internal Instagram track ID |
+| track_stream_info_by_id(track_id: str, max_id: str = "") | dict | Streamed clips-pivot page (`clips/stream_clips_pivot_page/`) — clips using this audio + audio-asset metadata, the surface IG's app uses to render the "Audio" page |
 | track_download_by_url(url: str, filename: str = "", folder: Path = "") | Path | Download track by URL |
 | search_music(query: str) | List[Track] | Search music and return track objects |
 

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -119,6 +119,38 @@ class PublicRequestMixin:
         self.public.mount("https://", adapter)
         self.public.mount("http://", adapter)
 
+    def public_head(self, url: str, follow_redirects: bool = False):
+        """
+        Issue a ``HEAD`` request through the public session — useful
+        for resolving short-link redirects without downloading the
+        body (e.g. ``instagram.com/share/...`` link expansion).
+
+        Bypasses :meth:`public_request`'s GET/POST machinery so the
+        per-call ``follow_redirects`` flag actually takes effect.
+
+        Parameters
+        ----------
+        url: str
+            Absolute URL.
+        follow_redirects: bool, default False
+            Whether to follow 3xx responses. Default ``False`` means
+            callers can read ``response.headers["location"]`` to
+            inspect the redirect target without actually fetching it.
+
+        Returns
+        -------
+        requests.Response
+            The raw response. Status code typically 200 / 301 / 302 /
+            307 / 308.
+        """
+        self.public_requests_count += 1
+        return self.public.head(
+            url,
+            allow_redirects=follow_redirects,
+            proxies=self.public.proxies,
+            timeout=self.request_timeout,
+        )
+
     def public_request(
         self,
         url,

--- a/instagrapi/mixins/track.py
+++ b/instagrapi/mixins/track.py
@@ -45,9 +45,9 @@ class TrackMixin:
             shutil.copyfileobj(response.raw, f)
         return path.resolve()
 
-    def _track_request(self, data: Dict[str, Any]) -> Dict:
+    def _track_request(self, data: Dict[str, Any], path: str = "clips/music/") -> Dict:
         try:
-            result = self.private_request("clips/music/", data)
+            result = self.private_request(path, data)
         except ClientError as e:
             if not self.last_json:
                 kw = {
@@ -104,3 +104,39 @@ class TrackMixin:
         if max_id:
             data["max_id"] = max_id
         return self._track_request(data)
+
+    def track_stream_info_by_id(self, track_id: str, max_id: str = "") -> Dict:
+        """
+        Fetch the streamed clips-pivot page for a given track id.
+
+        ``POST /clips/stream_clips_pivot_page/`` — the surface IG's app
+        uses to render the "Audio" page (clips that use this audio +
+        the audio-asset metadata). Returns the raw payload so the
+        caller can extract whatever they need (clip list, audio
+        cluster info, etc.).
+
+        Parameters
+        ----------
+        track_id: str
+            Track identifier (used as both ``audio_asset_id`` and
+            ``audio_cluster_id`` per IG's app behavior).
+        max_id: str, default ""
+            Pagination cursor for the next page of clips.
+
+        Returns
+        -------
+        Dict
+            Raw response.
+        """
+        data = {
+            "pivot_page_type": "audio",
+            "music_page": {
+                "tab_type": "clips",
+                "audio_asset_id": track_id,
+                "audio_cluster_id": track_id,
+            },
+            "_uuid": self.uuid,
+        }
+        if max_id:
+            data["music_page"]["max_id"] = max_id
+        return self._track_request(data, path="clips/stream_clips_pivot_page/")

--- a/tests.py
+++ b/tests.py
@@ -371,6 +371,58 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertIs(result, expected)
         fallback.assert_called_once_with("2110901750722920960")
 
+    def test_public_head_defaults_to_no_redirect_follow(self):
+        client = Client()
+        before = client.public_requests_count
+        response = Mock(status_code=302, headers={"location": "https://target/"})
+
+        with mock.patch.object(client.public, "head", return_value=response) as head:
+            result = client.public_head("https://instagram.com/share/abc")
+
+        self.assertIs(result, response)
+        self.assertEqual(client.public_requests_count, before + 1)
+        head.assert_called_once()
+        kwargs = head.call_args.kwargs
+        self.assertFalse(kwargs["allow_redirects"])
+
+    def test_public_head_follow_redirects_override(self):
+        client = Client()
+        response = Mock(status_code=200)
+
+        with mock.patch.object(client.public, "head", return_value=response) as head:
+            client.public_head("https://instagram.com/share/abc", follow_redirects=True)
+
+        kwargs = head.call_args.kwargs
+        self.assertTrue(kwargs["allow_redirects"])
+
+
+class TrackMixinRegressionTestCase(unittest.TestCase):
+    def test_track_stream_info_by_id_sends_expected_endpoint_and_payload(self):
+        client = Client()
+        with mock.patch.object(
+            client, "private_request", return_value={}
+        ) as private_request:
+            client.track_stream_info_by_id("18000000000000000")
+
+        private_request.assert_called_once()
+        path, data = private_request.call_args.args
+        self.assertEqual(path, "clips/stream_clips_pivot_page/")
+        self.assertEqual(data["pivot_page_type"], "audio")
+        self.assertEqual(data["music_page"]["tab_type"], "clips")
+        self.assertEqual(data["music_page"]["audio_asset_id"], "18000000000000000")
+        self.assertEqual(data["music_page"]["audio_cluster_id"], "18000000000000000")
+        self.assertNotIn("max_id", data["music_page"])
+
+    def test_track_stream_info_by_id_forwards_max_id(self):
+        client = Client()
+        with mock.patch.object(
+            client, "private_request", return_value={}
+        ) as private_request:
+            client.track_stream_info_by_id("18000000000000000", max_id="next-page")
+
+        _, data = private_request.call_args.args
+        self.assertEqual(data["music_page"]["max_id"], "next-page")
+
 
 class NoteMixinRegressionTestCase(unittest.TestCase):
     def test_get_note_helpers_by_user(self):


### PR DESCRIPTION
## Summary

Two utility endpoints.

### \`public_head(url, follow_redirects=False)\` — \`PublicRequestMixin\`

\`HEAD\` request through the public session. Useful for resolving \`instagram.com/share/...\` short-link redirects without downloading the body. Bypasses \`public_request\`'s GET/POST machinery and goes through \`self.public.head\` directly, so the per-call \`follow_redirects\` flag actually takes effect (\`requests.Session.head\` exposes \`allow_redirects\`). Increments \`public_requests_count\`.

### \`track_stream_info_by_id(track_id, max_id="")\` — \`TrackMixin\`

\`POST clips/stream_clips_pivot_page/\` — the surface IG's app uses to render the "Audio" page (clips using this audio + audio-asset metadata). Returns the raw payload.

### Supporting change

\`_track_request\` now accepts a \`path=\` kwarg (default \`"clips/music/"\`, existing callers unaffected). \`track_stream_info_by_id\` passes \`path="clips/stream_clips_pivot_page/"\`.

Ported from aiograpi [5950a63](https://github.com/subzeroid/aiograpi/commit/5950a63). The \`httpx_ext.request\` plumbing in that commit isn't relevant here — instagrapi uses \`requests\` directly, which already exposes \`allow_redirects\` on the session.

## Test plan

4 new cases:

- [x] \`public_head\` defaults to \`allow_redirects=False\`, increments request counter
- [x] \`public_head\` with \`follow_redirects=True\` override
- [x] \`track_stream_info_by_id\` endpoint + nested \`music_page\` payload shape (\`pivot_page_type\`, \`tab_type\`, \`audio_asset_id\`, \`audio_cluster_id\`)
- [x] \`track_stream_info_by_id\` forwards \`max_id\` into nested \`music_page\`
- [x] All 6 \`PublicRegressionTestCase\` + 2 \`TrackMixinRegressionTestCase\` tests pass
- [x] flake8 + isort clean
- [x] \`mkdocs build --strict\` passes

## Documentation

\`docs/usage-guide/track.md\` — new row for \`track_stream_info_by_id\`.
\`public_head\` is a low-level helper (alongside \`public_request\`, which is also docstring-only) — covered via inline docstring.

## Release plan

After merge: bump to \`2.5.8\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)