### PR TITLE
feat(media,comment): add media_info_v2 + media_check_offensive_comment_v2

### DIFF
--- a/docs/usage-guide/comment.md
+++ b/docs/usage-guide/comment.md
@@ -8,6 +8,7 @@ Post comment, viewing, like and unlike comments
 | media_comments(media_id: str, amount: int = 20) | List\[Comment] | Get comments for media; pass `amount=0` to keep paginating until exhaustion |
 | media_comments_chunk(media_id: str, max_amount: int, min_id: str = None) | Tuple[List\[Comment], str] | Get a paginated chunk of comments and the next `min_id` cursor |
 | media_check_offensive_comment(media_id: str, text: str) | bool | Ask Instagram whether a comment text is considered offensive |
+| media_check_offensive_comment_v2(media_id: str, comment: str) | dict | Lighter variant of `media_check_offensive_comment` — same endpoint without `with_action_data` wrapping; returns the raw payload so callers can inspect category / confidence flags beyond `is_offensive` |
 | comment_like(comment_pk: int, revert: bool = False) | bool | Like a comment |
 | comment_unlike(comment_pk: int) | bool | Unlike a comment |
 | comment_pin(media_id: str, comment_pk: int, revert: bool = False) | bool | Pin a comment on your media |

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -59,6 +59,7 @@ Low level methods:
 | media_info_a1(media_pk: str, max_id: str = None) | Media | Get media from PK via public web API |
 | media_info_gql(media_pk: str) | Media | Get media from PK via public GraphQL API |
 | media_info_v1(media_pk: str) | Media | Get media from PK via private mobile API |
+| media_info_v2(media_id: str) | Media | Alternative source for media info via `discover/media_metadata/` (`media_or_ad` payload). Useful as fallback when `media_info_v1` fails on certain ad-tagged or sponsored media. Strips `_userid` suffix automatically. |
 | user_medias_gql(user_id: str, amount: int = 0, sleep: int = 0) | List\[Media] | Get user media via public GraphQL API |
 | user_medias_paginated_gql(user_id: str, amount: int = 0, sleep: int = 2, end_cursor=None) | Tuple[List\[Media], str] | Get one public GraphQL page of user media |
 | user_medias_v1(user_id: str, amount: int = 0) | List\[Media] | Get user media via private mobile API |

--- a/instagrapi/mixins/comment.py
+++ b/instagrapi/mixins/comment.py
@@ -181,6 +181,39 @@ class CommentMixin:
         )
         return result["is_offensive"]
 
+    def media_check_offensive_comment_v2(self, media_id: str, comment: str) -> dict:
+        """
+        Lighter-weight variant of :meth:`media_check_offensive_comment`
+        — returns the full IG payload instead of just the boolean.
+
+        Same endpoint (``POST /media/comment/check_offensive_comment/``)
+        but skips the ``with_action_data`` wrapping (no ``_csrftoken`` /
+        ``_uid`` / breadcrumb) and just sends
+        ``{comment_text, media_id, _uuid}`` directly. Closer to what
+        the IG app posts in practice. Returns the raw response so
+        callers can inspect any flags IG ships beyond ``is_offensive``
+        (e.g. category / confidence in newer payloads).
+
+        Parameters
+        ----------
+        media_id: str
+            Unique identifier of a Media.
+        comment: str
+            String to check.
+
+        Returns
+        -------
+        dict
+            Raw response payload.
+        """
+        assert self.user_id, "Login required"
+        data = {
+            "comment_text": comment,
+            "media_id": media_id,
+            "_uuid": self.uuid,
+        }
+        return self.private_request("media/comment/check_offensive_comment/", data=data)
+
     def comment_like(self, comment_pk: int, revert: bool = False) -> bool:
         """
         Like a comment on a media

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -289,6 +289,41 @@ class MediaMixin:
             raise e
         return extract_media_v1(result["items"].pop())
 
+    def media_info_v2(self, media_id: str) -> Media:
+        """
+        Get media via the discover-style metadata endpoint.
+
+        ``GET /discover/media_metadata/?media_id={pk}`` — alternative
+        source for media info that returns a ``media_or_ad`` payload.
+        Useful as a fallback when ``media_info_v1`` fails on certain
+        ad-tagged or sponsored media. Unlike ``media_info_v1``, this
+        endpoint expects only the numeric pk (the ``_userid`` suffix
+        is stripped automatically if you pass a full media_id).
+
+        Parameters
+        ----------
+        media_id: str
+            Media pk or full media_id (``pk_userid``).
+
+        Returns
+        -------
+        Media
+            Extracted via :func:`extract_media_v1`.
+
+        Raises
+        ------
+        MediaNotFound
+            ``media_or_ad`` was missing from the response.
+        """
+        media_id = str(media_id).split("_")[0]
+        result = self.private_request(
+            "discover/media_metadata/", params={"media_id": media_id}
+        )
+        media = result.get("media_or_ad")
+        if not media:
+            raise MediaNotFound(media_id=media_id, **(self.last_json or {}))
+        return extract_media_v1(media)
+
     def media_info(self, media_pk: str, use_cache: bool = True) -> Media:
         """
         Get Media Information from PK

