### PR TITLE
Refresh external service documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,11 @@ Fast and effective unofficial Instagram API wrapper for Python.
 
 `instagrapi` combines public web and private mobile API flows, supports session persistence and challenge handling, and covers the main automation primitives for users, media, stories, direct messages, notes, locations, comments, insights, and uploads.
 
-If you want to work with Instagrapi for business interests, prefer [HikerAPI SaaS](https://hikerapi.com/p/bkXQlaVe).
-You will not need to spend weeks or even months setting it up.
-The service handles millions of daily requests, provides round-the-clock support, and offers partners a special rate.
-In many cases, clients first try to save money with self-hosted private API automation, then return to [HikerAPI SaaS](https://hikerapi.com/p/bkXQlaVe) after spending more time and money on accounts, proxies, and challenge handling.
-It is difficult to find good accounts, good proxies, resolve challenges reliably, and keep Instagram from banning accounts.
+Private API automation is fragile in production because account trust, proxies, device state, challenges, and rate limits can change independently of the library.
+For account-owned business workflows, prefer official Instagram APIs where they cover your use case.
+For production private API infrastructure, a hosted provider such as [HikerAPI](https://hikerapi.com/) may be a better fit than maintaining accounts, proxies, and challenge handling yourself.
 
-The instagrapi project is better suited for testing and research than for running a production business.
+The instagrapi project is best suited for testing, research, and controlled internal automation.
 
 ✨ [aiograpi - Asynchronous Python library for Instagram Private API](https://github.com/subzeroid/aiograpi) ✨
 
@@ -219,33 +217,12 @@ cl.video_upload_to_story(
 ```
 </details>
 
-## Ecosystem And Hosted Options
+## Related Projects
 
 If you need async Python, use [aiograpi](https://github.com/subzeroid/aiograpi).
 
-If you need hosted infrastructure instead of maintaining accounts, proxies, and challenge handling yourself, consider:
-
-* [HikerAPI](https://hikerapi.com/p/bkXQlaVe) for production-grade hosted Instagram API infrastructure
-* [Cloqly](https://cloqly.com/register?ref=58dbf70f) for premium rotating proxies and stable automation traffic
-* [DataLikers](https://datalikers.com/p/S9Lv5vBy) for Instagram MCP, Cache API, and datasets
-* [LamaTok](https://lamatok.com/p/B9ScEYIQ) for TikTok API access, automation, and data workflows
-* [InstaSurfBot](https://t.me/InstaSurfBot) for downloading Instagram media in Telegram
-* [OSINTagramBot](https://t.me/OSINTagramBot) for Instagram OSINT in Telegram
-
-### [HikerAPI Affiliate Program](https://hikerapi.com/help/affiliate)
-
-Refer users to HikerAPI and earn a percentage of their API spending:
-
-| Plan | Commission |
-|------|------------|
-| Start trial plan ($0.02/req) | **50%** |
-| Standard ($0.001/req) | **25%** |
-| Business ($0.00069/req) | **15%** |
-| Ultra ($0.0006/req) | **10%** |
-
-**Extras:** 2-level referral system, no caps, lifetime attribution
-
-**Payouts:** USDT / USDC (TRC-20 or ERC-20), minimum 20 USDT, request anytime from the dashboard
+For other languages, see [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest).
+For hosted production Instagram API infrastructure, see [HikerAPI](https://hikerapi.com/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,29 @@ If you need async Python, use [aiograpi](https://github.com/subzeroid/aiograpi).
 For other languages, see [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest).
 For hosted production Instagram API infrastructure, see [HikerAPI](https://hikerapi.com/).
 
+Related services:
+
+* [Cloqly](https://cloqly.com/register?ref=58dbf70f) for premium rotating proxies and stable automation traffic
+* [DataLikers](https://datalikers.com/p/S9Lv5vBy) for Instagram MCP, Cache API, and datasets
+* [LamaTok](https://lamatok.com/p/B9ScEYIQ) for TikTok API access, automation, and data workflows
+* [InstaSurfBot](https://t.me/InstaSurfBot) for downloading Instagram media in Telegram
+* [OSINTagramBot](https://t.me/OSINTagramBot) for Instagram OSINT in Telegram
+
+### [HikerAPI Affiliate Program](https://hikerapi.com/help/affiliate)
+
+Refer users to HikerAPI and earn a percentage of their API spending:
+
+| Plan | Commission |
+|------|------------|
+| Start trial plan ($0.02/req) | **50%** |
+| Standard ($0.001/req) | **25%** |
+| Business ($0.00069/req) | **15%** |
+| Ultra ($0.0006/req) | **10%** |
+
+**Extras:** 2-level referral system, no caps, lifetime attribution
+
+**Payouts:** USDT / USDC (TRC-20 or ERC-20), minimum 20 USDT, request anytime from the dashboard
+
 ## Contributing
 
 [![List of contributors](https://opencollective.com/instagrapi/contributors.svg?width=890&button=0)](https://github.com/subzeroid/instagrapi/graphs/contributors)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,6 @@
     The previous `@instagrapi` Telegram group has been restricted by Meta and is no longer maintained.
     New support group: [aiograpi_support](https://t.me/aiograpi_support) — same maintainer, covers both `instagrapi` and `aiograpi`.
 
-### We recommend using our services:
-
-* [LamaTok](https://lamatok.com/p/B9ScEYIQ) for TikTok API access, automation, and data workflows 🔥
-* [HikerAPI](https://hikerapi.com/p/bkXQlaVe) for production-grade hosted Instagram API infrastructure ⚡⚡⚡
-* [DataLikers](https://datalikers.com/p/S9Lv5vBy) for Instagram MCP, Cache API, and Datasets 🚀
-* [InstaSurfBot](https://t.me/InstaSurfBot) for downloading Instagram media in Telegram
-* [OSINTagramBot](https://t.me/OSINTagramBot) for Instagram OSINT in Telegram
-
 [![Package](https://github.com/subzeroid/instagrapi/actions/workflows/python-package.yml/badge.svg?branch=master)](https://github.com/subzeroid/instagrapi/actions/workflows/python-package.yml)
 [![PyPI](https://img.shields.io/pypi/v/instagrapi)][pypi]
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/instagrapi)][pypi]
@@ -25,6 +17,8 @@ Support **Python 3.10+**
 `Python 3.9` support was dropped in `2.5.0` — pin to `instagrapi==2.4.5` if you need it.
 
 For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzeroid/instagrapi-rest/tree/main/golang), Erlang, Elixir, Nim, Haskell, Lisp, Closure, Julia, R, Java, Kotlin, Scala, OCaml, JavaScript, Crystal, Ruby, Rust, [Swift](https://github.com/subzeroid/instagrapi-rest/tree/main/swift), Objective-C, Visual Basic, .NET, Pascal, Perl, Lua, PHP and others), I suggest using [instagrapi-rest](https://github.com/subzeroid/instagrapi-rest)
+
+For hosted production Instagram API infrastructure, see [HikerAPI](https://hikerapi.com/).
 
 Support chat in Telegram: [aiograpi_support](https://t.me/aiograpi_support)
 ![](https://gist.githubusercontent.com/m8rge/4c2b36369c9f936c02ee883ca8ec89f1/raw/c03fd44ee2b63d7a2a195ff44e9bb071e87b4a40/telegram-single-path-24px.svg) and [GitHub Discussions](https://github.com/subzeroid/instagrapi/discussions)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,14 @@ For any other languages (e.g. C++, C#, F#, D, [Golang](https://github.com/subzer
 
 For hosted production Instagram API infrastructure, see [HikerAPI](https://hikerapi.com/).
 
+Related services:
+
+* [Cloqly](https://cloqly.com/register?ref=58dbf70f) for premium rotating proxies and stable automation traffic
+* [DataLikers](https://datalikers.com/p/S9Lv5vBy) for Instagram MCP, Cache API, and datasets
+* [LamaTok](https://lamatok.com/p/B9ScEYIQ) for TikTok API access, automation, and data workflows
+* [InstaSurfBot](https://t.me/InstaSurfBot) for downloading Instagram media in Telegram
+* [OSINTagramBot](https://t.me/OSINTagramBot) for Instagram OSINT in Telegram
+
 Support chat in Telegram: [aiograpi_support](https://t.me/aiograpi_support)
 ![](https://gist.githubusercontent.com/m8rge/4c2b36369c9f936c02ee883ca8ec89f1/raw/c03fd44ee2b63d7a2a195ff44e9bb071e87b4a40/telegram-single-path-24px.svg) and [GitHub Discussions](https://github.com/subzeroid/instagrapi/discussions)
 

--- a/docs/usage-guide/best-practices.md
+++ b/docs/usage-guide/best-practices.md
@@ -22,7 +22,7 @@ from instagrapi import Client
 
 cl = Client()
 before_ip = cl._send_public_request("https://api.ipify.org/")
-cl.set_proxy("http://<api_key>:wifi;ca;;;toronto@proxy.soax.com:9137")
+cl.set_proxy("http://username:password@proxy.example.com:8080")
 after_ip = cl._send_public_request("https://api.ipify.org/")
 
 print(f"Before: {before_ip}")


### PR DESCRIPTION
## Summary
- Reword README production guidance to keep HikerAPI as a neutral hosted infrastructure option.
- Keep related service links in README and docs index: Cloqly, DataLikers, LamaTok, InstaSurfBot, OSINTagramBot.
- Restore the HikerAPI Affiliate Program section in README.
- Replace the concrete proxy-provider example with `proxy.example.com`.

Commits:
- https://github.com/subzeroid/instagrapi/commit/01a3d6ad710011e4c8dea7f5dc43b4e02d36d272
- https://github.com/subzeroid/instagrapi/commit/e21b42e74c1f7ff4d9765b8f7e12b848fbc2fd11

## Verification
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/mkdocs build --strict`
- `git diff --check`
- `rg` confirmed old `We recommend using our services`, `/p/bkXQlaVe`, and `proxy.soax.com` strings are gone
