### PR TITLE
feat: add direct message reactions

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -8,6 +8,10 @@
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread
 | direct_answer(thread_id: int, text: str)                                  | DirectMessage           | Add Message to exist Thread
 | direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = [], reply_to_message: Optional[DirectMessage] = None) | DirectMessage | Send Message to Users or Threads, optionally as a reply
+| direct_send_reaction(thread_id: int, message_id: int, emoji: str = "❤", client_context: Optional[str] = None) | bool | Send an emoji reaction to a message
+| direct_delete_reaction(thread_id: int, message_id: int, emoji: str = "❤", client_context: Optional[str] = None) | bool | Delete your emoji reaction from a message
+| direct_message_like(thread_id: int, message_id: int, client_context: Optional[str] = None) | bool | Like a message with a heart reaction
+| direct_message_unlike(thread_id: int, message_id: int, client_context: Optional[str] = None) | bool | Remove your heart reaction from a message
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
 | direct_thread_by_participants(user_ids: List[int])                        | DirectThread            | Get thread by user_id
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
@@ -91,6 +95,15 @@ DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028
 
 >>> cl.direct_send('Reply text', thread_ids=[thread.id], reply_to_message=message)
 DirectMessage(id=30076213210116812312341061613568, user_id=None, thread_id=34028236684171031231231231233331238762, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 5, 127298, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
+
+>>> cl.direct_send_reaction(thread.id, message.id, emoji="😂", client_context=message.client_context)
+True
+
+>>> cl.direct_message_like(thread.id, message.id, client_context=message.client_context)
+True
+
+>>> cl.direct_message_unlike(thread.id, message.id, client_context=message.client_context)
+True
 
 >>> cl.direct_thread_by_participants([cl.user_id])
 DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[DirectMessage(id=30076214123123123123123864, user_id=1903424587, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 49, 107154, ...)

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -456,6 +456,161 @@ class DirectMixin:
         )
         return extract_direct_message(result["payload"])
 
+    def _direct_message_reaction(
+        self,
+        thread_id: int,
+        message_id: int,
+        emoji: str,
+        reaction_status: str,
+        client_context: Optional[str] = None,
+        action_source: str = "double_tap",
+        target_item_type: Optional[str] = None,
+    ) -> bool:
+        assert self.user_id, "Login required"
+        assert reaction_status in ("created", "deleted"), 'Unsupported reaction_status="%s"' % reaction_status
+        token = self.generate_mutation_token()
+        data = {
+            "action": "send_item",
+            "is_x_transport_forward": "false",
+            "send_silently": "false",
+            "is_shh_mode": "0",
+            "send_attribution": "message_reaction",
+            "client_context": token,
+            "device_id": self.android_device_id,
+            "mutation_token": token,
+            "btt_dual_send": "false",
+            "nav_chain": (
+                "1qT:feed_timeline:1,1qT:feed_timeline:2,1qT:feed_timeline:3,"
+                "7Az:direct_inbox:4,7Az:direct_inbox:5,5rG:direct_thread:7"
+            ),
+            "is_ae_dual_send": "false",
+            "offline_threading_id": token,
+            "thread_ids": dumps([str(thread_id)]),
+            "item_type": "reaction",
+            "reaction_type": "like",
+            "reaction_status": reaction_status,
+            "node_type": "item",
+            "item_id": str(message_id),
+            "emoji": emoji,
+            "reaction_action_source": action_source,
+        }
+        if client_context:
+            data["original_message_client_context"] = client_context
+        if target_item_type:
+            data["target_item_type"] = target_item_type
+        result = self.private_request(
+            "direct_v2/threads/broadcast/reaction/",
+            data=self.with_default_data(data),
+            with_signature=False,
+        )
+        return result.get("status") == "ok"
+
+    def direct_send_reaction(
+        self,
+        thread_id: int,
+        message_id: int,
+        emoji: str = "❤",
+        client_context: Optional[str] = None,
+        action_source: str = "double_tap",
+        target_item_type: Optional[str] = None,
+    ) -> bool:
+        """
+        Send an emoji reaction to a Direct message item.
+
+        Parameters
+        ----------
+        thread_id: int
+            Direct Message thread id
+        message_id: int
+            Direct Message item id to react to
+        emoji: str, optional
+            Emoji reaction. Default is heart
+        client_context: str, optional
+            Original message client_context when available
+        action_source: str, optional
+            Reaction source. Default is "double_tap"
+        target_item_type: str, optional
+            Original message item type for special items like raven_media or voice_media
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        return self._direct_message_reaction(
+            thread_id,
+            message_id,
+            emoji,
+            "created",
+            client_context=client_context,
+            action_source=action_source,
+            target_item_type=target_item_type,
+        )
+
+    def direct_delete_reaction(
+        self,
+        thread_id: int,
+        message_id: int,
+        emoji: str = "❤",
+        client_context: Optional[str] = None,
+        action_source: str = "double_tap",
+        target_item_type: Optional[str] = None,
+    ) -> bool:
+        """
+        Delete the current user's emoji reaction from a Direct message item.
+
+        Parameters
+        ----------
+        thread_id: int
+            Direct Message thread id
+        message_id: int
+            Direct Message item id to remove the reaction from
+        emoji: str, optional
+            Emoji reaction to remove. Default is heart
+        client_context: str, optional
+            Original message client_context when available
+        action_source: str, optional
+            Reaction source. Default is "double_tap"
+        target_item_type: str, optional
+            Original message item type for special items like raven_media or voice_media
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        return self._direct_message_reaction(
+            thread_id,
+            message_id,
+            emoji,
+            "deleted",
+            client_context=client_context,
+            action_source=action_source,
+            target_item_type=target_item_type,
+        )
+
+    def direct_message_like(
+        self,
+        thread_id: int,
+        message_id: int,
+        client_context: Optional[str] = None,
+    ) -> bool:
+        """
+        Like a Direct message item with a heart reaction.
+        """
+        return self.direct_send_reaction(thread_id, message_id, client_context=client_context)
+
+    def direct_message_unlike(
+        self,
+        thread_id: int,
+        message_id: int,
+        client_context: Optional[str] = None,
+    ) -> bool:
+        """
+        Remove the current user's heart reaction from a Direct message item.
+        """
+        return self.direct_delete_reaction(thread_id, message_id, client_context=client_context)
+
     def direct_send_photo(self, path: Path, user_ids: List[int] = [], thread_ids: List[int] = []) -> DirectMessage:
         """
         Send a direct photo to list of users or threads

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -149,6 +149,77 @@ class ClientDirectMediaLiveTestCase(_helpers.ClientPrivateTestCase):
             except Exception as exc:
                 print(f"Direct media live cleanup direct_thread_hide failed: {exc.__class__.__name__} {exc}")
 
+    def direct_message_by_id(self, client, thread_id, message_id, amount=10):
+        thread = client.direct_thread(thread_id, amount=amount)
+        for message in thread.messages:
+            if str(message.id) == str(message_id):
+                return message
+        return None
+
+    def direct_message_has_reaction(self, message, sender_id, emoji="❤"):
+        reactions = getattr(message, "reactions", None)
+        for reaction in getattr(reactions, "emojis", []) or []:
+            if str(reaction.sender_id) == str(sender_id) and reaction.emoji == emoji:
+                return True
+        return False
+
+    def test_direct_message_reaction_live(self):
+        sender = self.cl
+        recipient = self.fresh_accounts(1, exclude_user_ids={sender.user_id})[0]
+        sent_messages = []
+        thread_id = None
+
+        try:
+            seed_message = sender.direct_send(
+                f"instagrapi direct reaction live {int(time.time())}",
+                user_ids=[recipient.user_id],
+            )
+            self.assertIsInstance(seed_message, DirectMessage)
+            sent_messages.append((sender, seed_message))
+
+            thread_id = seed_message.thread_id or self.thread_id_by_participants(sender, recipient.user_id)
+            self.assertTrue(thread_id)
+
+            reply_message = recipient.direct_answer(
+                thread_id,
+                f"instagrapi direct reaction ack {int(time.time())}",
+            )
+            self.assertIsInstance(reply_message, DirectMessage)
+            sent_messages.append((recipient, reply_message))
+
+            target_message = None
+            for _ in range(6):
+                target_message = self.direct_message_by_id(recipient, thread_id, seed_message.id)
+                if target_message:
+                    break
+                time.sleep(2)
+            self.assertIsNotNone(target_message)
+
+            self.assertTrue(recipient.direct_send_reaction(thread_id, seed_message.id))
+
+            reacted_message = None
+            for _ in range(6):
+                reacted_message = self.direct_message_by_id(sender, thread_id, seed_message.id)
+                if reacted_message and self.direct_message_has_reaction(reacted_message, recipient.user_id):
+                    break
+                time.sleep(3)
+            else:
+                self.fail(f"Direct reaction was not visible: {getattr(reacted_message, 'reactions', None)}")
+
+            self.assertTrue(recipient.direct_message_unlike(thread_id, seed_message.id))
+
+            cleared_message = None
+            for _ in range(6):
+                cleared_message = self.direct_message_by_id(sender, thread_id, seed_message.id)
+                if cleared_message and not self.direct_message_has_reaction(cleared_message, recipient.user_id):
+                    break
+                time.sleep(3)
+            else:
+                self.fail(f"Direct reaction was still visible: {getattr(cleared_message, 'reactions', None)}")
+        finally:
+            if thread_id:
+                self.cleanup_direct_media_messages(thread_id, sent_messages, [sender, recipient])
+
     def test_direct_send_voice_and_video_with_thread_and_user_ids(self):
         sender = self.cl
         recipient = self.fresh_accounts(1, exclude_user_ids={sender.user_id})[0]

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -78,6 +78,64 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["replied_to_client_context"], reply_to_message.client_context)
         self.assertEqual(data["client_context"], "mutation-token")
 
+    def test_direct_send_reaction_posts_reaction_payload(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private,
+        ):
+            result = client.direct_send_reaction(
+                123,
+                456,
+                emoji="😂",
+                client_context="original-client-context",
+                action_source="reaction_sheet",
+            )
+
+        self.assertTrue(result)
+        private.assert_called_once_with(
+            "direct_v2/threads/broadcast/reaction/",
+            data=mock.ANY,
+            with_signature=False,
+        )
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), ["123"])
+        self.assertEqual(data["_uuid"], "uuid-1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["client_context"], "mutation-token")
+        self.assertEqual(data["offline_threading_id"], "mutation-token")
+        self.assertEqual(data["mutation_token"], "mutation-token")
+        self.assertEqual(data["action"], "send_item")
+        self.assertEqual(data["item_type"], "reaction")
+        self.assertEqual(data["reaction_type"], "like")
+        self.assertEqual(data["reaction_status"], "created")
+        self.assertEqual(data["node_type"], "item")
+        self.assertEqual(data["item_id"], "456")
+        self.assertEqual(data["emoji"], "😂")
+        self.assertEqual(data["reaction_action_source"], "reaction_sheet")
+        self.assertEqual(data["original_message_client_context"], "original-client-context")
+
+    def test_direct_message_unlike_posts_deleted_reaction(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private,
+        ):
+            result = client.direct_message_unlike(123, 456, client_context="original-client-context")
+
+        self.assertTrue(result)
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(data["reaction_status"], "deleted")
+        self.assertEqual(data["emoji"], "❤")
+        self.assertEqual(data["reaction_type"], "like")
+        self.assertEqual(data["original_message_client_context"], "original-client-context")
+
     def fake_rupload_session(self, media_id):
         class FakeResponse:
             status_code = 200


### PR DESCRIPTION
## Summary
- Add Direct message reaction send/delete support via `direct_send_reaction()` and `direct_delete_reaction()`.
- Add heart-specific convenience wrappers: `direct_message_like()` and `direct_message_unlike()`.
- Document the new Direct helpers and cover the request payload with regression tests.
- Add a live Direct reaction test that sends a message, creates a reaction, verifies it appears on the message, removes it, and verifies it is cleared.

## Verification
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m pytest -sv tests/live/test_direct.py::ClientDirectMediaLiveTestCase::test_direct_message_reaction_live`

Related issues: #2354, #916, #579
