### PR TITLE
fix: tighten cookie domain check in load_session_cookie example

### DIFF
--- a/examples/load_session_cookie.py
+++ b/examples/load_session_cookie.py
@@ -55,7 +55,8 @@ def get_instagram_cookies_from_browser(browser_name):
 
         instagram_cookies = {}
         for cookie in browser_cookies:
-            if "instagram.com" in cookie.domain:
+            domain = (cookie.domain or "").lstrip(".").lower()
+            if domain == "instagram.com" or domain.endswith(".instagram.com"):
                 instagram_cookies[cookie.name] = cookie.value
 
         print(f"Found {len(instagram_cookies)} Instagram cookies in {browser_name}")


### PR DESCRIPTION
## Summary

CodeQL \`py/incomplete-url-substring-sanitization\` flagged \`examples/load_session_cookie.py:58\`:

\`\`\`python
if "instagram.com" in cookie.domain:
\`\`\`

That substring match would let through attacker-owned domains like \`evil-instagram.com.example\` or \`notinstagram.community\`, allowing unrelated cookies to be treated as Instagram session data.

### Fix

Explicit eTLD+1 match. Lowercase the domain, strip the leading dot that browsers use for subdomain-wildcard cookies (e.g. \`.instagram.com\`), then compare exactly against \`instagram.com\` or accept any strict subdomain via \`endswith(".instagram.com")\`.

\`\`\`python
domain = (cookie.domain or "").lstrip(".").lower()
if domain == "instagram.com" or domain.endswith(".instagram.com"):
\`\`\`

Closes CodeQL alert #15.

## Test plan

- [x] Python AST parse OK
- [x] flake8 + black + isort clean

This is an example script — no automated tests for the example layer (other examples in the directory follow the same convention).

## Release plan

This is a docs/example-only change — \`examples/\` is not part of the PyPI artefact, so no version bump / release needed unless you want one for the changelog. I'd suggest skipping the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)