### PR TITLE
Update Reel upload rupload flow

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -1,7 +1,6 @@
 import contextlib
 import json
 import os
-import random
 import tempfile
 import time
 from pathlib import Path
@@ -160,26 +159,115 @@ class UploadClipMixin:
             thumbnail = Path(thumbnail)
         upload_id = str(int(time.time() * 1000))
         thumbnail, width, height, duration = analyze_video(path, thumbnail)
-        waterfall_id = str(uuid4())
-        # upload_name example: '1576102477530_0_7823256191'
-        upload_name = "{upload_id}_0_{rand}".format(
-            upload_id=upload_id, rand=random.randint(1000000000, 9999999999)
+        with open(path, "rb") as fp:
+            clip_data = fp.read()
+            clip_len = str(len(clip_data))
+        duration_ms = str(int(duration * 1000))
+        composer_session_id = str(uuid4())
+        asset_id = uuid4().hex[:12].upper()
+        target_id = self.user_id or getattr(self, "_user_id", None)
+        upload_context = {
+            "source_attribution": None,
+            "enable_video_dimension_upscale": False,
+            "source_type": "clips",
+            "quality": "",
+        }
+        if target_id:
+            upload_context["target_id"] = int(target_id)
+        upload_timestamp_ms = upload_id
+        upload_name = "{upload_uuid}-0-{length}-{timestamp}-{timestamp}".format(
+            upload_uuid=uuid4().hex,
+            length=clip_len,
+            timestamp=upload_timestamp_ms,
         )
+        upload_settings = {
+            "composer_session_id": composer_session_id,
+            "upload_setting_properties": {
+                "upload_settings_version": "v0.1",
+                "codec": {},
+                "context": upload_context,
+                "video": {
+                    "video_height": height,
+                    "video_gop_size_sec": 0,
+                    "video_rotation_angle": 0,
+                    "video_width": width,
+                    "source_video_codec": None,
+                    "video_partial_frame_size_bytes": 0,
+                    "asset_id": asset_id,
+                    "video_key_frame_size_bytes": 0,
+                    "target_duration": int(duration),
+                    "video_original_file_size": int(clip_len),
+                    "video_duration_milliseconds": int(duration_ms),
+                    "audio_bit_rate_bps": -1,
+                    "video_bit_rate_bps": 0,
+                    "audio_codec_type": None,
+                    "video_fps": 30,
+                },
+                "creative_tools": {
+                    "transmuxing_eligible": False,
+                    "transcoding_required": True,
+                },
+                "network": {
+                    "download_latency_connection_quality": "ig_dummy",
+                    "network_connection_name": "ig_dummy",
+                    "download_bandwidth_connection_quality": "ig_dummy",
+                },
+            },
+            "preview_spec": {
+                "spec_version": 1,
+                "video_dur_ms": int(duration_ms),
+                "audio_dur_ms": int(duration_ms),
+            },
+        }
+        upload_settings_data = json.dumps(upload_settings)
+        upload_settings_len = str(len(upload_settings_data.encode("utf-8")))
+        headers = {
+            "Accept-Encoding": "gzip",
+            "Content-Type": "application/json",
+            "Content-Length": upload_settings_len,
+            "Offset": "0",
+            "X-Entity-Length": upload_settings_len,
+            "X-Entity-Name": "upload_settings",
+            "X-Entity-Type": "application/json",
+            "X_FB_VIDEO_WATERFALL_ID": f"{composer_session_id}_settings",
+        }
+        response = self.private.post(
+            "https://{domain}/upload_settings/{session_id}".format(
+                domain=config.API_DOMAIN,
+                session_id=composer_session_id,
+            ),
+            data=upload_settings_data,
+            headers=headers,
+        )
+        self.request_log(response)
+        if response.status_code != 200:
+            raise ClipNotUpload(response=self.last_response, **self.last_json)
         rupload_params = {
-            "is_clips_video": "1",
-            "retry_context": '{"num_reupload":0,"num_step_auto_retry":0,"num_step_manual_retry":0}',
-            "media_type": "2",
-            "xsharing_user_ids": json.dumps([self.user_id]),
-            "upload_id": upload_id,
-            "upload_media_duration_ms": str(int(duration * 1000)),
-            "upload_media_width": str(width),
+            "provenance_metadata": json.dumps({"origin": ["EXTERNAL"]}),
             "upload_media_height": str(height),
+            "share_type": "reels",
+            "debug_segment_id": "0",
+            "extract_cover_frame": "1",
+            "upload_engine_config_enum": "0",
+            "xsharing_user_ids": "[]",
+            "upload_media_width": str(width),
+            "stella_data": "{}",
+            "is_clips_video": "1",
+            "is_optimistic_upload": "true",
+            "upload_media_duration_ms": duration_ms,
+            "content_tags": "use_default_cover",
+            "upload_id": upload_id,
+            "retry_context": '{"num_reupload":0,"num_step_manual_retry":0,"num_step_auto_retry":0}',
+            "session_id": upload_id,
+            "media_type": "2",
         }
         headers = {
             "Accept-Encoding": "gzip",
             "X-Instagram-Rupload-Params": json.dumps(rupload_params),
-            "X_FB_VIDEO_WATERFALL_ID": waterfall_id,
+            "X_FB_VIDEO_WATERFALL_ID": f"{composer_session_id}_{asset_id}_Mixed_0",
             "X-Entity-Type": "video/mp4",
+            "Segment-Start-Offset": "0",
+            "Segment-Type": "3",
         }
         response = self.private.get(
             "https://{domain}/rupload_igvideo/{name}".format(
@@ -190,9 +278,6 @@ class UploadClipMixin:
         self.request_log(response)
         if response.status_code != 200:
             raise ClipNotUpload(response=self.last_response, **self.last_json)
-        with open(path, "rb") as fp:
-            clip_data = fp.read()
-            clip_len = str(len(clip_data))
         headers = {
             "Offset": "0",
             "X-Entity-Name": upload_name,

--- a/tests.py
+++ b/tests.py
@@ -5263,6 +5263,88 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertIsInstance(media, Media)
         self.assertEqual(str(media.video_url), "https://example.com/video.mp4")
 
+    def test_clip_upload_uses_current_reels_rupload_shape(self):
+        client = self.build_client()
+        client.last_json = {"media": self.build_media_payload()}
+        ok_response = Mock(status_code=200)
+
+        with mock.patch(
+            "instagrapi.mixins.clip.analyze_video",
+            return_value=(Path("/tmp/thumb.jpg"), 720, 1280, 6.023),
+        ):
+            with mock.patch("time.time", return_value=1778346423.0):
+                with mock.patch.object(
+                    client.private, "get", return_value=ok_response
+                ) as private_get:
+                    with mock.patch.object(
+                        client.private,
+                        "post",
+                        side_effect=[ok_response, ok_response],
+                    ) as private_post:
+                        with mock.patch.object(
+                            client, "clip_configure", return_value={"status": "ok"}
+                        ):
+                            with mock.patch(
+                                "builtins.open",
+                                mock.mock_open(read_data=b"video-bytes"),
+                            ):
+                                with mock.patch("time.sleep"):
+                                    client.clip_upload(Path("example.mp4"), "caption")
+
+        post_calls = private_post.call_args_list
+        self.assertEqual(len(post_calls), 2)
+        upload_settings_call, video_upload_call = post_calls
+        self.assertRegex(
+            upload_settings_call.args[0],
+            r"https://i\.instagram\.com/upload_settings/[0-9a-f-]{36}$",
+        )
+        settings_headers = upload_settings_call.kwargs["headers"]
+        self.assertEqual(settings_headers["Content-Type"], "application/json")
+        self.assertEqual(settings_headers["X-Entity-Name"], "upload_settings")
+        self.assertEqual(settings_headers["X-Entity-Type"], "application/json")
+        self.assertEqual(settings_headers["Offset"], "0")
+        self.assertEqual(
+            settings_headers["Content-Length"],
+            settings_headers["X-Entity-Length"],
+        )
+        settings_payload = json.loads(upload_settings_call.kwargs["data"])
+        self.assertEqual(
+            settings_payload["composer_session_id"],
+            upload_settings_call.args[0].rsplit("/", 1)[-1],
+        )
+        settings_properties = settings_payload["upload_setting_properties"]
+        self.assertEqual(settings_properties["context"]["source_type"], "clips")
+        self.assertEqual(settings_properties["context"]["target_id"], 1)
+        self.assertEqual(settings_properties["video"]["video_width"], 720)
+        self.assertEqual(settings_properties["video"]["video_height"], 1280)
+        self.assertEqual(settings_properties["video"]["video_original_file_size"], 11)
+        self.assertEqual(settings_payload["preview_spec"]["video_dur_ms"], 6023)
+
+        upload_url = video_upload_call.args[0]
+        upload_name = upload_url.rsplit("/", 1)[-1]
+        self.assertRegex(
+            upload_name,
+            r"^[0-9a-f]{32}-0-11-1778346423000-1778346423000$",
+        )
+        self.assertTrue(private_get.call_args.args[0].endswith(upload_name))
+
+        headers = video_upload_call.kwargs["headers"]
+        self.assertEqual(headers["Content-Type"], "application/octet-stream")
+        self.assertEqual(headers["X-Entity-Type"], "video/mp4")
+        self.assertEqual(headers["X-Entity-Length"], "11")
+        self.assertEqual(headers["X-Entity-Name"], upload_name)
+        self.assertEqual(headers["Offset"], "0")
+        self.assertEqual(headers["Segment-Start-Offset"], "0")
+        self.assertEqual(headers["Segment-Type"], "3")
+
+        rupload_params = json.loads(headers["X-Instagram-Rupload-Params"])
+        self.assertEqual(rupload_params["share_type"], "reels")
+        self.assertEqual(rupload_params["is_optimistic_upload"], "true")
+        self.assertEqual(rupload_params["content_tags"], "use_default_cover")
+        self.assertEqual(rupload_params["xsharing_user_ids"], "[]")
+        self.assertEqual(rupload_params["upload_media_duration_ms"], "6023")
+        self.assertEqual(rupload_params["session_id"], rupload_params["upload_id"])
+
     def test_video_story_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 


### PR DESCRIPTION
## Summary

- update `clip_upload` to send current Instagram Android `428.0.0.47.67` Reel `upload_settings/{composer_session_id}` before `rupload_igvideo`
- switch Reel upload names to `{uuid32}-0-{byte_length}-{timestamp_ms}-{timestamp_ms}` and send current rupload params/segment headers
- add a mock regression test for the current Reel upload request shape

## HAR

Fresh capture reviewed locally: `/Users/colinfrl/work/sub/hars_insta/428/reel_upload_428_success.har`. Notes saved to `/Users/colinfrl/work/sub/hars_insta/428/REEL_UPLOAD_2026-05-09.md`.

The HAR includes successful `POST /upload_settings/...`, `GET /rupload_igvideo/...`, and `POST /rupload_igvideo/...`. It does not include a successful final `media/configure_to_clips/?video=1`, so this PR intentionally leaves final configure payloads unchanged.

## Related issues

- https://github.com/subzeroid/instagrapi/issues/1530
- https://github.com/subzeroid/instagrapi/issues/1486
- https://github.com/subzeroid/instagrapi/issues/1464
- https://github.com/subzeroid/instagrapi/issues/813

## Tests

- `TEST_ACCOUNTS_URL= .venv/bin/python -m unittest tests.UploadRegressionTestCase`
- `.venv/bin/flake8 instagrapi/mixins/clip.py tests.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- live Reel upload check on the branch: fresh account downloaded a source clip, `clip_upload` created Reel `3893388814490255775_36914474778`, and cleanup deleted it successfully
