### PR TITLE
docs: announce Telegram support group move to @aiograpi_support

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-https://t.me/instagrapi.
+https://t.me/aiograpi_support.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # instagrapi
 
+> ⚠️ **Telegram support group moved to https://t.me/aiograpi_support** — the previous `@instagrapi` group has been restricted by Meta and is no longer maintained.
+
 [![PyPI](https://img.shields.io/pypi/v/instagrapi)](https://pypi.org/project/instagrapi/)
 [![Python](https://img.shields.io/pypi/pyversions/instagrapi)](https://pypi.org/project/instagrapi/)
 [![License](https://img.shields.io/pypi/l/instagrapi)](LICENSE)
@@ -151,7 +153,7 @@ Anonymous/public web paths are best treated as opportunistic rather than guarant
 * [Best Practices](https://subzeroid.github.io/instagrapi/usage-guide/best-practices.html) for sessions, proxies, and anti-abuse handling
 * [Handle Exceptions](https://subzeroid.github.io/instagrapi/usage-guide/handle_exception.html) for centralizing `429`, challenge, and relogin logic
 * [GitHub Discussions](https://github.com/subzeroid/instagrapi/discussions)
-* [Support chat in Telegram](https://t.me/instagrapi)
+* Support chat in Telegram: https://t.me/aiograpi_support — the previous `@instagrapi` group was restricted by Meta and is no longer maintained
 
 For other languages, consider [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest). For async Python, see [aiograpi](https://github.com/subzeroid/aiograpi).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,4 @@ Only the latest versions are supported
 
 ## Reporting a Vulnerability
 
-Report vulnerabilities in the telegram channel https://t.me/instagrapi or https://github.com/subzeroid/instagrapi/issues
+Report vulnerabilities in the telegram channel https://t.me/aiograpi_support or https://github.com/subzeroid/instagrapi/issues

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # instagrapi
 
+!!! warning "Telegram support group moved"
+    The previous `@instagrapi` Telegram group has been restricted by Meta and is no longer maintained.
+    New support group: **https://t.me/aiograpi_support** — same maintainer, covers both `instagrapi` and `aiograpi`.
+
 ### We recommend using our services:
 
 * [LamaTok](https://lamatok.com/p/B9ScEYIQ) for TikTok API access, automation, and data workflows 🔥
@@ -22,7 +26,7 @@ Support **Python 3.10+**
 
 For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzeroid/instagrapi-rest/tree/main/golang), Erlang, Elixir, Nim, Haskell, Lisp, Closure, Julia, R, Java, Kotlin, Scala, OCaml, JavaScript, Crystal, Ruby, Rust, [Swift](https://github.com/subzeroid/instagrapi-rest/tree/main/swift), Objective-C, Visual Basic, .NET, Pascal, Perl, Lua, PHP and others), I suggest using [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest)
 
-[Support Chat in Telegram](https://t.me/instagrapi)
+Support chat in Telegram: https://t.me/aiograpi_support
 ![](https://gist.githubusercontent.com/m8rge/4c2b36369c9f936c02ee883ca8ec89f1/raw/c03fd44ee2b63d7a2a195ff44e9bb071e87b4a40/telegram-single-path-24px.svg) and [GitHub Discussions](https://github.com/subzeroid/instagrapi/discussions)
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.5.11"
+version = "2.5.12"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]


### PR DESCRIPTION
## Summary

The `@instagrapi` Telegram support group has been restricted by a Meta copyright takedown — group settings are frozen and messages are no longer delivered. Direct users to the new group via every surface we control:

- **README**: banner at the top + replace the support-chat bullet with `https://t.me/aiograpi_support`
- **docs/index.md**: `!!! warning` admonition + replace inline support link
- **pyproject.toml**: bump `2.5.11` → `2.5.12` so the notice ships to PyPI's project page on auto-release

URLs are written as plain `https://t.me/aiograpi_support` (not masked link text) so they remain copy-pasteable from PyPI's rendered description and any context that strips markdown.

## Test plan

- [x] `flake8 instagrapi --select=E9,F63,F7,F82` — clean
- [x] `isort --check-only instagrapi` — clean
- [ ] After merge + tag `2.5.12`: verify PyPI project page shows the banner
- [ ] After merge: verify mkdocs builds and the admonition renders on the published site