### PR TITLE
Add Reel Facebook share config helper

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -83,6 +83,17 @@ class UploadClipMixin:
     Helpers to upload CLIP videos
     """
 
+    def clip_share_to_fb_config(self) -> Dict:
+        """
+        Get Reel Facebook sharing configuration for the current user.
+
+        Returns
+        -------
+        Dict
+            A dictionary of response from the call
+        """
+        return self.private_request("clips/user/share_to_fb_config/")
+
     def clip_upload(
         self,
         path: Path,

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -5,7 +5,7 @@ import random
 import tempfile
 import time
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 from uuid import uuid4
 
 from instagrapi import config
@@ -83,16 +83,39 @@ class UploadClipMixin:
     Helpers to upload CLIP videos
     """
 
-    def clip_share_to_fb_config(self) -> Dict:
+    def clip_share_to_fb_config(
+        self, device_status: Optional[Dict[str, object]] = None
+    ) -> Dict:
         """
         Get Reel Facebook sharing configuration for the current user.
+
+        Parameters
+        ----------
+        device_status: Dict[str, object], optional
+            Device video capability status sent by the Instagram Android app.
 
         Returns
         -------
         Dict
             A dictionary of response from the call
         """
-        return self.private_request("clips/user/share_to_fb_config/")
+        device_status = device_status or {
+            "hw_av1_dec": False,
+            "hw_vp9_dec": False,
+            "hw_avc_dec": False,
+            "10bit_hw_av1_dec": False,
+            "10bit_hw_vp9_dec": False,
+            "is_hlg_supported": False,
+            "chip_vendor": "others",
+            "chip_name": "unknown",
+            "core_count": 0,
+            "max_ghz_sum": 0,
+            "min_ghz_sum": 0,
+        }
+        return self.private_request(
+            "clips/user/share_to_fb_config/",
+            params={"device_status": json.dumps(device_status)},
+        )
 
     def clip_upload(
         self,

--- a/tests.py
+++ b/tests.py
@@ -5124,6 +5124,18 @@ class UploadRegressionTestCase(unittest.TestCase):
             }
         return payload
 
+    def test_clip_share_to_fb_config_requests_reel_facebook_config(self):
+        client = self.build_client()
+        expected = {"status": "ok", "eligible": True}
+
+        with mock.patch.object(
+            client, "private_request", return_value=expected
+        ) as private_request:
+            result = client.clip_share_to_fb_config()
+
+        private_request.assert_called_once_with("clips/user/share_to_fb_config/")
+        self.assertEqual(result, expected)
+
     def test_photo_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 

--- a/tests.py
+++ b/tests.py
@@ -5133,7 +5133,13 @@ class UploadRegressionTestCase(unittest.TestCase):
         ) as private_request:
             result = client.clip_share_to_fb_config()
 
-        private_request.assert_called_once_with("clips/user/share_to_fb_config/")
+        private_request.assert_called_once()
+        endpoint = private_request.call_args.args[0]
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(endpoint, "clips/user/share_to_fb_config/")
+        device_status = json.loads(params["device_status"])
+        self.assertEqual(device_status["chip_vendor"], "others")
+        self.assertFalse(device_status["hw_av1_dec"])
         self.assertEqual(result, expected)
 
     def test_photo_upload_raises_clear_error_when_configure_has_no_media(self):


### PR DESCRIPTION
## Summary
- add `clip_share_to_fb_config()` for the Reel Facebook sharing config endpoint observed in the Android 428 HAR
- send the observed `device_status` query parameter with a conservative default payload
- cover the helper with a mock regression test

Related: https://github.com/subzeroid/instagrapi/issues/2416
Commits:
- https://github.com/subzeroid/instagrapi/commit/08f2c449a50df34e406b037b9918700f16afe3a2
- https://github.com/subzeroid/instagrapi/commit/50c0f48f6f447dc7a30e9b0b1ab71b49c3b0315c

## Tests
- `.venv/bin/python -m unittest tests.UploadRegressionTestCase.test_clip_share_to_fb_config_requests_reel_facebook_config`
- `.venv/bin/python -m unittest tests.UploadRegressionTestCase`