### PR TITLE
Add feed photo and album music upload helpers

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - media
+          - upload
           - direct
           - timeline
           - user
@@ -39,6 +40,10 @@ jobs:
       - name: Run media test
         if: github.event.inputs.test_target == 'media' || github.event.inputs.test_target == 'all'
         run: pytest -sv tests/live/test_media.py::ClientMediaTestCase tests/live/test_comments.py::ClientCommentRepliesLiveTestCase
+
+      - name: Run upload music test
+        if: github.event.inputs.test_target == 'upload' || github.event.inputs.test_target == 'all'
+        run: pytest -sv tests/live/test_upload.py::ClientFeedMusicUploadLiveTestCase
 
       - name: Run direct media test
         if: github.event.inputs.test_target == 'direct' || github.event.inputs.test_target == 'all'

--- a/instagrapi/mixins/album.py
+++ b/instagrapi/mixins/album.py
@@ -1,6 +1,6 @@
 import time
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from instagrapi.exceptions import (
@@ -8,7 +8,7 @@ from instagrapi.exceptions import (
     AlbumNotDownload,
     AlbumUnknownFormat,
 )
-from instagrapi.types import Location, Media, Usertag
+from instagrapi.types import Location, Media, Track, Usertag
 from instagrapi.utils import date_time_original, dumps
 
 
@@ -227,6 +227,84 @@ class UploadAlbumMixin:
                         "Album upload",
                     )
         raise (configure_exception or AlbumConfigureError)(response=self.last_response, **self.last_json)
+
+    def album_upload_with_music(
+        self,
+        paths: List[Path],
+        caption: str,
+        track: Union[Track, Dict],
+        usertags: List[Usertag] = [],
+        location: Location = None,
+        configure_timeout: int = 3,
+        configure_handler=None,
+        configure_exception=None,
+        to_story=False,
+        extra_data: Dict[str, str] = {},
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: int = 30000,
+        browse_session_id: Optional[str] = None,
+        alacorn_session_id: Optional[str] = None,
+    ) -> Media:
+        """
+        Upload a feed album/carousel with attached music.
+
+        Parameters
+        ----------
+        paths: List[Path]
+            List of paths for media to upload.
+        caption: str
+            Media caption.
+        track: Track or dict
+            Track from music search/browser response or a compatible dict.
+        usertags: List[Usertag], optional
+            List of users to be tagged on this upload.
+        location: Location, optional
+            Location tag for this upload.
+        configure_timeout: int
+            Timeout between configure attempts.
+        configure_handler
+            Configure handler method, default is None.
+        configure_exception
+            Configure exception class, default is None.
+        to_story: bool
+            Currently not used, default is False.
+        extra_data: Dict[str, str], optional
+            Additional configure params.
+        audio_asset_start_time: int, optional
+            Audio start time in milliseconds. Defaults to the first highlighted
+            start time from the track, or 0.
+        overlap_duration: int, optional
+            Audio duration in milliseconds, default 30000.
+        browse_session_id: str, optional
+            Music browser session id.
+        alacorn_session_id: str, optional
+            Music browser session id returned by ``music_in_feed_audio_browser``.
+            Fetched automatically when omitted.
+
+        Returns
+        -------
+        Media
+            A Media response from the call.
+        """
+        data = dict(extra_data or {})
+        data["music_params"] = self._feed_music_params(
+            track,
+            audio_asset_start_time=audio_asset_start_time,
+            overlap_duration=overlap_duration,
+            browse_session_id=browse_session_id,
+            alacorn_session_id=alacorn_session_id,
+        )
+        return self.album_upload(
+            paths,
+            caption,
+            usertags=usertags,
+            location=location,
+            configure_timeout=configure_timeout,
+            configure_handler=configure_handler,
+            configure_exception=configure_exception,
+            to_story=to_story,
+            extra_data=data,
+        )
 
     def album_configure(
         self,

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -3,7 +3,7 @@ import random
 import shutil
 import time
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -27,6 +27,7 @@ from instagrapi.types import (
     StoryMention,
     StoryPoll,
     StorySticker,
+    Track,
     Usertag,
 )
 from instagrapi.utils import date_time_original, dumps
@@ -276,6 +277,72 @@ class UploadPhotoMixin:
                     "Photo upload",
                 )
         raise PhotoConfigureError(response=self.last_response, **self.last_json)