--- a/tests.py
+++ b/tests.py
@@ -424,6 +424,103 @@ class TrackMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["music_page"]["max_id"], "next-page")
 
 
+class MediaInfoV2RegressionTestCase(unittest.TestCase):
+    def _media_or_ad_payload(self):
+        return {
+            "pk": "1",
+            "id": "1_2",
+            "code": "abc",
+            "taken_at": 1710000000,
+            "media_type": 1,
+            "user": {
+                "pk": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "image_versions2": {
+                "candidates": [
+                    {"url": "https://example.com/x.jpg", "width": 100, "height": 100}
+                ]
+            },
+        }
+
+    def test_media_info_v2_strips_userid_suffix(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"media_or_ad": self._media_or_ad_payload()},
+        ) as private_request:
+            media = client.media_info_v2("3613500067578544892_25025320")
+
+        private_request.assert_called_once_with(
+            "discover/media_metadata/",
+            params={"media_id": "3613500067578544892"},
+        )
+        self.assertEqual(media.pk, "1")
+
+    def test_media_info_v2_passes_pk_only_unchanged(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"media_or_ad": self._media_or_ad_payload()},
+        ) as private_request:
+            client.media_info_v2("3613500067578544892")
+
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(params["media_id"], "3613500067578544892")
+
+    def test_media_info_v2_raises_media_not_found_when_payload_empty(self):
+        from instagrapi.exceptions import MediaNotFound
+
+        client = Client()
+        client.last_json = {}
+        with mock.patch.object(client, "private_request", return_value={}):
+            with self.assertRaises(MediaNotFound):
+                client.media_info_v2("9_8")
+
+
+class CheckOffensiveCommentV2RegressionTestCase(unittest.TestCase):
+    def _build_logged_in_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        return client
+
+    def test_v2_payload_is_lighter_than_v1(self):
+        client = self._build_logged_in_client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"is_offensive": True, "category": "harassment"},
+        ) as private_request:
+            result = client.media_check_offensive_comment_v2("9_8", "rude")
+
+        private_request.assert_called_once()
+        path, kwargs = (
+            private_request.call_args.args[0],
+            private_request.call_args.kwargs,
+        )
+        self.assertEqual(path, "media/comment/check_offensive_comment/")
+        # data passed as keyword to mirror aiograpi shape
+        self.assertEqual(kwargs["data"]["comment_text"], "rude")
+        self.assertEqual(kwargs["data"]["media_id"], "9_8")
+        self.assertIn("_uuid", kwargs["data"])
+        # No with_action_data wrapping → no _csrftoken / _uid /
+        # user_breadcrumb in the payload.
+        self.assertNotIn("_csrftoken", kwargs["data"])
+        self.assertNotIn("_uid", kwargs["data"])
+        self.assertNotIn("user_breadcrumb", kwargs["data"])
+        # Raw response is returned, not just bool.
+        self.assertEqual(result, {"is_offensive": True, "category": "harassment"})
+
+    def test_v2_requires_login(self):
+        client = Client()
+        # No authorization_data → user_id property returns None.
+        with self.assertRaises(AssertionError):
+            client.media_check_offensive_comment_v2("9_8", "rude")
+
+
 class NoteMixinRegressionTestCase(unittest.TestCase):
     def test_get_note_helpers_by_user(self):
         client = Client()


### PR DESCRIPTION
## Summary

Final batch of new endpoints. Two media-side methods:

| Method | Endpoint | Description |
|--------|----------|-------------|
| `media_info_v2(media_id) -> Media` | `GET discover/media_metadata/` | Alternative source for media info that returns a `media_or_ad` payload. Useful as a fallback when `media_info_v1` fails on certain ad-tagged or sponsored media. Strips `_userid` suffix automatically. |
| `media_check_offensive_comment_v2(media_id, comment) -> dict` | `POST media/comment/check_offensive_comment/` | Lighter variant of the existing v1 — same endpoint without `with_action_data` wrapping; sends `{comment_text, media_id, _uuid}` directly. Returns raw payload so callers can inspect new flags beyond `is_offensive` (e.g. category / confidence). v1 stays for backward compat. |

Ported from aiograpi [5c7ced4](https://github.com/subzeroid/aiograpi/commit/5c7ced4).

## Test plan

5 new cases across two new offline regression test classes:

**`MediaInfoV2RegressionTestCase`** (3 cases):
- [x] `_userid` suffix stripping — full media_id input → pk-only `media_id` param
- [x] pk-only input passes through unchanged
- [x] `MediaNotFound` raised when `media_or_ad` is missing from response

**`CheckOffensiveCommentV2RegressionTestCase`** (2 cases):
- [x] lighter payload shape: no `_csrftoken` / `_uid` / `user_breadcrumb` (no `with_action_data` wrap), raw response returned (not just bool)
- [x] login guard via `assert self.user_id`

- [x] flake8 + isort clean
- [x] `mkdocs build --strict` passes

## Documentation

- `docs/usage-guide/media.md` — new row for `media_info_v2` in viewing/editing methods table
- `docs/usage-guide/comment.md` — new row for `media_check_offensive_comment_v2`

## Release plan

After merge: bump to `2.5.9`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)