### PR TITLE
Document direct message reply support

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -7,7 +7,7 @@
 | direct_thread(thread_id: int, amount: int = 20)                           | DirectThread            | Get Thread with Messages
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread
 | direct_answer(thread_id: int, text: str)                                  | DirectMessage           | Add Message to exist Thread
-| direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = []) | DirectMessage        | Send Message to Users or Threads
+| direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = [], reply_to_message: Optional[DirectMessage] = None) | DirectMessage | Send Message to Users or Threads, optionally as a reply
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
 | direct_thread_by_participants(user_ids: List[int])                        | DirectThread            | Get thread by user_id
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
@@ -87,6 +87,9 @@ DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028
 DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028236684171031231231231233331238762, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 5, 127298, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 
 >>> cl.direct_send('How are you?', thread_ids=[thread.id])
+DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028236684171031231231231233331238762, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 5, 127298, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
+
+>>> cl.direct_send('Reply text', thread_ids=[thread.id], reply_to_message=message)
 DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028236684171031231231231233331238762, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 5, 127298, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 
 >>> cl.direct_thread_by_participants([cl.user_id])

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -401,6 +401,8 @@ class DirectMixin:
 
         send_attribute: str, optional
             Sending option. Default is "message_button"
+        reply_to_message: DirectMessage, optional
+            Message to reply to in the target thread
 
         Returns
         -------

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -45,6 +45,39 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
             }
         }
 
+    def test_direct_send_reply_includes_replied_to_fields(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+        reply_to_message = Mock(spec=DirectMessage)
+        reply_to_message.id = "30000000000000000000000000000000000"
+        reply_to_message.client_context = "reply-client-context"
+        expected = Mock(spec=DirectMessage)
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch("instagrapi.mixins.direct.extract_direct_message", return_value=expected),
+            mock.patch.object(client, "private_request", return_value=self.direct_payload()) as private,
+        ):
+            result = client.direct_send(
+                "reply text",
+                thread_ids=[123],
+                reply_to_message=reply_to_message,
+            )
+
+        self.assertIs(result, expected)
+        private.assert_called_once_with(
+            "direct_v2/threads/broadcast/text/",
+            data=mock.ANY,
+            with_signature=False,
+        )
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [123])
+        self.assertEqual(data["replied_to_action_source"], "swipe")
+        self.assertEqual(data["replied_to_item_id"], reply_to_message.id)
+        self.assertEqual(data["replied_to_client_context"], reply_to_message.client_context)
+        self.assertEqual(data["client_context"], "mutation-token")
+
     def fake_rupload_session(self, media_id):
         class FakeResponse:
             status_code = 200


### PR DESCRIPTION
## Summary
- document `direct_send(..., reply_to_message=...)` in the direct usage guide and method docstring
- add regression coverage for reply payload fields sent to `direct_v2/threads/broadcast/text/`

Related issue: https://github.com/subzeroid/instagrapi/issues/1717
Commit: https://github.com/subzeroid/instagrapi/commit/895e2f9

## Tests
- `.venv/bin/python -m unittest tests.regression.test_direct.DirectMixinRegressionTestCase`
- `.venv/bin/ruff check instagrapi/mixins/direct.py tests/regression/test_direct.py docs/usage-guide/direct.md`