+
+    def photo_upload_with_music(
+        self,
+        path: Path,
+        caption: str,
+        track: Union[Track, Dict],
+        upload_id: str = "",
+        usertags: List[Usertag] = [],
+        location: Location = None,
+        extra_data: Dict[str, str] = {},
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: int = 30000,
+        browse_session_id: Optional[str] = None,
+        alacorn_session_id: Optional[str] = None,
+    ) -> Media:
+        """
+        Upload a feed photo with attached music.
+
+        Parameters
+        ----------
+        path: Path
+            Path to the media
+        caption: str
+            Media caption
+        track: Track or dict
+            Track from music search/browser response or a compatible dict.
+        upload_id: str, optional
+            Unique upload_id.
+        usertags: List[Usertag], optional
+            List of users to be tagged on this upload.
+        location: Location, optional
+            Location tag for this upload.
+        extra_data: Dict[str, str], optional
+            Additional configure params.
+        audio_asset_start_time: int, optional
+            Audio start time in milliseconds. Defaults to the first highlighted
+            start time from the track, or 0.
+        overlap_duration: int, optional
+            Audio duration in milliseconds, default 30000.
+        browse_session_id: str, optional
+            Music browser session id.
+        alacorn_session_id: str, optional
+            Music browser session id returned by ``music_in_feed_audio_browser``.
+            Fetched automatically when omitted.
+
+        Returns
+        -------
+        Media
+            A Media response from the call
+        """
+        data = dict(extra_data or {})
+        data["music_params"] = self._feed_music_params(
+            track,
+            audio_asset_start_time=audio_asset_start_time,
+            overlap_duration=overlap_duration,
+            browse_session_id=browse_session_id,
+            alacorn_session_id=alacorn_session_id,
+        )
+        return self.photo_upload(
+            path,
+            caption,
+            upload_id=upload_id,
+            usertags=usertags,
+            location=location,
+            extra_data=data,
+        )
 
     def photo_configure(
         self,

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -261,7 +261,7 @@ class UploadPhotoMixin:
         for attempt in range(10):
             self.logger.debug(f"Attempt #{attempt} to configure Photo: {path}")
             time.sleep(3)
-            if self.photo_configure(
+            configured = self.photo_configure(
                 upload_id,
                 width,
                 height,
@@ -269,10 +269,11 @@ class UploadPhotoMixin:
                 usertags,
                 location,
                 extra_data=extra_data,
-            ):
+            )
+            if configured:
                 self.expose()
                 return self._extract_configured_media_or_raise(
-                    self.last_json,
+                    configured,
                     PhotoConfigureError,
                     "Photo upload",
                 )

--- a/instagrapi/mixins/track.py
+++ b/instagrapi/mixins/track.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Union
 from urllib.parse import urlparse
 
 import requests
@@ -12,6 +12,17 @@ from instagrapi.utils import json_value
 
 
 class TrackMixin:
+    @staticmethod
+    def _track_value(track: Union[Track, Dict], key: str):
+        if isinstance(track, dict):
+            return track.get(key)
+        return getattr(track, key, None)
+
+    @classmethod
+    def _track_highlight_start(cls, track: Union[Track, Dict]) -> int:
+        highlight_times = cls._track_value(track, "highlight_start_times_in_ms") or []
+        return int(highlight_times[0]) if highlight_times else 0
+
     def track_download_by_url(self, url: str, filename: str = "", folder: Path = "") -> Path:
         """
         Download track by URL
@@ -52,6 +63,70 @@ class TrackMixin:
                 raise TrackNotFound(**kw)
             raise e
         return result
+
+    def music_in_feed_audio_browser(self, browse_session_id: Optional[str] = None) -> Dict:
+        """
+        Retrieve music candidates for feed photo and carousel posts.
+
+        Parameters
+        ----------
+        browse_session_id: str, optional
+            Browser session id. Generated when omitted.
+
+        Returns
+        -------
+        Dict
+            Raw response from ``music/music_in_feed_audio_browser/``.
+        """
+        if browse_session_id is None:
+            browse_session_id = self.generate_uuid()
+        return self.private_request(
+            "music/music_in_feed_audio_browser/",
+            data={
+                "product": "music_in_feed",
+                "_uuid": self.uuid,
+                "browse_session_id": browse_session_id,
+            },
+            with_signature=False,
+        )
+
+    def _feed_music_params(
+        self,
+        track: Union[Track, Dict],
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: int = 30000,
+        browse_session_id: Optional[str] = None,
+        alacorn_session_id: Optional[str] = None,
+    ) -> Dict:
+        audio_asset_id = self._track_value(track, "audio_asset_id") or self._track_value(track, "id")
+        audio_cluster_id = self._track_value(track, "audio_cluster_id")
+        assert audio_asset_id, "track.audio_asset_id or track.id is required"
+        assert audio_cluster_id, "track.audio_cluster_id is required"
+        if audio_asset_start_time is None:
+            audio_asset_start_time = self._track_highlight_start(track)
+        if alacorn_session_id is None:
+            alacorn_session_id = self._track_value(track, "alacorn_session_id")
+        if alacorn_session_id is None:
+            alacorn_session_id = self.music_in_feed_audio_browser().get("alacorn_session_id")
+        assert alacorn_session_id, "alacorn_session_id is required"
+
+        data = {
+            "audio_asset_id": audio_asset_id,
+            "audio_cluster_id": audio_cluster_id,
+            "audio_asset_start_time_in_ms": int(audio_asset_start_time),
+            "derived_content_start_time_in_ms": 0,
+            "overlap_duration_in_ms": int(overlap_duration),
+            "browse_session_id": browse_session_id,
+            "product": "music_in_feed",
+            "song_name": self._track_value(track, "title") or "",
+            "artist_name": self._track_value(track, "display_artist") or "",
+            "alacorn_session_id": alacorn_session_id,
+            "audio_apply_source": 0,
+        }
+        music_canonical_id = self._track_value(track, "music_canonical_id")
+        if music_canonical_id:
+            data["music_canonical_id"] = music_canonical_id
+        return data
 
     def track_info_by_canonical_id(self, music_canonical_id: str) -> Track:
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,7 +30,7 @@ from tests.live.test_signup import SignUpTestCase
 from tests.live.test_story import ClientStoryTestCase
 from tests.live.test_timeline import ClientTimelineLiveTestCase
 from tests.live.test_totp import TOTPTestCase
-from tests.live.test_upload import ClienUploadTestCase
+from tests.live.test_upload import ClientFeedMusicUploadLiveTestCase, ClienUploadTestCase
 from tests.live.test_user import (
     ClientFollowRequestLiveTestCase,
     ClientUserExtendTestCase,

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -150,3 +150,104 @@ class ClienUploadTestCase(_helpers.ClientPrivateTestCase):
         finally:
             cleanup(path)
             self.assertTrue(self.cl.media_delete(media.id))
+
+
+class ClientFeedMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):
+    photo_path = Path("examples/kanada.jpg")
+    album_paths = [Path("examples/kanada.jpg"), Path("examples/background.png")]
+
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for feed music upload live tests")
+        try:
+            self.cl = self.fresh_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def iter_track_candidates(self, value):
+        if isinstance(value, list):
+            for item in value:
+                yield from self.iter_track_candidates(item)
+            return
+        if not isinstance(value, dict):
+            return
+
+        track = value.get("track") or value
+        if (track.get("audio_asset_id") or track.get("id")) and track.get("audio_cluster_id"):
+            yield track
+
+        for key in ("items", "preview_items", "tracks"):
+            yield from self.iter_track_candidates(value.get(key) or [])
+        yield from self.iter_track_candidates((value.get("playlist") or {}).get("preview_items") or [])
+
+    def feed_music_track(self):
+        music = self.cl.music_in_feed_audio_browser()
+        self.assertEqual(music.get("status"), "ok")
+
+        alacorn_session_id = music.get("alacorn_session_id")
+        if not alacorn_session_id:
+            self.skipTest("music_in_feed_audio_browser did not return alacorn_session_id")
+
+        track = next(self.iter_track_candidates(music.get("items") or []), None)
+        if not track:
+            self.skipTest("music_in_feed_audio_browser did not return a usable track")
+        return track, alacorn_session_id
+
+    def uploaded_media_payload(self, media):
+        result = self.cl.private_request(f"media/{media.pk}/info/")
+        items = result.get("items") or []
+        self.assertTrue(items)
+        return items[0]
+
+    def assertUploadedMediaHasMusic(self, media):
+        payload = self.uploaded_media_payload(media)
+        music_metadata = payload.get("music_metadata") or {}
+        self.assertEqual(music_metadata.get("audio_type"), "licensed_music")
+
+    def cleanup_uploaded_media(self, media):
+        if not media:
+            return
+        try:
+            self.assertTrue(self.cl.media_delete(media.id))
+        except Exception as exc:
+            print(f"Feed music upload cleanup media_delete failed: {exc.__class__.__name__} {exc}")
+
+    def test_photo_upload_with_music_live(self):
+        track, alacorn_session_id = self.feed_music_track()
+        media = None
+        try:
+            media = self.cl.photo_upload_with_music(
+                self.photo_path,
+                "",
+                track,
+                alacorn_session_id=alacorn_session_id,
+            )
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.media_type, 1)
+            self.assertUploadedMediaHasMusic(media)
+        finally:
+            self.cleanup_uploaded_media(media)
+
+    def test_album_upload_with_music_live(self):
+        track, alacorn_session_id = self.feed_music_track()
+        media = None
+        try:
+            media = self.cl.album_upload_with_music(
+                self.album_paths,
+                "",
+                track,
+                alacorn_session_id=alacorn_session_id,
+            )
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.media_type, 8)
+            self.assertGreaterEqual(len(media.resources), 2)
+            self.assertUploadedMediaHasMusic(media)
+        finally:
+            self.cleanup_uploaded_media(media)

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -89,6 +89,23 @@ class UploadRegressionTestCase(unittest.TestCase):
 
         self.assertIn("without media payload", str(ctx.exception))
 
+    def test_photo_upload_extracts_configure_media_when_expose_overwrites_last_json(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=1)
+
+        def expose():
+            client.last_json = {"status": "ok"}
+            return client.last_json
+
+        client.expose = expose
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(client, "photo_configure", return_value={"status": "ok", "media": media_payload}):
+                with mock.patch("time.sleep"):
+                    media = client.photo_upload(Path("example.jpg"), "caption")
+
+        self.assertIsInstance(media, Media)
+        self.assertEqual(media.pk, "1")
+
     def test_video_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -153,6 +153,102 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertIsInstance(media, Media)
         photo_rupload.assert_called_once_with(Path("slide.png"), to_album=True)
 
+    def test_music_in_feed_audio_browser_requests_feed_music_product(self):
+        client = self.build_client()
+        expected = {"status": "ok", "alacorn_session_id": "alacorn-1"}
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.music_in_feed_audio_browser(browse_session_id="browse-1")
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "music/music_in_feed_audio_browser/",
+            data={
+                "product": "music_in_feed",
+                "_uuid": "uuid",
+                "browse_session_id": "browse-1",
+            },
+            with_signature=False,
+        )
+
+    def test_photo_upload_with_music_adds_music_params_without_mutating_extra_data(self):
+        client = self.build_client()
+        track = types.SimpleNamespace(
+            id="track-id",
+            audio_asset_id="asset-id",
+            audio_cluster_id="cluster-id",
+            highlight_start_times_in_ms=[58000],
+            title="Memories",
+            display_artist="Justin Lee",
+        )
+        extra_data = {"share_to_facebook": 1}
+
+        with mock.patch.object(client, "photo_upload", return_value="uploaded") as photo_upload:
+            result = client.photo_upload_with_music(
+                Path("photo.jpg"),
+                "caption",
+                track,
+                extra_data=extra_data,
+                alacorn_session_id="alacorn-1",
+            )
+
+        self.assertEqual(result, "uploaded")
+        self.assertEqual(extra_data, {"share_to_facebook": 1})
+        upload_extra = photo_upload.call_args.kwargs["extra_data"]
+        self.assertEqual(upload_extra["share_to_facebook"], 1)
+        self.assertEqual(
+            upload_extra["music_params"],
+            {
+                "audio_asset_id": "asset-id",
+                "audio_cluster_id": "cluster-id",
+                "audio_asset_start_time_in_ms": 58000,
+                "derived_content_start_time_in_ms": 0,
+                "overlap_duration_in_ms": 30000,
+                "browse_session_id": None,
+                "product": "music_in_feed",
+                "song_name": "Memories",
+                "artist_name": "Justin Lee",
+                "alacorn_session_id": "alacorn-1",
+                "audio_apply_source": 0,
+            },
+        )
+
+    def test_album_upload_with_music_adds_music_params_without_mutating_extra_data(self):
+        client = self.build_client()
+        track = {
+            "id": "track-id",
+            "audio_cluster_id": "cluster-id",
+            "highlight_start_times_in_ms": [12000],
+            "title": "Album song",
+            "display_artist": "Album artist",
+        }
+        extra_data = {"disable_comments": 1}
+
+        with mock.patch.object(client, "album_upload", return_value="uploaded") as album_upload:
+            result = client.album_upload_with_music(
+                [Path("one.jpg"), Path("two.jpg")],
+                "caption",
+                track,
+                extra_data=extra_data,
+                alacorn_session_id="alacorn-1",
+                browse_session_id="browse-1",
+                overlap_duration=15000,
+            )
+
+        self.assertEqual(result, "uploaded")
+        self.assertEqual(extra_data, {"disable_comments": 1})
+        upload_extra = album_upload.call_args.kwargs["extra_data"]
+        self.assertEqual(upload_extra["disable_comments"], 1)
+        self.assertEqual(upload_extra["music_params"]["audio_asset_id"], "track-id")
+        self.assertEqual(upload_extra["music_params"]["audio_cluster_id"], "cluster-id")
+        self.assertEqual(upload_extra["music_params"]["audio_asset_start_time_in_ms"], 12000)
+        self.assertEqual(upload_extra["music_params"]["overlap_duration_in_ms"], 15000)
+        self.assertEqual(upload_extra["music_params"]["browse_session_id"], "browse-1")
+        self.assertEqual(upload_extra["music_params"]["product"], "music_in_feed")
+        self.assertEqual(upload_extra["music_params"]["song_name"], "Album song")
+        self.assertEqual(upload_extra["music_params"]["artist_name"], "Album artist")
+        self.assertEqual(upload_extra["music_params"]["alacorn_session_id"], "alacorn-1")
+
     def test_photo_story_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 


### PR DESCRIPTION
## Summary
- add feed music browser support for photo/carousel music sessions
- add shared feed music params builder matching current Android configure payload
- add `photo_upload_with_music` and `album_upload_with_music` wrappers
- preserve the photo configure response before `expose()` so photo uploads can still extract the configured media payload
- add regression and live coverage for photo/carousel uploads with feed music

Refs #2144

## Tests
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check instagrapi/mixins/photo.py tests/regression/test_upload.py tests/live/test_upload.py tests/__init__.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/live-account-tests.yml"); puts "yaml ok"'`\n- `env -u TEST_ACCOUNTS_URL .venv/bin/python -m pytest -q tests/live/test_upload.py::ClientFeedMusicUploadLiveTestCase`\n- live: `pytest -sv tests/live/test_upload.py::ClientFeedMusicUploadLiveTestCase` passed for photo and album music uploads\n- GitHub PR checks passed\n