### PR TITLE
fix: replace tempfile.mktemp with safe mkstemp helper

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import os
 import random
 import tempfile
 import time
@@ -16,6 +17,19 @@ try:
     from PIL import Image
 except ImportError:
     raise Exception("You don't have PIL installed. Please install PIL or Pillow>=8.1.1")
+
+
+def _make_tmp_path(suffix: str) -> str:
+    """Create a uniquely-named tempfile path safely.
+
+    ``tempfile.mktemp`` is deprecated and prone to TOCTOU races. We
+    use ``mkstemp`` to atomically create the file under a unique
+    name, then close the file descriptor — the path is reserved and
+    safe for the caller to reopen.
+    """
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    return path
 
 
 class DownloadClipMixin:
@@ -233,7 +247,7 @@ class UploadClipMixin:
         Media
             A Media response from the call
         """
-        tmpaudio = Path(tempfile.mktemp(".m4a"))
+        tmpaudio = Path(_make_tmp_path(".m4a"))
         tmpaudio = self.track_download_by_url(track.uri, "track", tmpaudio.parent)
         tmpvideo = None
         try:
@@ -260,7 +274,7 @@ class UploadClipMixin:
             video = video.set_audio(audio_clip)
             video_duration = video.duration
             # save the media in tmp folder
-            tmpvideo = Path(tempfile.mktemp(".mp4"))
+            tmpvideo = Path(_make_tmp_path(".mp4"))
             video.write_videofile(str(tmpvideo))
             # create the extra data to upload with it
             data = dict(extra_data or {})

--- a/instagrapi/story.py
+++ b/instagrapi/story.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 from typing import List
@@ -22,6 +23,19 @@ try:
     from PIL import Image
 except ImportError:
     raise Exception("You don't have PIL installed. Please install PIL or Pillow>=8.1.1")
+
+
+def _make_tmp_path(suffix: str) -> str:
+    """Create a uniquely-named tempfile path safely.
+
+    ``tempfile.mktemp`` is deprecated and prone to TOCTOU races. We
+    use ``mkstemp`` to atomically create the file under a unique
+    name, then close the file descriptor — the path is reserved and
+    safe for the caller to reopen.
+    """
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    return path
 
 
 class StoryBuilder:
@@ -181,7 +195,7 @@ class StoryBuilder:
         if getattr(clip, "duration", None):
             if duration > int(clip.duration) or not duration:
                 duration = int(clip.duration)
-        destination = tempfile.mktemp(".mp4")
+        destination = _make_tmp_path(".mp4")
         cvc = (
             CompositeVideoClip(clips, size=(self.width, self.height))
             .set_fps(24)
@@ -191,7 +205,7 @@ class StoryBuilder:
         paths = []
         if duration > 15:
             for i in range(duration // 15 + (1 if duration % 15 else 0)):
-                path = tempfile.mktemp(".mp4")
+                path = _make_tmp_path(".mp4")
                 start = i * 15
                 rest = duration - start
                 end = start + (rest if rest < 15 else 15)

--- a/tests.py
+++ b/tests.py
@@ -635,6 +635,43 @@ class LocationMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(location.external_id, 108835465815492)
 
 
+class TempfileHelperRegressionTestCase(unittest.TestCase):
+    """Verify the safe-tempfile helper actually creates the file (TOCTOU
+    fix for the previous ``tempfile.mktemp`` usage that was flagged by
+    CodeQL ``py/insecure-temporary-file``)."""
+
+    def test_clip_helper_creates_file_with_suffix(self):
+        from instagrapi.mixins.clip import _make_tmp_path
+
+        path = _make_tmp_path(".m4a")
+        try:
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(path.endswith(".m4a"))
+        finally:
+            os.remove(path)
+
+    def test_clip_helper_returns_unique_paths(self):
+        from instagrapi.mixins.clip import _make_tmp_path
+
+        a = _make_tmp_path(".mp4")
+        b = _make_tmp_path(".mp4")
+        try:
+            self.assertNotEqual(a, b)
+        finally:
+            os.remove(a)
+            os.remove(b)
+
+    def test_story_helper_creates_file_with_suffix(self):
+        from instagrapi.story import _make_tmp_path
+
+        path = _make_tmp_path(".mp4")
+        try:
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(path.endswith(".mp4"))
+        finally:
+            os.remove(path)
+
+
 class FbSearchRegressionTestCase(unittest.TestCase):
     """Offline regression tests for FbSearchMixin v2 SERP endpoints
     and the typeahead-stream flattener."""


### PR DESCRIPTION
## Summary

CodeQL \`py/insecure-temporary-file\` flagged 4 call sites of the deprecated \`tempfile.mktemp()\`:

- \`instagrapi/mixins/clip.py:236\` (audio download path for music tracks)
- \`instagrapi/mixins/clip.py:263\` (final video path before reel upload)
- \`instagrapi/story.py:184\` (composite-video destination)
- \`instagrapi/story.py:194\` (sub-clip path inside the 15s split loop)

\`mktemp\` returns a name without creating the file, opening a TOCTOU window where another process can race in and place a symlink at the predictable path.

### Fix

Introduce a small \`_make_tmp_path(suffix)\` helper in each module that wraps \`tempfile.mkstemp()\` — atomically creates the file under a unique name, closes the fd, and returns the path for the caller to reopen. Same external behavior (a string path with a fixed suffix), no race window.

Closes 4 CodeQL alerts (#7, #9, #10, #16).

## Test plan

3 new cases in \`TempfileHelperRegressionTestCase\`:

- [x] clip helper creates the file with the requested suffix on disk
- [x] two consecutive clip helper calls return unique paths (uniqueness guarantee)
- [x] story helper creates the file with the requested suffix on disk
- [x] flake8 + isort clean

## Release plan

After merge: bump to \`2.5.10\`, tag, auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)