### PR TITLE
docs: link instagrapi.com guides and compare pages from README and PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Anonymous/public web paths are best treated as opportunistic rather than guarant
 
 ## Documentation And Support
 
+API reference and full usage guide live at [subzeroid.github.io/instagrapi](https://subzeroid.github.io/instagrapi/):
+
 * [Documentation index](https://subzeroid.github.io/instagrapi/)
 * [Getting Started](https://subzeroid.github.io/instagrapi/getting-started.html)
 * [Usage Guide](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html)
@@ -156,6 +158,26 @@ Anonymous/public web paths are best treated as opportunistic rather than guarant
 * Support chat in Telegram: https://t.me/aiograpi_support — the previous `@instagrapi` group was restricted by Meta and is no longer maintained
 
 For other languages, consider [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest). For async Python, see [aiograpi](https://github.com/subzeroid/aiograpi).
+
+## Tutorials
+
+Hands-on guides for real instagrapi work — login flows, sessions, proxies, scraping, posting, error handling — live at [instagrapi.com/guides](https://instagrapi.com/guides/):
+
+* [Instagram Private API in Python](https://instagrapi.com/guides/instagram-private-api-python/) — pillar walkthrough: login, sessions, fetching, posting
+* [2FA and `challenge_required`](https://instagrapi.com/guides/instagrapi-2fa-challenge/)
+* [Session persistence: file, Redis, and Postgres patterns](https://instagrapi.com/guides/instagrapi-session-persistence/)
+* [Configuring proxies (HTTP, SOCKS5, residential)](https://instagrapi.com/guides/instagrapi-proxy-setup/)
+* [Instagram scraper in Python: a working setup](https://instagrapi.com/guides/instagram-scraper-python/)
+* [Upload a photo from Python](https://instagrapi.com/guides/instagrapi-upload-photo-python/)
+* [Download Instagram stories](https://instagrapi.com/guides/instagrapi-download-stories-python/)
+* [Common errors reference](https://instagrapi.com/guides/errors/) — `challenge_required`, `login_required`, `please_wait_a_few_minutes`, `feedback_required`, `proxy_address_is_blocked`
+* [Framework integrations](https://instagrapi.com/guides/integrations/) — Django, FastAPI, Celery, Docker, AWS Lambda
+
+Comparing instagrapi to other tools:
+
+* [instagrapi vs Instaloader](https://instagrapi.com/compare/instaloader/) — download-only vs authenticated automation
+* [instagrapi vs aiograpi](https://instagrapi.com/guides/instagrapi-vs-aiograpi/) — sync or async
+* [Instagram API libraries by language](https://instagrapi.com/guides/instagram-api-libraries-by-language/) — what's actually maintained in 2026
 
 
 <details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/subzeroid/instagrapi"
+Homepage = "https://instagrapi.com"
 Repository = "https://github.com/subzeroid/instagrapi"
+Documentation = "https://subzeroid.github.io/instagrapi/"
+Issues = "https://github.com/subzeroid/instagrapi/issues"
+Guides = "https://instagrapi.com/guides/"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
## Why

`instagrapi.com` (the OSS brand site) shipped 2026-04-29 with 33 pages of hands-on guides, error references, framework integrations, and comparison pages. Until now, the GitHub README and PyPI sidebar pointed users only at GitHub itself and the github.io API reference — none of the topical content that answers common pain points (challenge_required, session persistence, proxy setup) was discoverable from the two highest-traffic surfaces of the OSS project.

This PR adds those cross-links. Two effects:
1. PyPI / GitHub readers get sent directly to the guide that solves their problem (better UX).
2. Two high-authority backlinks (PyPI + GitHub README, both dofollow) point at the young instagrapi.com site, which materially helps it rank for the commercial Python-Instagram queries the project depends on.

## Changes

### `pyproject.toml`

`[project.urls]` expanded from 2 slots to 5:

| Label | URL |
|---|---|
| Homepage | `https://instagrapi.com` (was `github.com/subzeroid/instagrapi`) |
| Repository | `https://github.com/subzeroid/instagrapi` (unchanged) |
| Documentation | `https://subzeroid.github.io/instagrapi/` (NEW — API reference) |
| Issues | `https://github.com/subzeroid/instagrapi/issues` (NEW) |
| Guides | `https://instagrapi.com/guides/` (NEW — hands-on tutorials) |

Homepage moved to the brand site since that's the polished landing for new users; GitHub stays as Repository.

### `README.md`

New `## Tutorials` section between `## Documentation And Support` and `## Ecosystem And Hosted Options`, with 12 links to instagrapi.com guides + comparison pages:

- Pillar: Instagram Private API in Python
- Common pain: 2FA & challenge_required, session persistence, proxy setup
- Use cases: scraper, upload, download stories
- Reference: errors hub, framework integrations
- Comparisons: vs Instaloader, vs aiograpi, libraries by language

The existing `## Documentation And Support` section (subzeroid.github.io API reference) is preserved and unchanged in substance — only an intro line added pointing readers to the github.io reference.

## Verification

- `flake8 instagrapi --select=E9,F63,F7,F82` clean
- `isort --check-only instagrapi` clean
- `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` parses
- All 13 instagrapi.com URLs in README verified to resolve in `dist/` of the live site

## Release

This is a docs-and-metadata change. Per repo convention:
- README.md and pyproject.toml are user-facing (PyPI sidebar shows them)
- Suggest a patch bump (2.5.12 → 2.5.13) on squash-merge → tag → auto-publish