### PR TITLE
Add archive media and story readers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`Highlight`](usage-guide/highlight.md) - Highlights
   * [`Notes`](usage-guide/notes.md) - Notes
   * [`Story`](usage-guide/story.md) - Story
+  * [`StoryArchiveDay`](usage-guide/story.md) - Story archive day shell
   * [`StoryLink`](usage-guide/story.md) - Link sticker
   * [`StoryLocation`](usage-guide/story.md) - Tag Location in Story (as sticker)
   * [`StoryMention`](usage-guide/story.md) - Mention users in Story (user, coordinates and dimensions)

--- a/docs/usage-guide/fundamentals.md
+++ b/docs/usage-guide/fundamentals.md
@@ -34,6 +34,7 @@ use an internal fallback chain and choose the best currently working path for th
   * [`Highlight`](highlight.md) - Highlights
   * [`Notes`](notes.md) - Direct Notes
   * [`Story`](story.md) - Story
+  * [`StoryArchiveDay`](story.md) - Story archive day shell
   * [`StoryLink`](story.md) - Story link sticker
   * [`StoryLocation`](story.md) - Tag Location in Story (as sticker)
   * [`StoryMention`](story.md) - Mention users in Story (user, coordinates and dimensions)

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -16,6 +16,7 @@
 * [`Comment`](comment.md) - Comments to Media
 * [`Highlight`](highlight.md) - Highlights
 * [`Story`](story.md) - Story
+* [`StoryArchiveDay`](story.md) - Story archive day shell
 * [`StoryLink`](story.md) - Story link sticker
 * [`StoryLocation`](story.md) - Tag Location in Story (as sticker)
 * [`StoryMention`](story.md) - Mention users in Story (user, coordinates and dimensions)

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -41,6 +41,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_unlike(media_id: str) | bool | Unlike media |
 | media_seen(media_ids: List[str], skipped_media_ids: List[str] = []) | bool | Mark media as seen |
 | media_likers(media_id: str) | List\[UserShort] | Return users who liked this post |
+| archive_medias(amount: int = 0) | List\[Media] | Get archived media from your account |
 | media_archive(media_id: str) | bool | Archive media |
 | media_unarchive(media_id: str) | bool | Unarchive media |
 | media_pin(media_pk: str) | bool | Pin media to profile |
