### PR TITLE
Add Reels pin helpers

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -45,6 +45,8 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_unarchive(media_id: str) | bool | Unarchive media |
 | media_pin(media_pk: str) | bool | Pin media to profile |
 | media_unpin(media_pk: str) | bool | Unpin media from profile |
+| clip_pin(media_pk: str) | bool | Pin Reel to the Reels tab/profile Reels grid |
+| clip_unpin(media_pk: str) | bool | Unpin Reel from the Reels tab/profile Reels grid |
 | media_create_livestream(title: str = "Instagram Live") | dict | Create a new livestream and return stream metadata |
 | media_start_livestream(broadcast_id: str) | dict | Start an existing livestream |
 | media_end_livestream(broadcast_id: str) | dict | End an existing livestream |

--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -11,7 +11,7 @@ from instagrapi.mixins.album import DownloadAlbumMixin, UploadAlbumMixin
 from instagrapi.mixins.auth import LoginMixin
 from instagrapi.mixins.bloks import BloksMixin
 from instagrapi.mixins.challenge import ChallengeResolveMixin
-from instagrapi.mixins.clip import DownloadClipMixin, UploadClipMixin
+from instagrapi.mixins.clip import ClipMixin, DownloadClipMixin, UploadClipMixin
 from instagrapi.mixins.collection import CollectionMixin
 from instagrapi.mixins.comment import CommentMixin
 from instagrapi.mixins.direct import DirectMixin
@@ -84,6 +84,7 @@ class Client(
     StoryMixin,
     PasswordMixin,
     SignUpMixin,
+    ClipMixin,
     DownloadClipMixin,
     UploadClipMixin,
     ReelsMixin,

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -31,6 +31,49 @@ def _make_tmp_path(suffix: str) -> str:
     return path
 
 
+class ClipMixin:
+    """
+    Helpers for CLIP/Reel actions
+    """
+
+    def clip_pin(self, media_pk: str, revert: bool = False) -> bool:
+        """
+        Pin Reel to the Reels tab/profile Reels grid
+
+        Parameters
+        ----------
+        media_pk: str
+        revert: bool, optional
+            Unpin when True
+
+        Returns
+        -------
+        bool
+        A boolean value
+        """
+        name = "unpin" if revert else "pin"
+        result = self.private_request(
+            f"users/{name}_timeline_media/",
+            data={"post_id": str(media_pk), "profile_grid": "clips"},
+        )
+        return result["status"] == "ok"
+
+    def clip_unpin(self, media_pk: str) -> bool:
+        """
+        Unpin Reel from the Reels tab/profile Reels grid
+
+        Parameters
+        ----------
+        media_pk: str
+
+        Returns
+        -------
+        bool
+        A boolean value
+        """
+        return self.clip_pin(media_pk, True)
+
+
 class DownloadClipMixin:
     """
     Helpers to download CLIP videos

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -1,0 +1,48 @@
+from tests.helpers import *
+
+
+class ClipPinRegressionTestCase(unittest.TestCase):
+    def test_clip_pin_uses_reels_grid_payload(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"status": "ok"},
+        ) as private_request:
+            result = client.clip_pin("3894040329476845448")
+
+        self.assertTrue(result)
+        private_request.assert_called_once_with(
+            "users/pin_timeline_media/",
+            data={"post_id": "3894040329476845448", "profile_grid": "clips"},
+        )
+
+    def test_clip_unpin_uses_reels_grid_payload(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"status": "ok"},
+        ) as private_request:
+            result = client.clip_unpin("3894040329476845448")
+
+        self.assertTrue(result)
+        private_request.assert_called_once_with(
+            "users/unpin_timeline_media/",
+            data={"post_id": "3894040329476845448", "profile_grid": "clips"},
+        )
+
+    def test_clip_pin_revert_unpins_reels_grid(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"status": "ok"},
+        ) as private_request:
+            result = client.clip_pin("3894040329476845448", revert=True)
+
+        self.assertTrue(result)
+        private_request.assert_called_once_with(
+            "users/unpin_timeline_media/",
+            data={"post_id": "3894040329476845448", "profile_grid": "clips"},
+        )


### PR DESCRIPTION
## Summary
- add `Client.clip_pin()` and `Client.clip_unpin()` for pinning Reels to the Reels tab/profile Reels grid
- send the Android-observed `profile_grid=clips` payload to `users/{pin,unpin}_timeline_media/`
- document the new helpers and add regression coverage for the exact private API payload

## Verification
- `.venv/bin/python -m pytest tests/regression/test_clip.py tests/regression/test_media.py`
- `.venv/bin/python -m ruff check instagrapi/__init__.py instagrapi/mixins/clip.py tests/regression/test_clip.py`
- `git diff --check HEAD~1..HEAD`

## Capture notes
Verified against Instagram Android 428 traffic with Charon/HAR. Relevant requests returned `{"status":"ok"}`:

```text
POST /api/v1/users/pin_timeline_media/
{"post_id":"<media_pk>","profile_grid":"clips"}

POST /api/v1/users/unpin_timeline_media/
{"post_id":"<media_pk>","profile_grid":"clips"}
```

The same `profile_grid=clips` parameter was also confirmed in the Android APK decompilation for the Reels grid pin/unpin flows.

Fixes #2196
