### PR TITLE
feat(direct): add direct_send_voice() + fix direct_send_video() (closes #2447)

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - media
+          - direct
           - user
           - all
 
@@ -38,6 +39,10 @@ jobs:
       - name: Run media test
         if: github.event.inputs.test_target == 'media' || github.event.inputs.test_target == 'all'
         run: pytest -sv tests.py::ClientMediaTestCase tests.py::ClientCommentRepliesLiveTestCase
+
+      - name: Run direct media test
+        if: github.event.inputs.test_target == 'direct' || github.event.inputs.test_target == 'all'
+        run: pytest -sv tests.py::ClientDirectMediaLiveTestCase
 
       - name: Run user test
         if: github.event.inputs.test_target == 'user' || github.event.inputs.test_target == 'all'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -85,6 +85,7 @@ jobs:
           pytest -sv \
             tests.py::ExtractorsRegressionTestCase \
             tests.py::PublicRegressionTestCase \
+            tests.py::DirectMixinRegressionTestCase \
             tests.py::ChallengeRegressionTestCase \
             tests.py::CommentRepliesRegressionTestCase \
             tests.py::AuthAndStoryRegressionTestCase \

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -21,7 +21,7 @@
 | direct_thread_mute_video_call(thread_id: int, revert: bool = False)       | bool                    | Mute video call for the thread
 | direct_thread_unmute_video_call(thread_id: int)                           | bool                    | Unmute video call for the thread
 | direct_send_photo(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct photo to list of users or threads
-| direct_send_video(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct video to list of users or threads
+| direct_send_video(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct video (.mp4 / H.264 + AAC) to list of users or threads
 | direct_send_voice(path: Path, user_ids: List[int], thread_ids: List[int], waveform: Optional[List[float]]) | DirectMessage | Send a direct voice (audio) message; path must be m4a/AAC
 | video_upload_to_direct(path: Path, caption: str, thumbnail: Path, mentions: List[StoryMention], thread_ids: List[int] = [], extra_data: Dict[str, str] = {}) | DirectMessage | Upload video to direct thread as a story and configure it
 

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -22,11 +22,12 @@
 | direct_thread_unmute_video_call(thread_id: int)                           | bool                    | Unmute video call for the thread
 | direct_send_photo(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct photo to list of users or threads
 | direct_send_video(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct video to list of users or threads
+| direct_send_voice(path: Path, user_ids: List[int], thread_ids: List[int], waveform: Optional[List[float]]) | DirectMessage | Send a direct voice (audio) message; path must be m4a/AAC
 | video_upload_to_direct(path: Path, caption: str, thumbnail: Path, mentions: List[StoryMention], thread_ids: List[int] = [], extra_data: Dict[str, str] = {}) | DirectMessage | Upload video to direct thread as a story and configure it
 
 Notes:
 
-* For `direct_send()`, `direct_send_photo()`, and `direct_send_video()`, pass exactly one of `user_ids` or `thread_ids`.
+* For `direct_send()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
 * `direct_thread()` paginates internally until it collects `amount` messages or reaches the end of the thread.
 * Media-changing direct endpoints are more sensitive to session quality than read-only inbox calls. Stable sessions loaded via `dump_settings()/load_settings()` are more reliable than browser-only `sessionid` reuse.
 
@@ -110,6 +111,11 @@ DirectMessage(id=300775273512312312312321568, user_id=None, thread_id=3402823612
 >>> video_path = cl.video_download(cl.media_pk_from_url('https://www.instagram.com/p/B3rFQPblq40/'))
 >>> cl.direct_send_video(video_path, user_ids=[cl.user_id])  # or
 >>> cl.direct_send_video(video_path, thread_ids=[thread.id])
+
+>>> # Voice/audio DM. Audio MUST be AAC in an MP4 container (.m4a).
+>>> # Convert via ffmpeg first if needed:
+>>> #   ffmpeg -i input.wav -c:a aac -b:a 64k -ac 1 -ar 44100 voice.m4a
+>>> cl.direct_send_voice("voice.m4a", thread_ids=[thread.id])
 Analyzing video file "/.../example_2155839952940084788.mp4"
 DirectMessage(id=300775489123123123123664, user_id=None, thread_id=34012312312312312398762, timestamp=datetime.datetime(2021, 9, 1, 14, 39, 56, 959454, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from instagrapi.exceptions import ClientNotFoundError, DirectThreadNotFound
+from instagrapi.exceptions import ClientError, ClientNotFoundError, DirectThreadNotFound
 from instagrapi.extractors import (
     extract_direct_media,
     extract_direct_message,
@@ -520,6 +520,200 @@ class DirectMixin:
                 )
             thread_ids = [int(thread_id)]
         return self.video_upload_to_direct(Path(path), thread_ids=thread_ids)
+
+    def direct_send_voice(
+        self,
+        path: Path,
+        user_ids: List[int] = [],
+        thread_ids: List[int] = [],
+        waveform: Optional[List[float]] = None,
+    ) -> DirectMessage:
+        """
+        Send a voice (audio) DM to a list of users or threads.
+
+        Replicates the IG Android client's three-step protocol:
+
+        1. ``GET https://rupload.facebook.com/messenger_audio/{upload_id}_0_{key}``
+           returns the resumable upload offset.
+        2. ``POST`` to the same URL with the audio bytes returns
+           ``{"media_id": <int>}``.
+        3. ``POST direct_v2/threads/broadcast/voice_attachment/`` with that
+           ``media_id`` as ``attachment_fbid`` sends the message.
+
+        The audio file MUST be AAC in an MP4 container (``.m4a``); the server
+        rejects other formats at upload_finish.
+
+        Parameters
+        ----------
+        path: Path
+            Path to an m4a/AAC voice clip.
+        user_ids: List[int]
+            List of unique identifiers of Users id.
+        thread_ids: List[int]
+            List of unique identifiers of Direct Message thread id.
+        waveform: Optional[List[float]]
+            Optional list of 70 amplitude values in ``[0.0, 1.0]`` for the IG
+            voice-bubble UI. The server does not validate amplitudes — it is
+            UI-cosmetic only. Defaults to random values that produce a natural
+            buzzy bubble (zeros render as flat dots, not bars).
+
+        Returns
+        -------
+        DirectMessage
+            An object of DirectMessage.
+        """
+        assert self.user_id, "Login required"
+        assert (user_ids or thread_ids) and not (
+            user_ids and thread_ids
+        ), "Specify user_ids or thread_ids, but not both"
+        if user_ids:
+            thread = self.direct_thread_by_participants(user_ids)
+            thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
+            if not thread_id:
+                raise DirectThreadNotFound(
+                    "No existing direct thread found for participants; "
+                    "direct voice send currently requires an existing thread",
+                    user_ids=user_ids,
+                    **(self.last_json if isinstance(self.last_json, dict) else {}),
+                )
+            thread_ids = [int(thread_id)]
+
+        audio_bytes = Path(path).read_bytes()
+        upload_id = str(int(time.time() * 1000))
+        rand_key = random.randint(-(2**31), 2**31 - 1)
+
+        # Steps 1 + 2: upload to rupload.facebook.com, get media_id.
+        media_id = self._voice_rupload(audio_bytes, upload_id, rand_key)
+
+        # Step 3: broadcast voice_attachment with media_id as attachment_fbid.
+        if waveform is None:
+            waveform = [round(random.uniform(0.2, 0.95), 3) for _ in range(70)]
+        token = self.generate_mutation_token()
+        data = {
+            "action": "send_item",
+            "thread_ids": dumps([int(tid) for tid in thread_ids]),
+            "send_attribution": "inbox",
+            "client_context": token,
+            "attachment_fbid": str(media_id),
+            "device_id": self.android_device_id,
+            "mutation_token": token,
+            "_uuid": self.uuid,
+            "waveform": dumps(waveform),
+            "waveform_sampling_frequency_hz": "10",
+            "upload_id": upload_id,
+            "offline_threading_id": token,
+        }
+        result = self.private_request(
+            "direct_v2/threads/broadcast/voice_attachment/",
+            data=self.with_default_data(data),
+            with_signature=False,
+        )
+        return extract_direct_message(result["payload"])
+
+    def _voice_rupload(
+        self, audio_bytes: bytes, upload_id: str, rand_key: int
+    ) -> int:
+        """Upload audio to rupload.facebook.com and return the media_id used as
+        attachment_fbid in the voice_attachment broadcast.
+
+        Notes
+        -----
+        The IG mobile app strips most ``X-IG-*`` / ``X-Bloks-*`` / ``X-Pigeon-*``
+        headers when calling FB-domain endpoints. ``self.private`` keeps a full
+        IG-mobile header set pinned on its session, which leaks into per-call
+        requests via session-merging and causes FB rupload to return a generic
+        404 ("We're sorry, but something went wrong"). We therefore use a fresh
+        ``requests.Session`` here with only the headers FB rupload expects.
+
+        The captured request from the official client also included
+        ``x-meta-zca`` (Play Integrity attestation) and ``x-meta-usdid`` (signed
+        device id) headers. Empirical testing shows the server accepts the
+        upload without them — they appear to be informational/risk-scoring
+        rather than strictly validated.
+        """
+        import requests
+
+        entity = f"{upload_id}_0_{rand_key}"
+        url = f"https://rupload.facebook.com/messenger_audio/{entity}"
+
+        sess = requests.Session()
+        if getattr(self, "proxy", None):
+            sess.proxies = {"http": self.proxy, "https": self.proxy}
+
+        bearer = self.private.headers.get("Authorization") or (
+            f"Bearer IGT:2:{self.authorization_data.get('sessionid', '')}"
+        )
+        user_id = str(self.user_id)
+        rur = self.private.headers.get("IG-U-RUR", "")
+        mid = self.private.headers.get("X-MID", "")
+
+        headers = {
+            "authorization": bearer,
+            "ig-intended-user-id": user_id,
+            "ig-u-ds-user-id": user_id,
+            # NOTE: real client sends zstd; requests cannot decode zstd so use
+            # gzip. The server honors either.
+            "accept-encoding": "gzip",
+            "accept-language": "en-US",
+            "priority": "u=6, i",
+            "user-agent": self.user_agent,
+            "audio_type": "FILE_ATTACHMENT",
+            "x-fb-client-ip": "True",
+            "x-fb-friendly-name": "undefined:media-upload",
+            "x-fb-http-engine": "Tigon/MNS/TCP",
+            "x-fb-request-analytics-tags": (
+                '{"network_tags":{"product":"567067343352427",'
+                '"surface":"undefined","request_category":"media_upload",'
+                '"purpose":"none","retry_attempt":"0"}}'
+            ),
+            "x-fb-rmd": "state=URL_ELIGIBLE",
+            "x-fb-server-cluster": "True",
+            "x-tigon-is-retry": "False",
+            "x-ig-salt-ids": "51052545",
+        }
+        if rur:
+            headers["ig-u-rur"] = rur
+        if mid:
+            headers["x-mid"] = mid
+
+        # 1. fetch resumable offset
+        r = sess.get(url, headers=headers, timeout=30)
+        if r.status_code != 200:
+            raise ClientError(
+                f"messenger_audio offset GET failed: "
+                f"{r.status_code} {r.text[:300]}"
+            )
+        try:
+            offset = int(r.json().get("offset", 0))
+        except Exception:
+            offset = 0
+
+        # 2. POST audio bytes
+        post_headers = dict(headers)
+        post_headers.update(
+            {
+                "content-type": "application/octet-stream",
+                "offset": str(offset),
+                "x-entity-length": str(len(audio_bytes)),
+                "x-entity-name": entity,
+                "x-entity-type": "audio/mp4",
+            }
+        )
+        r = sess.post(
+            url, data=audio_bytes[offset:], headers=post_headers, timeout=120
+        )
+        if r.status_code != 200:
+            raise ClientError(
+                f"messenger_audio upload POST failed: "
+                f"{r.status_code} {r.text[:300]}"
+            )
+        try:
+            media_id = int(r.json()["media_id"])
+        except Exception as exc:
+            raise ClientError(
+                f"messenger_audio response missing media_id: {r.text[:300]}"
+            ) from exc
+        return media_id
 
     def direct_send_file(
         self,

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1,6 +1,8 @@
 import random
 import re
+import secrets
 import time
+import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -488,21 +490,37 @@ class DirectMixin:
         self, path: Path, user_ids: List[int] = [], thread_ids: List[int] = []
     ) -> DirectMessage:
         """
-        Send a direct video to list of users or threads
+        Send a direct video to a list of users or threads.
+
+        Replicates the IG Android client's three-step protocol (captured
+        2026-05-06). Instagram retired
+        ``direct_v2/threads/broadcast/configure_video/`` and migrated to
+        ``raven_attachment/?video=1``:
+
+        1. ``GET https://rupload.facebook.com/messenger_video/{32hex}-{seg}-{size}-{ms}-{ms}``
+           returns the resumable upload offset.
+        2. ``POST`` to the same URL with raw mp4 bytes returns
+           ``{"media_id": <int>, "id": 0}``.
+        3. ``POST direct_v2/threads/broadcast/raven_attachment/?video=1`` with a
+           signed body whose ``attachment_fbid`` and ``video_result`` both equal
+           the ``media_id`` from step 2.
+
+        The video MUST be H.264 in an MP4 container (``.mp4``); the server
+        ``x-entity-type`` is fixed at ``video/mp4``.
 
         Parameters
         ----------
         path: Path
-            Path to video that will be posted on the thread
+            Path to a .mp4 file (H.264 + AAC).
         user_ids: List[int]
-            List of unique identifier of Users id
+            List of unique identifiers of Users id.
         thread_ids: List[int]
-            List of unique identifier of Direct Message thread id
+            List of unique identifiers of Direct Message thread id.
 
         Returns
         -------
         DirectMessage
-            An object of DirectMessage
+            An object of DirectMessage.
         """
         assert self.user_id, "Login required"
         assert (user_ids or thread_ids) and not (
@@ -519,7 +537,198 @@ class DirectMixin:
                     **(self.last_json if isinstance(self.last_json, dict) else {}),
                 )
             thread_ids = [int(thread_id)]
-        return self.video_upload_to_direct(Path(path), thread_ids=thread_ids)
+
+        path = Path(path)
+        video_bytes = path.read_bytes()
+        size = len(video_bytes)
+
+        # Probe duration + dimensions via ffprobe (best-effort; defaults work).
+        duration_sec = 1.0
+        width, height = 720, 1280
+        try:
+            import json as _json
+            import subprocess as _subprocess
+            out = _subprocess.check_output(
+                ["ffprobe", "-v", "error", "-print_format", "json",
+                 "-show_streams", str(path)],
+                stderr=_subprocess.DEVNULL,
+            )
+            info = _json.loads(out)
+            for s in info.get("streams", []):
+                if s.get("codec_type") == "video":
+                    width = int(s.get("width") or width)
+                    height = int(s.get("height") or height)
+                    if s.get("duration"):
+                        duration_sec = float(s["duration"])
+                    break
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Steps 1 + 2: FB-domain rupload, returns media_id.
+        hex_id = secrets.token_hex(16)
+        ms = int(time.time() * 1000)
+        entity = f"{hex_id}-0-{size}-{ms}-{ms}"
+        upload_id = str(random.randint(10**11, 10**12 - 1))
+        waterfall_id = f"{upload_id}_{hex_id[:12].upper()}_Mixed_0"
+        media_id = self._video_rupload(video_bytes, entity, waterfall_id)
+
+        # Step 3: signed broadcast to raven_attachment/?video=1.
+        token = self.generate_mutation_token()
+        composition_id = str(uuid.uuid4())
+        camera_session_id = str(uuid.uuid4())
+        data = {
+            "recipient_users": "[]",
+            "view_mode": "permanent",
+            "has_camera_metadata": "1",
+            "camera_entry_point": "3",
+            "thread_ids": dumps([str(tid) for tid in thread_ids]),
+            "reshare_mode": "allow_reshare",
+            "original_media_type": "2",  # 2 = video
+            "send_attribution": "direct_composer",
+            "client_context": token,
+            "camera_session_id": camera_session_id,
+            "attachment_fbid": str(media_id),
+            "include_e2ee_mentioned_user_list": "1",
+            "hide_from_profile_grid": "false",
+            "timezone_offset": "0",
+            "client_shared_at": str(int(time.time())),
+            "configure_mode": "2",
+            "source_type": "3",
+            "camera_position": "back",
+            "video_result": str(media_id),
+            "_uid": str(self.user_id),
+            "device_id": self.android_device_id,
+            "composition_id": composition_id,
+            "mutation_token": token,
+            "_uuid": self.uuid,
+            "creation_surface": "camera",
+            "has_ig_camera_edits": "false",
+            "capture_type": "normal",
+            "audience": "default",
+            "upload_id": upload_id,
+            "client_timestamp": str(int(time.time())),
+            "media_transformation_info": dumps({
+                "width": str(width), "height": str(height),
+                "x_transform": "0", "y_transform": "0",
+                "zoom": "1.0", "rotation": "0.0",
+                "background_coverage": "0.0",
+            }),
+            "clips": [{"length": duration_sec, "source_type": "3",
+                       "camera_position": "back"}],
+            "poster_frame_index": 0,
+            "length": duration_sec,
+            "audio_muted": False,
+            "edits": {"filter_type": 0, "filter_strength": 1.0},
+            "extra": {"source_width": width, "source_height": height},
+            "device": {"manufacturer": "Google", "model": "sdk_gphone_arm64",
+                       "android_version": 30, "android_release": "11"},
+        }
+        result = self.private_request(
+            "direct_v2/threads/broadcast/raven_attachment/?video=1",
+            data=self.with_default_data(data),
+            with_signature=True,
+        )
+        return extract_direct_message(result["payload"])
+
+    def _video_rupload(
+        self, video_bytes: bytes, entity_name: str, waterfall_id: str
+    ) -> int:
+        """Upload mp4 bytes to ``rupload.facebook.com/messenger_video/...`` and
+        return the ``media_id`` used as ``attachment_fbid`` in the broadcast.
+
+        Notes
+        -----
+        Same constraint as :meth:`_voice_rupload` — ``self.private`` pins ~30
+        IG-mobile-only headers (``X-IG-*``, ``X-Bloks-*``, ``X-Pigeon-*``,
+        plus ``Host: i.instagram.com``) that FB's rupload edge rejects with a
+        generic 404. We use a fresh ``requests.Session`` here with only the
+        captured allow-list.
+        """
+        import requests
+
+        url = f"https://rupload.facebook.com/messenger_video/{entity_name}"
+
+        sess = requests.Session()
+        if getattr(self, "proxy", None):
+            sess.proxies = {"http": self.proxy, "https": self.proxy}
+
+        bearer = self.private.headers.get("Authorization") or (
+            f"Bearer IGT:2:{self.authorization_data.get('sessionid', '')}"
+        )
+        user_id = str(self.user_id)
+        rur = self.private.headers.get("IG-U-RUR", "")
+        mid = self.private.headers.get("X-MID", "")
+
+        headers = {
+            "authorization": bearer,
+            "ig-intended-user-id": user_id,
+            "ig-u-ds-user-id": user_id,
+            "accept-encoding": "gzip",
+            "accept-language": "en-US",
+            "priority": "u=6, i",
+            "user-agent": self.user_agent,
+            "video_type": "FILE_ATTACHMENT",
+            "segment-start-offset": "0",
+            "segment-type": "3",
+            "ephemeral_media_view_mode": "2",
+            "ig_raven_metadata": "{}",
+            "x_fb_video_waterfall_id": waterfall_id,
+            "x-fb-client-ip": "True",
+            "x-fb-friendly-name": "undefined:media-upload",
+            "x-fb-http-engine": "Tigon/MNS/TCP",
+            "x-fb-request-analytics-tags": (
+                '{"network_tags":{"product":"567067343352427",'
+                '"surface":"undefined","request_category":"media_upload",'
+                '"purpose":"none","retry_attempt":"0"}}'
+            ),
+            "x-fb-rmd": "state=URL_ELIGIBLE",
+            "x-fb-server-cluster": "True",
+            "x-tigon-is-retry": "False",
+            "x-ig-salt-ids": "51052545",
+        }
+        if rur:
+            headers["ig-u-rur"] = rur
+        if mid:
+            headers["x-mid"] = mid
+
+        # 1. fetch resumable offset
+        r = sess.get(url, headers=headers, timeout=30)
+        if r.status_code != 200:
+            raise ClientError(
+                f"messenger_video offset GET failed: "
+                f"{r.status_code} {r.text[:300]}"
+            )
+        try:
+            offset = int(r.json().get("offset", 0))
+        except Exception:
+            offset = 0
+
+        # 2. POST video bytes
+        post_headers = dict(headers)
+        post_headers.update(
+            {
+                "content-type": "application/octet-stream",
+                "offset": str(offset),
+                "x-entity-length": str(len(video_bytes)),
+                "x-entity-name": entity_name,
+                "x-entity-type": "video/mp4",
+            }
+        )
+        r = sess.post(
+            url, data=video_bytes[offset:], headers=post_headers, timeout=300
+        )
+        if r.status_code != 200:
+            raise ClientError(
+                f"messenger_video upload POST failed: "
+                f"{r.status_code} {r.text[:300]}"
+            )
+        try:
+            media_id = int(r.json()["media_id"])
+        except Exception as exc:
+            raise ClientError(
+                f"messenger_video response missing media_id: {r.text[:300]}"
+            ) from exc
+        return media_id
 
     def direct_send_voice(
         self,

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -486,6 +486,23 @@ class DirectMixin:
         """
         return self.direct_send_file(path, user_ids, thread_ids, content_type="photo")
 
+    def _direct_thread_id_from_user_ids(
+        self, user_ids: List[int], media_kind: str
+    ) -> int:
+        thread = self.direct_thread_by_participants(user_ids)
+        thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
+        if not thread_id and isinstance(self.last_json, dict):
+            thread = self.last_json.get("thread") or {}
+            thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
+        if not thread_id:
+            raise DirectThreadNotFound(
+                "No existing direct thread found for participants; "
+                f"direct {media_kind} send currently requires an existing thread",
+                user_ids=user_ids,
+                **(self.last_json if isinstance(self.last_json, dict) else {}),
+            )
+        return int(thread_id)
+
     def direct_send_video(
         self, path: Path, user_ids: List[int] = [], thread_ids: List[int] = []
     ) -> DirectMessage:
@@ -527,16 +544,7 @@ class DirectMixin:
             user_ids and thread_ids
         ), "Specify user_ids or thread_ids, but not both"
         if user_ids:
-            thread = self.direct_thread_by_participants(user_ids)
-            thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
-            if not thread_id:
-                raise DirectThreadNotFound(
-                    "No existing direct thread found for participants; "
-                    "direct video send currently requires an existing thread",
-                    user_ids=user_ids,
-                    **(self.last_json if isinstance(self.last_json, dict) else {}),
-                )
-            thread_ids = [int(thread_id)]
+            thread_ids = [self._direct_thread_id_from_user_ids(user_ids, "video")]
 
         path = Path(path)
         video_bytes = path.read_bytes()
@@ -548,9 +556,17 @@ class DirectMixin:
         try:
             import json as _json
             import subprocess as _subprocess
+
             out = _subprocess.check_output(
-                ["ffprobe", "-v", "error", "-print_format", "json",
-                 "-show_streams", str(path)],
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-print_format",
+                    "json",
+                    "-show_streams",
+                    str(path),
+                ],
                 stderr=_subprocess.DEVNULL,
             )
             info = _json.loads(out)
@@ -607,21 +623,31 @@ class DirectMixin:
             "audience": "default",
             "upload_id": upload_id,
             "client_timestamp": str(int(time.time())),
-            "media_transformation_info": dumps({
-                "width": str(width), "height": str(height),
-                "x_transform": "0", "y_transform": "0",
-                "zoom": "1.0", "rotation": "0.0",
-                "background_coverage": "0.0",
-            }),
-            "clips": [{"length": duration_sec, "source_type": "3",
-                       "camera_position": "back"}],
+            "media_transformation_info": dumps(
+                {
+                    "width": str(width),
+                    "height": str(height),
+                    "x_transform": "0",
+                    "y_transform": "0",
+                    "zoom": "1.0",
+                    "rotation": "0.0",
+                    "background_coverage": "0.0",
+                }
+            ),
+            "clips": [
+                {"length": duration_sec, "source_type": "3", "camera_position": "back"}
+            ],
             "poster_frame_index": 0,
             "length": duration_sec,
             "audio_muted": False,
             "edits": {"filter_type": 0, "filter_strength": 1.0},
             "extra": {"source_width": width, "source_height": height},
-            "device": {"manufacturer": "Google", "model": "sdk_gphone_arm64",
-                       "android_version": 30, "android_release": "11"},
+            "device": {
+                "manufacturer": "Google",
+                "model": "sdk_gphone_arm64",
+                "android_version": 30,
+                "android_release": "11",
+            },
         }
         result = self.private_request(
             "direct_v2/threads/broadcast/raven_attachment/?video=1",
@@ -652,9 +678,7 @@ class DirectMixin:
         if getattr(self, "proxy", None):
             sess.proxies = {"http": self.proxy, "https": self.proxy}
 
-        bearer = self.private.headers.get("Authorization") or (
-            f"Bearer IGT:2:{self.authorization_data.get('sessionid', '')}"
-        )
+        bearer = self.private.headers.get("Authorization") or self.authorization
         user_id = str(self.user_id)
         rur = self.private.headers.get("IG-U-RUR", "")
         mid = self.private.headers.get("X-MID", "")
@@ -695,8 +719,7 @@ class DirectMixin:
         r = sess.get(url, headers=headers, timeout=30)
         if r.status_code != 200:
             raise ClientError(
-                f"messenger_video offset GET failed: "
-                f"{r.status_code} {r.text[:300]}"
+                f"messenger_video offset GET failed: " f"{r.status_code} {r.text[:300]}"
             )
         try:
             offset = int(r.json().get("offset", 0))
@@ -714,9 +737,7 @@ class DirectMixin:
                 "x-entity-type": "video/mp4",
             }
         )
-        r = sess.post(
-            url, data=video_bytes[offset:], headers=post_headers, timeout=300
-        )
+        r = sess.post(url, data=video_bytes[offset:], headers=post_headers, timeout=300)
         if r.status_code != 200:
             raise ClientError(
                 f"messenger_video upload POST failed: "
@@ -776,16 +797,7 @@ class DirectMixin:
             user_ids and thread_ids
         ), "Specify user_ids or thread_ids, but not both"
         if user_ids:
-            thread = self.direct_thread_by_participants(user_ids)
-            thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
-            if not thread_id:
-                raise DirectThreadNotFound(
-                    "No existing direct thread found for participants; "
-                    "direct voice send currently requires an existing thread",
-                    user_ids=user_ids,
-                    **(self.last_json if isinstance(self.last_json, dict) else {}),
-                )
-            thread_ids = [int(thread_id)]
+            thread_ids = [self._direct_thread_id_from_user_ids(user_ids, "voice")]
 
         audio_bytes = Path(path).read_bytes()
         upload_id = str(int(time.time() * 1000))
@@ -819,9 +831,7 @@ class DirectMixin:
         )
         return extract_direct_message(result["payload"])
 
-    def _voice_rupload(
-        self, audio_bytes: bytes, upload_id: str, rand_key: int
-    ) -> int:
+    def _voice_rupload(self, audio_bytes: bytes, upload_id: str, rand_key: int) -> int:
         """Upload audio to rupload.facebook.com and return the media_id used as
         attachment_fbid in the voice_attachment broadcast.
 
@@ -849,9 +859,7 @@ class DirectMixin:
         if getattr(self, "proxy", None):
             sess.proxies = {"http": self.proxy, "https": self.proxy}
 
-        bearer = self.private.headers.get("Authorization") or (
-            f"Bearer IGT:2:{self.authorization_data.get('sessionid', '')}"
-        )
+        bearer = self.private.headers.get("Authorization") or self.authorization
         user_id = str(self.user_id)
         rur = self.private.headers.get("IG-U-RUR", "")
         mid = self.private.headers.get("X-MID", "")
@@ -889,8 +897,7 @@ class DirectMixin:
         r = sess.get(url, headers=headers, timeout=30)
         if r.status_code != 200:
             raise ClientError(
-                f"messenger_audio offset GET failed: "
-                f"{r.status_code} {r.text[:300]}"
+                f"messenger_audio offset GET failed: " f"{r.status_code} {r.text[:300]}"
             )
         try:
             offset = int(r.json().get("offset", 0))
@@ -908,9 +915,7 @@ class DirectMixin:
                 "x-entity-type": "audio/mp4",
             }
         )
-        r = sess.post(
-            url, data=audio_bytes[offset:], headers=post_headers, timeout=120
-        )
+        r = sess.post(url, data=audio_bytes[offset:], headers=post_headers, timeout=120)
         if r.status_code != 200:
             raise ClientError(
                 f"messenger_audio upload POST failed: "

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ import logging
 import os
 import os.path
 import random
+import subprocess
 import tempfile
 import time
 import types
@@ -3199,6 +3200,166 @@ class ClientDirectTestCase(ClientPrivateTestCase):
             pass
 
 
+class ClientDirectMediaLiveTestCase(ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for direct media live tests")
+        self.cl = self.fresh_account()
+
+    def make_media_fixture(self, suffix, args):
+        try:
+            import imageio_ffmpeg
+        except ImportError:
+            self.skipTest("imageio_ffmpeg is required to generate media fixtures")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+
+        try:
+            subprocess.run(
+                [imageio_ffmpeg.get_ffmpeg_exe(), "-y", *args, str(path)],
+                check=True,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            self.skipTest(f"Could not generate {suffix} fixture: {exc}")
+        return path
+
+    def make_voice_m4a(self):
+        return self.make_media_fixture(
+            ".m4a",
+            [
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=880:duration=1",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "64k",
+                "-ac",
+                "1",
+                "-ar",
+                "44100",
+            ],
+        )
+
+    def make_video_mp4(self):
+        return self.make_media_fixture(
+            ".mp4",
+            [
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=blue:s=320x568:r=30:d=1",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440:duration=1",
+                "-shortest",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "64k",
+            ],
+        )
+
+    def thread_id_by_participants(self, client, user_id):
+        thread = client.direct_thread_by_participants([user_id])
+        thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
+        if not thread_id and isinstance(client.last_json, dict):
+            last_thread = client.last_json.get("thread") or {}
+            thread_id = last_thread.get("thread_v2_id") or last_thread.get("thread_id")
+        return thread_id
+
+    def cleanup_direct_media_messages(self, thread_id, messages, clients):
+        for client, message in messages:
+            if not getattr(message, "id", None):
+                continue
+            try:
+                client.direct_message_delete(thread_id, message.id)
+            except Exception as exc:
+                print(
+                    "Direct media live cleanup direct_message_delete failed: "
+                    f"{exc.__class__.__name__} {exc}"
+                )
+        for client in clients:
+            try:
+                client.direct_thread_hide(thread_id)
+            except Exception as exc:
+                print(
+                    "Direct media live cleanup direct_thread_hide failed: "
+                    f"{exc.__class__.__name__} {exc}"
+                )
+
+    def test_direct_send_voice_and_video_with_thread_and_user_ids(self):
+        sender = self.cl
+        recipient = self.fresh_accounts(1, exclude_user_ids={sender.user_id})[0]
+        voice_path = self.make_voice_m4a()
+        video_path = self.make_video_mp4()
+        sent_messages = []
+        thread_id = None
+
+        try:
+            seed_message = sender.direct_send(
+                f"instagrapi direct media live warm {int(time.time())}",
+                user_ids=[recipient.user_id],
+            )
+            self.assertIsInstance(seed_message, DirectMessage)
+            sent_messages.append((sender, seed_message))
+
+            thread_id = seed_message.thread_id or self.thread_id_by_participants(
+                sender, recipient.user_id
+            )
+            self.assertTrue(thread_id)
+
+            reply_message = recipient.direct_send(
+                f"instagrapi direct media live reply {int(time.time())}",
+                user_ids=[sender.user_id],
+            )
+            self.assertIsInstance(reply_message, DirectMessage)
+            sent_messages.append((recipient, reply_message))
+
+            thread_voice = sender.direct_send_voice(voice_path, thread_ids=[thread_id])
+            self.assertIsInstance(thread_voice, DirectMessage)
+            self.assertTrue(thread_voice.id)
+            sent_messages.append((sender, thread_voice))
+
+            user_voice = sender.direct_send_voice(
+                voice_path, user_ids=[recipient.user_id]
+            )
+            self.assertIsInstance(user_voice, DirectMessage)
+            self.assertTrue(user_voice.id)
+            sent_messages.append((sender, user_voice))
+
+            thread_video = sender.direct_send_video(video_path, thread_ids=[thread_id])
+            self.assertIsInstance(thread_video, DirectMessage)
+            self.assertTrue(thread_video.id)
+            sent_messages.append((sender, thread_video))
+
+            user_video = sender.direct_send_video(
+                video_path, user_ids=[recipient.user_id]
+            )
+            self.assertIsInstance(user_video, DirectMessage)
+            self.assertTrue(user_video.id)
+            sent_messages.append((sender, user_video))
+        finally:
+            if thread_id:
+                self.cleanup_direct_media_messages(
+                    thread_id, sent_messages, [sender, recipient]
+                )
+
+
 class ClientDirectMessageTypesTestCase(ClientPrivateTestCase):
     """Test that DirectMessage and DirectThread fields use structured Pydantic models instead of raw dictionaries"""
 
@@ -3587,38 +3748,268 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         client.last_json = {}
         return client
 
-    def test_direct_send_video_uses_direct_story_flow_for_thread_ids(self):
+    def make_temp_file(self, suffix, content):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(content)
+            path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
+    def make_video_file(self, content=b"video-bytes"):
+        return self.make_temp_file(".mp4", content)
+
+    def make_voice_file(self, content=b"voice-bytes"):
+        return self.make_temp_file(".m4a", content)
+
+    def direct_payload(self):
+        return {
+            "payload": {
+                "item_id": "1",
+                "timestamp": 1761953663000000,
+                "user_id": "1",
+            }
+        }
+
+    def fake_rupload_session(self, media_id):
+        class FakeResponse:
+            status_code = 200
+            text = "{}"
+
+            def __init__(self, payload):
+                self.payload = payload
+
+            def json(self):
+                return self.payload
+
+        class FakeSession:
+            def __init__(self):
+                self.proxies = {}
+                self.calls = []
+
+            def get(self, url, headers, timeout):
+                self.calls.append(("GET", url, headers, None))
+                return FakeResponse({"offset": 0})
+
+            def post(self, url, data, headers, timeout):
+                self.calls.append(("POST", url, headers, data))
+                return FakeResponse({"media_id": media_id})
+
+        return FakeSession()
+
+    def test_direct_send_video_uploads_and_broadcasts_for_thread_ids(self):
         client = self.build_client()
         expected = Mock(spec=DirectMessage)
+        path = self.make_video_file()
 
-        with mock.patch.object(
-            client, "video_upload_to_direct", return_value=expected
-        ) as video_upload:
-            result = client.direct_send_video("clip.mp4", thread_ids=[123])
+        with (
+            mock.patch("instagrapi.mixins.direct.time.time", return_value=1234.567),
+            mock.patch(
+                "instagrapi.mixins.direct.secrets.token_hex", return_value="a" * 32
+            ),
+            mock.patch(
+                "instagrapi.mixins.direct.random.randint", return_value=111111111111
+            ),
+            mock.patch.object(
+                client, "_video_rupload", return_value=987654321
+            ) as rupload,
+            mock.patch.object(
+                client, "generate_mutation_token", return_value="mutation-token"
+            ),
+            mock.patch(
+                "instagrapi.mixins.direct.extract_direct_message", return_value=expected
+            ),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload()
+            ) as private,
+        ):
+            result = client.direct_send_video(path, thread_ids=[123])
 
         self.assertIs(result, expected)
-        video_upload.assert_called_once_with(Path("clip.mp4"), thread_ids=[123])
+        rupload.assert_called_once_with(
+            b"video-bytes",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-0-11-1234567-1234567",
+            "111111111111_AAAAAAAAAAAA_Mixed_0",
+        )
+        private.assert_called_once_with(
+            "direct_v2/threads/broadcast/raven_attachment/?video=1",
+            data=mock.ANY,
+            with_signature=True,
+        )
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), ["123"])
+        self.assertEqual(data["recipient_users"], "[]")
+        self.assertEqual(data["attachment_fbid"], "987654321")
+        self.assertEqual(data["video_result"], "987654321")
+        self.assertEqual(data["client_context"], "mutation-token")
+        self.assertEqual(data["mutation_token"], "mutation-token")
 
     def test_direct_send_video_resolves_existing_thread_for_user_ids(self):
         client = self.build_client()
         expected = Mock(spec=DirectMessage)
+        path = self.make_video_file()
+        thread_id = "340282366841710300949128149448121770626"
 
-        with mock.patch.object(
-            client,
-            "direct_thread_by_participants",
-            return_value={"thread_v2_id": "340282366841710300949128149448121770626"},
-        ) as thread_lookup:
-            with mock.patch.object(
-                client, "video_upload_to_direct", return_value=expected
-            ) as video_upload:
-                result = client.direct_send_video("clip.mp4", user_ids=[42])
+        with (
+            mock.patch.object(
+                client,
+                "direct_thread_by_participants",
+                return_value={"thread_v2_id": thread_id},
+            ) as thread_lookup,
+            mock.patch.object(client, "_video_rupload", return_value=123),
+            mock.patch.object(
+                client, "generate_mutation_token", return_value="mutation-token"
+            ),
+            mock.patch(
+                "instagrapi.mixins.direct.extract_direct_message", return_value=expected
+            ),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload()
+            ) as private,
+        ):
+            result = client.direct_send_video(path, user_ids=[42])
 
         self.assertIs(result, expected)
         thread_lookup.assert_called_once_with([42])
-        video_upload.assert_called_once_with(
-            Path("clip.mp4"),
-            thread_ids=[340282366841710300949128149448121770626],
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [thread_id])
+
+    def test_direct_send_video_resolves_existing_thread_from_last_json(self):
+        client = self.build_client()
+        expected = Mock(spec=DirectMessage)
+        path = self.make_video_file()
+        thread_id = "340282366841710300949128149448121770626"
+
+        def thread_lookup(user_ids):
+            client.last_json = {"thread": {"thread_v2_id": thread_id}}
+            return {"users": []}
+
+        with (
+            mock.patch.object(
+                client, "direct_thread_by_participants", side_effect=thread_lookup
+            ) as lookup,
+            mock.patch.object(client, "_video_rupload", return_value=123),
+            mock.patch.object(
+                client, "generate_mutation_token", return_value="mutation-token"
+            ),
+            mock.patch(
+                "instagrapi.mixins.direct.extract_direct_message", return_value=expected
+            ),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload()
+            ) as private,
+        ):
+            result = client.direct_send_video(path, user_ids=[42])
+
+        self.assertIs(result, expected)
+        lookup.assert_called_once_with([42])
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [thread_id])
+
+    def test_direct_send_voice_uploads_and_broadcasts_for_thread_ids(self):
+        client = self.build_client()
+        expected = Mock(spec=DirectMessage)
+        path = self.make_voice_file()
+
+        with (
+            mock.patch("instagrapi.mixins.direct.time.time", return_value=1234.567),
+            mock.patch("instagrapi.mixins.direct.random.randint", return_value=-99),
+            mock.patch.object(
+                client, "_voice_rupload", return_value=987654321
+            ) as rupload,
+            mock.patch.object(
+                client, "generate_mutation_token", return_value="mutation-token"
+            ),
+            mock.patch(
+                "instagrapi.mixins.direct.extract_direct_message", return_value=expected
+            ),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload()
+            ) as private,
+        ):
+            result = client.direct_send_voice(
+                path, thread_ids=[123], waveform=[0.1, 0.2]
+            )
+
+        self.assertIs(result, expected)
+        rupload.assert_called_once_with(b"voice-bytes", "1234567", -99)
+        private.assert_called_once_with(
+            "direct_v2/threads/broadcast/voice_attachment/",
+            data=mock.ANY,
+            with_signature=False,
         )
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [123])
+        self.assertEqual(data["attachment_fbid"], "987654321")
+        self.assertEqual(data["client_context"], "mutation-token")
+        self.assertEqual(data["mutation_token"], "mutation-token")
+        self.assertEqual(data["offline_threading_id"], "mutation-token")
+        self.assertEqual(data["upload_id"], "1234567")
+        self.assertEqual(json.loads(data["waveform"]), [0.1, 0.2])
+        self.assertEqual(data["waveform_sampling_frequency_hz"], "10")
+
+    def test_direct_send_voice_resolves_existing_thread_for_user_ids(self):
+        client = self.build_client()
+        expected = Mock(spec=DirectMessage)
+        path = self.make_voice_file()
+        thread_id = "340282366841710300949128149448121770626"
+
+        with (
+            mock.patch.object(
+                client,
+                "direct_thread_by_participants",
+                return_value={"thread_v2_id": thread_id},
+            ) as thread_lookup,
+            mock.patch.object(client, "_voice_rupload", return_value=123),
+            mock.patch.object(
+                client, "generate_mutation_token", return_value="mutation-token"
+            ),
+            mock.patch(
+                "instagrapi.mixins.direct.extract_direct_message", return_value=expected
+            ),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload()
+            ) as private,
+        ):
+            result = client.direct_send_voice(path, user_ids=[42], waveform=[0.3])
+
+        self.assertIs(result, expected)
+        thread_lookup.assert_called_once_with([42])
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [int(thread_id)])
+        self.assertEqual(data["attachment_fbid"], "123")
+        self.assertEqual(json.loads(data["waveform"]), [0.3])
+
+    def test_direct_send_voice_resolves_existing_thread_from_last_json(self):
+        client = self.build_client()
+        expected = Mock(spec=DirectMessage)
+        path = self.make_voice_file()
+        thread_id = "340282366841710300949128149448121770626"
+
+        def thread_lookup(user_ids):
+            client.last_json = {"thread": {"thread_v2_id": thread_id}}
+            return {"users": []}
+
+        with (
+            mock.patch.object(
+                client, "direct_thread_by_participants", side_effect=thread_lookup
+            ) as lookup,
+            mock.patch.object(client, "_voice_rupload", return_value=123),
+            mock.patch.object(
+                client, "generate_mutation_token", return_value="mutation-token"
+            ),
+            mock.patch(
+                "instagrapi.mixins.direct.extract_direct_message", return_value=expected
+            ),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload()
+            ) as private,
+        ):
+            result = client.direct_send_voice(path, user_ids=[42], waveform=[0.3])
+
+        self.assertIs(result, expected)
+        lookup.assert_called_once_with([42])
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [int(thread_id)])
 
     def test_direct_send_video_raises_when_existing_thread_is_missing(self):
         client = self.build_client()
@@ -3626,12 +4017,58 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         with mock.patch.object(
             client, "direct_thread_by_participants", return_value={}
         ) as thread_lookup:
-            with mock.patch.object(client, "video_upload_to_direct") as video_upload:
+            with mock.patch.object(client, "_video_rupload") as rupload:
                 with self.assertRaises(DirectThreadNotFound):
                     client.direct_send_video("clip.mp4", user_ids=[42])
 
         thread_lookup.assert_called_once_with([42])
-        video_upload.assert_not_called()
+        rupload.assert_not_called()
+
+    def test_direct_send_voice_raises_when_existing_thread_is_missing(self):
+        client = self.build_client()
+        path = self.make_voice_file()
+
+        with mock.patch.object(
+            client, "direct_thread_by_participants", return_value={}
+        ) as thread_lookup:
+            with mock.patch.object(client, "_voice_rupload") as rupload:
+                with self.assertRaises(DirectThreadNotFound):
+                    client.direct_send_voice(path, user_ids=[42])
+
+        thread_lookup.assert_called_once_with([42])
+        rupload.assert_not_called()
+
+    def test_video_rupload_uses_client_authorization_fallback(self):
+        client = self.build_client()
+        client.authorization_data = {"ds_user_id": "123", "sessionid": "raw-session"}
+        client.private.headers.pop("Authorization", None)
+        session = self.fake_rupload_session(media_id=987654321)
+
+        with mock.patch("requests.Session", return_value=session):
+            media_id = client._video_rupload(
+                b"video-bytes", "entity-name", "waterfall-id"
+            )
+
+        self.assertEqual(media_id, 987654321)
+        self.assertEqual(session.calls[0][2]["authorization"], client.authorization)
+        self.assertNotEqual(
+            session.calls[0][2]["authorization"], "Bearer IGT:2:raw-session"
+        )
+
+    def test_voice_rupload_uses_client_authorization_fallback(self):
+        client = self.build_client()
+        client.authorization_data = {"ds_user_id": "123", "sessionid": "raw-session"}
+        client.private.headers.pop("Authorization", None)
+        session = self.fake_rupload_session(media_id=987654321)
+
+        with mock.patch("requests.Session", return_value=session):
+            media_id = client._voice_rupload(b"voice-bytes", "1234567", -99)
+
+        self.assertEqual(media_id, 987654321)
+        self.assertEqual(session.calls[0][2]["authorization"], client.authorization)
+        self.assertNotEqual(
+            session.calls[0][2]["authorization"], "Bearer IGT:2:raw-session"
+        )
 
 
 class UserMixinRegressionTestCase(unittest.TestCase):


### PR DESCRIPTION
Closes #2447 — `instagrapi` can now send both voice AND video DMs.

## Summary

Two related changes captured from the live IG Android app via mitmproxy:

1. **`direct_send_voice(path, user_ids, thread_ids, waveform=None)`** — new helper, mirrors `direct_send_video()` style. m4a/AAC audio.
2. **`direct_send_video()`** — rewritten to use the new `raven_attachment/?video=1` endpoint. The maintainer's open question on #2447 yesterday was *exactly* what the new endpoint is; this is the answer captured live.

Both go through the same general 3-step protocol via `rupload.facebook.com`:

- **Voice**: `messenger_audio/{upload_id}_0_{key}` (resumable GET-then-POST) → `direct_v2/threads/broadcast/voice_attachment/`
- **Video**: `messenger_video/{32hex}-{seg}-{size}-{ms}-{ms}` (resumable GET-then-POST) → `direct_v2/threads/broadcast/raven_attachment/?video=1` (signed body)

Both live-verified end-to-end (`GET 200` → `POST 200` with `media_id` → broadcast `status: "ok"`).

## Why direct_send_video needed rewriting

instagrapi 2.5.11 had **three** broken paths for direct video:

- `direct_send_video()` misread `thread_v2_id` nesting (response is `{"thread": {"thread_v2_id": ...}}`)
- `video_upload_to_direct()` routes to `media/configure_to_story/?video=1` which 500s — that's the **story** endpoint, not direct
- `direct_send_file(content_type="video")` hits the retired `direct_v2/threads/broadcast/configure_video/` endpoint with `"This feature is no longer supported"`

The new path follows what the IG Android client itself does today (capture from 2026-05-06).

## Capture method (for reproducibility)

The mobile app's FB-domain calls (`rupload.facebook.com/messenger_audio`, `messenger_video`) enforce TLS pinning at the **native mbedtls layer** inside `libstartup.so` — neither HTTP Toolkit's bundled bypass nor `frida-multiple-unpinning` cover it. Worked around with a 4-byte static patch at vaddr `0x3d3b2c` (changed `cbz w0, #0x3d3b88` → `b #0x3d3b88`), inside the mbedtls handshake state machine right after the X.509 verify call. Pulled with `adb pull`, patched in pure Python with `capstone` + `pyelftools`, pushed back. Then mitmproxy capture worked normally.

## Key implementation gotchas (both endpoints)

- **Use a fresh `requests.Session`** for the FB-domain calls. `self.private` pins ~30 IG-mobile-only headers (`X-IG-*`, `X-Bloks-*`, `X-Pigeon-*`, plus `Host: i.instagram.com` and `Content-Type: application/x-www-form-urlencoded`). Requests merges those with per-call headers, so they leak through and FB rupload returns a generic 404 (`"We're sorry, but something went wrong"`). Only the captured allow-list works.
- **`audio_type: FILE_ATTACHMENT`** for voice / **`video_type: FILE_ATTACHMENT`** for video — required, captured request had it, omitting it 404s.
- **Voice broadcast body is plain URL-encoded** (`with_signature=False`); **video broadcast body is signed** (`with_signature=True` → `signed_body=SIGNATURE.{json}`). Different formats per endpoint.
- **Audio format**: AAC in MP4 container (`.m4a`); rejected at upload_finish otherwise.
- **Video format**: H.264 in MP4 container (`.mp4`); `x-entity-type: video/mp4` is fixed.
- **Waveform is UI-cosmetic only** for voice — server doesn't validate amplitudes; defaults to random in `[0.2, 0.95]`.
- **`x-meta-zca`** (Play Integrity attestation) and **`x-meta-usdid`** (signed device id) are NOT strictly required. The captured request from the official client included them, but the server accepts uploads without them — they appear to be risk-scoring inputs, not auth gates. So no need to forge keystore signatures from a Python server.

## Live verification

| Endpoint | Verified |
|---|---|
| `direct_send_voice(path, thread_ids=[...])` | ✅ status=ok, msg_id returned |
| `direct_send_voice(path, user_ids=[...])` | ✅ thread resolved via `direct_thread_by_participants` |
| `direct_send_video(path, thread_ids=[...])` | ✅ status=ok, msg_id returned, video plays in recipient's IG |
| `direct_send_video(path, user_ids=[...])` | ✅ thread resolved like above |
| Bad audio container (e.g. ogg) | ✅ server returns clean error at upload step |
| Existing thread missing | ✅ raises `DirectThreadNotFound` (matching `direct_send_video` behavior) |

## Test plan for reviewers

```python
from instagrapi import Client
cl = Client()
cl.login(USERNAME, PASSWORD)

# voice
cl.direct_send_voice("voice.m4a", user_ids=[recipient_pk])  # or thread_ids=[...]

# video
cl.direct_send_video("clip.mp4", user_ids=[recipient_pk])   # or thread_ids=[...]
```

Both return `DirectMessage` with `item_id`, `msg_id`, `thread_id` populated.

## Notes for reviewers

- Two commits, additive change. Existing methods touched: `direct_send_video()` body replaced (signature unchanged). All other methods untouched.
- Imports added to `instagrapi/mixins/direct.py`: `secrets`, `uuid` (and `ClientError` from `instagrapi.exceptions`).
- Uses `requests` (already a dep).
- Uses `self.user_id`, `self.uuid`, `self.android_device_id`, `self.user_agent`, `self.private.headers`, `self.authorization_data`, `self.generate_mutation_token()` — same surface as existing helpers.
- ffprobe is used best-effort for video dimensions/duration; absent ffprobe, sane defaults are used.
- Doc updated in `docs/usage-guide/direct.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)