@@ -72,6 +73,8 @@ Low level methods:
 | user_videos_paginated_v1(user_id: int, amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of videos |
 | usertag_medias_gql(user_id: str, amount: int = 0, sleep: int = 2) | List\[Media] | Get media where a user is tagged via public GraphQL API |
 | usertag_medias_v1(user_id: str, amount: int = 0) | List\[Media] | Get media where a user is tagged via private mobile API |
+| archive_medias_v1(amount: int = 0) | List\[Media] | Get archived media via private mobile API |
+| archive_medias_paginated_v1(amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of archived media |
 
 ### Example:
 
@@ -153,6 +156,9 @@ Low level methods:
 
 >>> cl.media_archive('2155832952940083788_1903424587')
 True
+
+>>> [media.pk for media in cl.archive_medias(amount=5)]
+['2155832952940083788']
 
 >>> cl.media_unarchive('2155832952940083788_1903424587')
 True

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -10,6 +10,8 @@
 | story_download(story_pk: int, filename: str = "", folder: Path = "")   | Path            | Download story media by media_type
 | story_download_by_url(url: str, filename: str = "", folder: Path = "") | Path            | Download story media using URL to file (mp4 or jpg)
 | story_viewers(story_pk: int, amount: int = 20)                         | List[UserShort] | List of story viewers (via Private API)
+| archive_story_days(amount: int = 0, include_memories: bool = True)      | List[StoryArchiveDay] | Get your story archive day shells
+| archive_stories(amount: int = 0)                                        | List[Story]     | Get your archived stories
 | story_like(story_id: str, revert: bool = False)                        | bool            | Like a story
 | story_unlike(story_id: str)                                            | bool            | Unlike a story
 
@@ -26,7 +28,27 @@ PosixPath('/app/189361307_229642088942817_9180243596650100310_n.mp4')
 
 >>> cl.story_download_by_url(s.thumbnail_url)  # URL to jpg file
 PosixPath('/app/191260083_2908005872746895_8988438451809588865_n.jpg')
+
+>>> days = cl.archive_story_days(amount=1)
+>>> days[0].id
+'archiveDay:1710000000000'
+
+>>> archived = cl.archive_stories(amount=5)
+>>> [story.pk for story in archived]
+['3155832952940083788']
 ```
+
+## Story Archive
+
+`archive_story_days()` returns `StoryArchiveDay` objects for the logged-in account's story archive. Use `archive_stories()` when you need the story media items from those archive days.
+
+Low level methods:
+
+| Method | Return | Description
+| ------ | ------ | -----------
+| archive_story_days_v1(amount: int = 0, include_memories: bool = True) | List[StoryArchiveDay] | Get story archive days via private mobile API
+| archive_story_days_paginated_v1(amount: int = 0, end_cursor: str = "", include_memories: bool = True, reel_id: str = "") | Tuple[List[StoryArchiveDay], str] | Get one private API page of story archive days
+| archive_stories_v1(amount: int = 0) | List[Story] | Get archived stories via private mobile API
 
 ## Upload Stories
 

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -24,6 +24,7 @@ from .types import (
     ReplyMessage,
     Resource,
     Story,
+    StoryArchiveDay,
     StoryHashtag,
     StoryLink,
     StoryLocation,
@@ -530,6 +531,11 @@ def extract_story_v1(data):
     if not story.get("taken_at"):
         story["taken_at"] = story.get("device_timestamp") or story.get("taken_at_timestamp")
     return Story(**story)
+
+
+def extract_story_archive_day(data):
+    """Extract story archive day from Private API"""
+    return StoryArchiveDay(**deepcopy(data))
 
 
 def extract_story_gql(data):

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -1030,6 +1030,75 @@ class MediaMixin:
         """
         return self.media_archive(media_id, revert=True)
 
+    def archive_medias_paginated_v1(self, amount: int = 0, end_cursor: str = "") -> Tuple[List[Media], str]:
+        """
+        Get a page of your archived medias by Private Mobile API
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of media to return, default is 0 (all medias)
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+
+        Returns
+        -------
+        Tuple[List[Media], str]
+            A tuple containing a list of medias and the next end_cursor value
+        """
+        amount = int(amount)
+        params = {"max_id": end_cursor} if end_cursor else {}
+        result = self.private_request("feed/only_me_feed/", params=params)
+        items = result.get("items", [])
+        if amount:
+            items = items[:amount]
+        medias = [extract_media_v1(item.get("media", item)) for item in items]
+        return medias, result.get("max_id") or ""
+
+    def archive_medias_v1(self, amount: int = 0) -> List[Media]:
+        """
+        Get your archived medias by Private Mobile API
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of media to return, default is 0 (all medias)
+
+        Returns
+        -------
+        List[Media]
+            A list of objects of Media
+        """
+        amount = int(amount)
+        medias = []
+        next_max_id = ""
+        while True:
+            medias_page, next_max_id = self.archive_medias_paginated_v1(amount=amount, end_cursor=next_max_id)
+            medias.extend(medias_page)
+            if not next_max_id:
+                break
+            if amount and len(medias) >= amount:
+                break
+        if amount:
+            medias = medias[:amount]
+        return medias
+
+    def archive_medias(self, amount: int = 0) -> List[Media]:
+        """
+        Get your archived medias
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of media to return, default is 0 (all medias)
+
+        Returns
+        -------
+        List[Media]
+            A list of objects of Media
+        """
+        return self.archive_medias_v1(amount)
+
     def usertag_medias_gql(self, user_id: str, amount: int = 0, sleep: int = 2) -> List[Media]:
         """
         Get medias where a user is tagged (by Public GraphQL API)

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -2,7 +2,7 @@ import json
 import shutil
 from copy import deepcopy
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 from urllib.parse import urlparse
 
 from instagrapi import config
@@ -13,12 +13,13 @@ from instagrapi.exceptions import (
     UserNotFound,
 )
 from instagrapi.extractors import (
+    extract_story_archive_day,
     extract_story_gql,
     extract_story_v1,
     extract_user_short,
     extract_viewer,
 )
-from instagrapi.types import Story, UserShort, Viewer
+from instagrapi.types import Story, StoryArchiveDay, UserShort, Viewer
 
 
 class StoryMixin:
@@ -229,6 +230,163 @@ class StoryMixin:
                     "Anonymous story fetch failed via public API and private fallback requires login"
                 ) from e
             return self.user_stories_v1(user_id, amount)
+
+    def archive_story_days_paginated_v1(
+        self,
+        amount: int = 0,
+        end_cursor: str = "",
+        include_memories: bool = True,
+        reel_id: str = "",
+    ) -> Tuple[List[StoryArchiveDay], str]:
+        """
+        Get a page of your story archive days by Private Mobile API
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of archive days to return, default is 0 (all days)
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+        include_memories: bool, optional
+            Whether to include memories metadata, default value is True
+        reel_id: str, optional
+            Archive reel identifier to filter by
+
+        Returns
+        -------
+        Tuple[List[StoryArchiveDay], str]
+            A tuple containing a list of archive days and the next end_cursor value
+        """
+        amount = int(amount)
+        params = {
+            "timezone_offset": self.timezone_offset,
+            "include_memories": "1" if include_memories else "0",
+        }
+        if end_cursor:
+            params["max_id"] = end_cursor
+        if reel_id:
+            params["reel_id"] = reel_id
+        result = self.private_request("archive/reel/day_shells_paginated/", params=params)
+        items = result.get("items", [])
+        if amount:
+            items = items[:amount]
+        return ([extract_story_archive_day(item) for item in items], result.get("max_id") or "")
+
+    def archive_story_days_v1(self, amount: int = 0, include_memories: bool = True) -> List[StoryArchiveDay]:
+        """
+        Get your story archive days by Private Mobile API
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of archive days to return, default is 0 (all days)
+        include_memories: bool, optional
+            Whether to include memories metadata, default value is True
+
+        Returns
+        -------
+        List[StoryArchiveDay]
+            A list of objects of StoryArchiveDay
+        """
+        amount = int(amount)
+        days = []
+        next_max_id = ""
+        while True:
+            days_page, next_max_id = self.archive_story_days_paginated_v1(
+                amount=amount,
+                end_cursor=next_max_id,
+                include_memories=include_memories,
+            )
+            days.extend(days_page)
+            if not next_max_id:
+                break
+            if amount and len(days) >= amount:
+                break
+        if amount:
+            days = days[:amount]
+        return days
+
+    def archive_story_days(self, amount: int = 0, include_memories: bool = True) -> List[StoryArchiveDay]:
+        """
+        Get your story archive days
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of archive days to return, default is 0 (all days)
+        include_memories: bool, optional
+            Whether to include memories metadata, default value is True
+
+        Returns
+        -------
+        List[StoryArchiveDay]
+            A list of objects of StoryArchiveDay
+        """
+        return self.archive_story_days_v1(amount, include_memories)
+
+    @staticmethod
+    def _archive_story_reels(response) -> List[dict]:
+        reels = response.get("reels") or response.get("reels_media") or []
+        if isinstance(reels, dict):
+            return list(reels.values())
+        if reels:
+            return reels
+        return [value for key, value in response.items() if str(key).startswith("archiveDay:")]
+
+    def archive_stories_v1(self, amount: int = 0) -> List[Story]:
+        """
+        Get your archived stories by Private Mobile API
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of stories to return, default is 0 (all stories)
+
+        Returns
+        -------
+        List[Story]
+            A list of objects of Story
+        """
+        amount = int(amount)
+        days = self.archive_story_days_v1(amount=0)
+        stories = []
+        for start in range(0, len(days), 50):
+            day_ids = [day.id for day in days[start : start + 50]]
+            if not day_ids:
+                continue
+            data = self.with_default_data(
+                {
+                    "reel_ids": day_ids,
+                    "reason": "on_tap",
+                    "source": "archive",
+                    "batch_size": len(day_ids),
+                }
+            )
+            result = self.private_request("feed/reels_media_stream/", data=data)
+            for reel in self._archive_story_reels(result):
+                for item in reel.get("items", []):
+                    story = extract_story_v1(item)
+                    self._stories_cache[story.pk] = story
+                    stories.append(story)
+                    if amount and len(stories) >= amount:
+                        return stories
+        return stories
+
+    def archive_stories(self, amount: int = 0) -> List[Story]:
+        """
+        Get your archived stories
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of stories to return, default is 0 (all stories)
+
+        Returns
+        -------
+        List[Story]
+            A list of objects of Story
+        """
+        return self.archive_stories_v1(amount)
 
     def story_seen(self, story_pks: List[int], skipped_story_pks: List[int] = []):
         """

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -643,6 +643,14 @@ class Story(TypesBaseModel):
     polls: List[StoryPoll] = []
 
 
+class StoryArchiveDay(TypesBaseModel):
+    id: str
+    timestamp: datetime
+    media_count: int
+    reel_type: str
+    latest_reel_media: Optional[int] = None
+
+
 class Guide(TypesBaseModel):
     id: Optional[str] = None
     title: Optional[str] = None

--- a/tests/live/test_archive.py
+++ b/tests/live/test_archive.py
@@ -1,0 +1,67 @@
+from instagrapi.types import StoryArchiveDay
+from tests import helpers as _helpers
+from tests.helpers import *
+
+
+class ClientArchiveLiveTestCase(_helpers.ClientPrivateTestCase):
+    _live_client = None
+    _live_account_error = None
+
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("Dedicated live account is required for archive tests")
+        if self.__class__._live_account_error:
+            self.skipTest(self.__class__._live_account_error)
+        if self.__class__._live_client:
+            self.cl = self.__class__._live_client
+            return
+        try:
+            self.cl = self.fresh_account()
+        except Exception as exc:
+            self.__class__._live_account_error = f"Could not prepare live account: {exc.__class__.__name__}"
+            self.skipTest(self.__class__._live_account_error)
+        self.__class__._live_client = self.cl
+
+    def test_archive_medias(self):
+        media = None
+        try:
+            media = self.cl.photo_upload(Path("examples/kanada.jpg"), "")
+            self.assertIsInstance(media, Media)
+            self.assertTrue(self.cl.media_archive(media.id))
+
+            archived = self.cl.archive_medias(amount=10)
+            self.assertIn(media.pk, [item.pk for item in archived])
+
+            self.assertTrue(self.cl.media_unarchive(media.id))
+            archived = self.cl.archive_medias(amount=10)
+            self.assertNotIn(media.pk, [item.pk for item in archived])
+        finally:
+            if media:
+                try:
+                    self.cl.media_unarchive(media.id)
+                except Exception:
+                    pass
+                self.assertTrue(self.cl.media_delete(media.id))
+
+    def test_archive_story_days(self):
+        days = self.cl.archive_story_days(amount=1)
+        self.assertIsInstance(days, list)
+        if days:
+            self.assertIsInstance(days[0], StoryArchiveDay)
+
+    def test_archive_stories(self):
+        days = self.cl.archive_story_days(amount=1)
+        if not days:
+            self.skipTest("Story archive is empty")
+
+        stories = self.cl.archive_stories(amount=1)
+        self.assertIsInstance(stories, list)
+        if stories:
+            self.assertIsInstance(stories[0], Story)

--- a/tests/regression/test_archive.py
+++ b/tests/regression/test_archive.py
@@ -1,0 +1,164 @@
+from instagrapi.types import StoryArchiveDay
+from tests.helpers import *
+
+
+class ArchiveRegressionTestCase(unittest.TestCase):
+    @staticmethod
+    def media_payload(pk="1", code="abc"):
+        return {
+            "pk": pk,
+            "id": f"{pk}_1",
+            "code": code,
+            "taken_at": 1710000000,
+            "media_type": 1,
+            "caption": None,
+            "user": {
+                "pk": "1",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "like_count": 0,
+            "image_versions2": {
+                "candidates": [
+                    {
+                        "url": "https://example.com/photo.jpg",
+                        "width": 720,
+                        "height": 720,
+                    }
+                ]
+            },
+        }
+
+    @staticmethod
+    def story_payload(pk="10"):
+        return {
+            "pk": pk,
+            "id": f"{pk}_1",
+            "taken_at": 1710000000,
+            "media_type": 1,
+            "user": {
+                "pk": "1",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "image_versions2": {
+                "candidates": [
+                    {
+                        "url": "https://example.com/story.jpg",
+                        "width": 720,
+                        "height": 1280,
+                    }
+                ]
+            },
+        }
+
+    def test_archive_medias_fetches_only_me_feed_and_paginates(self):
+        client = Client()
+        first_media = self.media_payload(pk="1", code="abc")
+        second_media = self.media_payload(pk="2", code="def")
+        client.private_request = Mock(
+            side_effect=[
+                {
+                    "items": [first_media],
+                    "num_results": 1,
+                    "more_available": True,
+                    "max_id": "next-page",
+                    "status": "ok",
+                },
+                {
+                    "items": [second_media],
+                    "num_results": 1,
+                    "more_available": False,
+                    "max_id": None,
+                    "status": "ok",
+                },
+            ]
+        )
+
+        medias = client.archive_medias(amount=2)
+
+        self.assertEqual([media.pk for media in medias], ["1", "2"])
+        self.assertEqual(client.private_request.call_count, 2)
+        first_call = client.private_request.call_args_list[0]
+        second_call = client.private_request.call_args_list[1]
+        self.assertEqual(first_call.args[0], "feed/only_me_feed/")
+        self.assertEqual(first_call.kwargs["params"], {})
+        self.assertEqual(second_call.kwargs["params"], {"max_id": "next-page"})
+
+    def test_archive_story_days_fetches_day_shells(self):
+        client = Client()
+        client.timezone_offset = 10800
+        client.private_request = Mock(
+            return_value={
+                "items": [
+                    {
+                        "timestamp": 1710000000,
+                        "media_count": 1,
+                        "id": "archiveDay:123",
+                        "reel_type": "archive_day_reel",
+                        "latest_reel_media": 1710000123,
+                    }
+                ],
+                "num_results": 1,
+                "more_available": False,
+                "max_id": None,
+                "status": "ok",
+            }
+        )
+
+        days = client.archive_story_days(amount=1)
+
+        self.assertEqual(len(days), 1)
+        self.assertIsInstance(days[0], StoryArchiveDay)
+        self.assertEqual(days[0].id, "archiveDay:123")
+        request = client.private_request.call_args
+        self.assertEqual(request.args[0], "archive/reel/day_shells_paginated/")
+        self.assertEqual(
+            request.kwargs["params"],
+            {"timezone_offset": 10800, "include_memories": "1"},
+        )
+
+    def test_archive_stories_fetches_reels_media_stream_for_archive_days(self):
+        client = Client()
+        client.__dict__["user_id"] = "1"
+        client.uuid = "uuid"
+        client.timezone_offset = 0
+        client.private_request = Mock(
+            side_effect=[
+                {
+                    "items": [
+                        {
+                            "timestamp": 1710000000,
+                            "media_count": 1,
+                            "id": "archiveDay:123",
+                            "reel_type": "archive_day_reel",
+                            "latest_reel_media": 1710000123,
+                        }
+                    ],
+                    "num_results": 1,
+                    "more_available": False,
+                    "status": "ok",
+                },
+                {
+                    "reels": {
+                        "archiveDay:123": {
+                            "id": "archiveDay:123",
+                            "items": [self.story_payload()],
+                        }
+                    },
+                    "status": "ok",
+                },
+            ]
+        )
+
+        stories = client.archive_stories(amount=1)
+
+        self.assertEqual(len(stories), 1)
+        self.assertEqual(stories[0].pk, "10")
+        stream_request = client.private_request.call_args_list[1]
+        self.assertEqual(stream_request.args[0], "feed/reels_media_stream/")
+        self.assertEqual(
+            stream_request.kwargs["data"]["reel_ids"],
+            ["archiveDay:123"],
+        )
+        self.assertEqual(stream_request.kwargs["data"]["reason"], "on_tap")


### PR DESCRIPTION
## Summary
- Add archived feed media readers using the private `feed/only_me_feed/` endpoint.
- Add story archive day shells and archived story readers using the current private archive endpoints.
- Document the new public methods and add regression/live coverage.

## Related
- Related to #2185

## Test Plan
- `python -m ruff check instagrapi/types.py instagrapi/extractors.py instagrapi/mixins/story.py instagrapi/mixins/media.py tests/regression/test_archive.py tests/live/test_archive.py`
- `python -m pytest tests/regression`
- Live archive test run: 5 passed, 1 skipped because the story archive was empty on the live account used for that run.
