### PR TITLE
Refresh root project documentation

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,0 @@
-[bandit]
-exclude: *venv*,*env*,*scratch*
-skips: B101,B311,B303,B306

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
           test: "true"
 
       - name: Run bandit
-        run: bandit --ini .bandit -r instagrapi
+        run: bandit -c pyproject.toml -r instagrapi
 
   lint:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,94 +1,85 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change.
+Thanks for helping improve `instagrapi`.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Before starting a larger change, open or comment on a GitHub issue so maintainers can confirm the direction. For usage questions and support, use [GitHub Discussions](https://github.com/subzeroid/instagrapi/discussions) or the Telegram support group [aiograpi_support](https://t.me/aiograpi_support).
 
-## Pull Request Process
+Please follow the [Code of Conduct](CODE_OF_CONDUCT.md) in all project spaces.
 
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a
-   build.
-2. Add or change [unittests](/tests/) that are specific to functionality according to [Development Guide](https://subzeroid.github.io/instagrapi/development-guide.html)
-3. Add documentation about your methods and changes to [docs](/docs)
-4. Update the README.md with details of changes to the interface, this includes new environment
-   variables, exposed ports, useful file locations and container parameters.
-5. Increase the version number in [pyproject.toml](/pyproject.toml) and date of last reverse-engineering in the README.md to the new version that this
-   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-6. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
-   do not have permission to do that, you may request the second reviewer to merge it for you.
+## Development Setup
 
-## Code of Conduct
+Use a virtual environment and install the package from `pyproject.toml` with test extras:
 
-### Our Pledge
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[test]"
+pre-commit install
+```
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+If you use `uv`, keep the same `pyproject.toml` source of truth:
 
-### Our Standards
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[test]"
+pre-commit install
+```
 
-Examples of behavior that contributes to creating a positive environment
-include:
+`pipx` is useful for globally installing `pre-commit`:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+```bash
+pipx install pre-commit
+```
 
-Examples of unacceptable behavior by participants include:
+Do not use `pipx` to install `instagrapi`; it is a library package, not a command-line application.
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+## Tests and Quality Checks
 
-### Our Responsibilities
+Run these checks before opening a pull request:
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+```bash
+ruff check .
+ruff format --check .
+pytest -q tests/regression
+bandit -c pyproject.toml -r instagrapi
+mkdocs build --strict
+pre-commit run --all-files
+```
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+To apply automatic lint and formatting fixes:
 
-### Scope
+```bash
+ruff check . --fix
+ruff format .
+```
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+Regression tests live in `tests/regression/`. Live-account tests live in `tests/live/` and require `TEST_ACCOUNTS_URL`; do not run or modify live tests in a way that prints credentials, proxies, sessions, or the account URL.
 
-### Enforcement
+## Pull Request Checklist
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+1. Branch from `master` and keep the change scoped.
+2. Add or update regression tests for changed behavior.
+3. Add focused live tests when the change depends on Instagram's live API behavior.
+4. Update `README.md` or `docs/` when public APIs, setup steps, troubleshooting, or user-visible behavior changes.
+5. Keep dependencies in `pyproject.toml`; do not add root `requirements*.txt`.
+6. Keep style and linting under Ruff; do not reintroduce `.flake8`, `.isort.cfg`, or Black-only config.
+7. Do not add Docker files unless the repository intentionally restores a maintained Docker workflow.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Maintainers handle release versioning and publishing unless a maintainer asks for a version bump in the PR.
 
-### Attribution
+## Project Documentation
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+- User guide: [subzeroid.github.io/instagrapi](https://subzeroid.github.io/instagrapi/)
+- Development guide: [development-guide](https://subzeroid.github.io/instagrapi/development-guide.html)
+- Error guides and tutorials: [instagrapi.com/guides](https://instagrapi.com/guides/)
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+## Release Commands
+
+Maintainer-only release flow:
+
+```bash
+python -m build
+twine upload dist/*
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023
+Copyright (c) 2023-2026 Mark Subzeroid and instagrapi contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -251,7 +251,15 @@ Refer users to HikerAPI and earn a percentage of their API spending:
 
 [![List of contributors](https://opencollective.com/instagrapi/contributors.svg?width=890&button=0)](https://github.com/subzeroid/instagrapi/graphs/contributors)
 
-To release, you need to call the following commands:
+For local setup, tests, linting, and pull request expectations, see [CONTRIBUTING.md](CONTRIBUTING.md) and the [development guide](https://subzeroid.github.io/instagrapi/development-guide.html).
 
-    python -m build
-    twine upload dist/*
+Maintainer release commands:
+
+```bash
+python -m build
+twine upload dist/*
+```
+
+## License
+
+`instagrapi` is distributed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,17 @@
 
 ## Supported Versions
 
-Only the latest versions are supported
+Only the latest released version is supported for security fixes.
 
 | Version    | Supported          |
 | ---------- | ------------------ |
-| 1.12.x     | :white_check_mark: |
-| < 1.12.0   | :x:                |
+| Latest release | :white_check_mark: |
+| Older releases | :x:                |
 
 ## Reporting a Vulnerability
 
-Report vulnerabilities in the Telegram channel [aiograpi_support](https://t.me/aiograpi_support) or https://github.com/subzeroid/instagrapi/issues
+Do not include account credentials, session IDs, proxy credentials, or private tokens in public issues.
+
+For sensitive reports, use GitHub private vulnerability reporting if it is available for this repository. For non-sensitive security bugs, open an issue at https://github.com/subzeroid/instagrapi/issues.
+
+For urgent maintainer contact, use the Telegram support group [aiograpi_support](https://t.me/aiograpi_support).

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -60,7 +60,7 @@ You'll be unable to merge code unless linting and tests pass. The main local che
 pytest -sv tests/regression
 ruff check .
 ruff format --check .
-bandit --ini .bandit -r instagrapi
+bandit -c pyproject.toml -r instagrapi
 mkdocs build --strict
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E9", "F63", "F7", "F82", "I"]
+
+[tool.bandit]
+exclude_dirs = ["*venv*", "*env*", "*scratch*"]
+skips = ["B101", "B311", "B303", "B306"]


### PR DESCRIPTION
## Summary
- Refresh root project docs for the current pyproject/Ruff/test layout.
- Replace stale Docker, requirements, flake8, isort, and legacy security-policy guidance.
- Move Bandit configuration from `.bandit` into `pyproject.toml` and update CI/docs commands.
- Update MIT copyright notice and add a README license section.

Commit: https://github.com/subzeroid/instagrapi/commit/7695e212808613e1cdcc4923f3821472b2cdbff1

## Verification
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
- `.venv/bin/pytest -q tests/regression` -> 171 passed, 1 warning, 3 subtests passed
- `.venv/bin/bandit -c pyproject.toml -r instagrapi`
- `.venv/bin/mkdocs build --strict`
- `git diff --check && test ! -e .bandit`
