### PR TITLE
Add direct thread title update

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -11,6 +11,7 @@
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
 | direct_thread_by_participants(user_ids: List[int])                        | DirectThread            | Get thread by user_id
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
+| direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a group thread title
 | direct_media_share(media_id: str, user_ids: List[int])                    | DirectMessage           | Share a media to list of users
 | direct_story_share(story_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage       | Share a story to list of users
 | direct_profile_share(user_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage      | Share a user profile to list of users
@@ -90,6 +91,9 @@ DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028
 
 >>> cl.direct_thread_by_participants([cl.user_id])
 DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[DirectMessage(id=30076214123123123123123864, user_id=1903424587, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 49, 107154, ...)
+
+>>> cl.direct_thread_update_title(thread.id, "New group title")
+True
 
 >>> cl.direct_media_share(media.pk, user_ids=[cl.user_id])
 DirectMessage(id=3007629312312312312312300374016, user_id=None, thread_id=340282366812313212334410641298762, timestamp=datetime.datetime(2021, 8, 31, 19, 45, 20, 708276, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1297,6 +1297,31 @@ class DirectMixin:
         )
         return result.get("status", "") == "ok"
 
+    def direct_thread_update_title(self, thread_id: int, title: str) -> bool:
+        """
+        Update a direct thread title
+
+        Parameters
+        ----------
+        thread_id: int
+            ID of thread to update
+        title: str
+            New thread title
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        assert self.user_id, "Login required"
+
+        result = self.private_request(
+            f"direct_v2/threads/{thread_id}/update_title/",
+            data={"_uuid": self.uuid, "title": title},
+            with_signature=False,
+        )
+        return result.get("status", "") == "ok"
+
     def direct_media_share(
         self,
         media_id: str,

--- a/tests.py
+++ b/tests.py
@@ -79,7 +79,7 @@ from instagrapi.types import (
     UserShort,
     Usertag,
 )
-from instagrapi.utils import gen_password, generate_jazoest
+from instagrapi.utils import dumps, gen_password, generate_jazoest
 from instagrapi.zones import UTC
 
 logger = logging.getLogger("instagrapi.tests")
@@ -3583,6 +3583,57 @@ class ClientDirectMediaLiveTestCase(ClientPrivateTestCase):
                 )
 
 
+class ClientDirectThreadLiveTestCase(ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        self.recipient_clients = []
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for direct thread live tests")
+        accounts = self.fresh_accounts(3)
+        self.cl = accounts[0]
+        self.recipient_clients = accounts[1:]
+
+    def test_direct_thread_update_title_live(self):
+        initial_title = f"instagrapi-title-{int(time.time())}"
+        updated_title = f"{initial_title}-updated"
+        token = self.cl.generate_mutation_token()
+        thread_id = None
+
+        try:
+            created = self.cl.private_request(
+                "direct_v2/create_group_thread/",
+                data={
+                    "_uuid": self.cl.uuid,
+                    "_uid": self.cl.user_id,
+                    "client_context": token,
+                    "is_partnership_folder": "false",
+                    "recipient_users": dumps(
+                        [int(client.user_id) for client in self.recipient_clients]
+                    ),
+                    "thread_title": initial_title,
+                },
+            )
+            thread_id = created.get("thread_id") or created.get("thread", {}).get(
+                "thread_id"
+            )
+            self.assertTrue(thread_id)
+
+            self.assertTrue(
+                self.cl.direct_thread_update_title(thread_id, updated_title)
+            )
+            thread = self.cl.direct_thread(thread_id, amount=1)
+            self.assertEqual(thread.thread_title, updated_title)
+        finally:
+            if thread_id:
+                try:
+                    self.cl.direct_thread_hide(thread_id)
+                except Exception as exc:
+                    logger.warning("Direct thread cleanup failed: %s", exc)
+
+
 class ClientDirectMessageTypesTestCase(ClientPrivateTestCase):
     """Test that DirectMessage and DirectThread fields use structured Pydantic models instead of raw dictionaries"""
 
@@ -3970,6 +4021,22 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         client.authorization_data = {"ds_user_id": "1"}
         client.last_json = {}
         return client
+
+    def test_direct_thread_update_title_posts_unsigned_title(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(
+            client, "private_request", return_value={"status": "ok"}
+        ) as private:
+            result = client.direct_thread_update_title(123, "Updated title")
+
+        self.assertTrue(result)
+        private.assert_called_once_with(
+            "direct_v2/threads/123/update_title/",
+            data={"_uuid": "uuid-1", "title": "Updated title"},
+            with_signature=False,
+        )
 
     def make_temp_file(self, suffix, content):
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:


### PR DESCRIPTION
Adds a high-level `direct_thread_update_title(thread_id, title)` helper for updating group direct thread titles.\n\nIssue: https://github.com/subzeroid/instagrapi/issues/2427\n\nVerification:\n- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m unittest tests.DirectMixinRegressionTestCase`\n- live: `tests.ClientDirectThreadLiveTestCase.test_direct_thread_update_title_live`