### PR TITLE
feat: add Trial Reels upload support

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -41,9 +41,12 @@ jobs:
         if: github.event.inputs.test_target == 'media' || github.event.inputs.test_target == 'all'
         run: pytest -sv tests/live/test_media.py::ClientMediaTestCase tests/live/test_comments.py::ClientCommentRepliesLiveTestCase
 
-      - name: Run upload music test
+      - name: Run upload live tests
         if: github.event.inputs.test_target == 'upload' || github.event.inputs.test_target == 'all'
-        run: pytest -sv tests/live/test_upload.py::ClientFeedMusicUploadLiveTestCase
+        run: |
+          pytest -sv \
+            tests/live/test_upload.py::ClientFeedMusicUploadLiveTestCase \
+            tests/live/test_upload.py::ClientTrialReelUploadLiveTestCase
 
       - name: Run direct media test
         if: github.event.inputs.test_target == 'direct' || github.event.inputs.test_target == 'all'

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -300,7 +300,7 @@ Upload medias to your feed. Common arguments:
 | video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {})            | Media   | Upload video (Support MP4 files)
 | album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {})                      | Media   | Upload Album (Support JPG/MP4 files)
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
-| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {})             | Media   | Upload Reels Clip (Support MP4 files)
+| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual") | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts
 | clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload Reels Clip as reel with music metadata
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
@@ -314,6 +314,8 @@ In `extra_data`, you can pass additional media settings, for example:
 | like_and_view_counts_disabled | Int    | [Disable like and view counts](https://github.com/subzeroid/instagrapi/issues/382) `{"like_and_view_counts_disabled": 1}`
 | disable_comments              | Int    | Disable comments `{"disable_comments": 1}`
 | invite_coauthor_user_id       | Int    | Add a coauthor to the post `{"invite_coauthor_user_id": "USER ID OF COAUTHOR HERE"}`. You also need to add this user to `usertags`
+
+Trial Reels are available only for accounts where Instagram has enabled the feature. When `trial=True`, `clip_upload` sends `trial_params={"graduation_strategy": "manual"}` by default and disables feed preview for the upload.
 
 ### Example:
 
@@ -331,6 +333,12 @@ In `extra_data`, you can pass additional media settings, for example:
         "like_and_view_counts_disabled": 1,
         "disable_comments": 1,
     }
+)
+
+>>> trial_reel = cl.clip_upload(
+    "/app/reel.mp4",
+    "Trying a new Reel format",
+    trial=True,
 )
 
 >>> media.dict()

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -164,7 +164,9 @@ class UploadClipMixin:
         location: Location = None,
         configure_timeout: int = 10,
         feed_show: str = "1",
-        extra_data: Dict[str, str] = {},
+        extra_data: Dict[str, object] = {},
+        trial: bool = False,
+        trial_graduation_strategy: str = "manual",
     ) -> Media:
         """
         Upload CLIP to Instagram
@@ -184,9 +186,16 @@ class UploadClipMixin:
             Location tag for this upload, default is none
         configure_timeout: int
             Timeout between attempt to configure media (set caption, etc), default is 10
-        extra_data: Dict[str, str], optional
+        feed_show: str
+            Show Reel preview in feed/profile grid, default is "1".
+            Forced to "0" for Trial Reels.
+        extra_data: Dict[str, object], optional
             Dict of extra data, if you need to add your params,
             like {"share_to_facebook": 1}.
+        trial: bool, optional
+            Upload as a Trial Reel for eligible accounts, default is False.
+        trial_graduation_strategy: str, optional
+            Trial Reel graduation strategy, default is "manual".
 
         Returns
         -------
@@ -201,6 +210,13 @@ class UploadClipMixin:
         with open(path, "rb") as fp:
             clip_data = fp.read()
             clip_len = str(len(clip_data))
+        configure_extra_data = dict(extra_data or {})
+        if trial:
+            feed_show = "0"
+            configure_extra_data.setdefault(
+                "trial_params",
+                {"graduation_strategy": trial_graduation_strategy},
+            )
         duration_ms = str(int(duration * 1000))
         composer_session_id = str(uuid4())
         asset_id = uuid4().hex[:12].upper()
@@ -347,7 +363,7 @@ class UploadClipMixin:
                     usertags,
                     location,
                     feed_show,
-                    extra_data=extra_data,
+                    extra_data=configure_extra_data,
                 )
             except ClientError as e:
                 if "Transcode not finished yet" in str(e):
@@ -373,7 +389,7 @@ class UploadClipMixin:
         path: Path,
         caption: str,
         track: Track,
-        extra_data: Dict[str, str] = {},
+        extra_data: Dict[str, object] = {},
     ) -> Media:
         """
         Upload CLIP as reel with music metadata.
@@ -393,7 +409,7 @@ class UploadClipMixin:
             The music track to be added to the video reel
             use cl.search_music(title)[0].dict()
 
-        extra_data: Dict[str, str], optional
+        extra_data: Dict[str, object], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
 
         Returns
@@ -480,7 +496,7 @@ class UploadClipMixin:
         usertags: List[Usertag] = [],
         location: Location = None,
         feed_show: str = "1",
-        extra_data: Dict[str, str] = {},
+        extra_data: Dict[str, object] = {},
     ) -> Dict:
         """
         Post Configure CLIP (send caption, thumbnail and more to Instagram)
@@ -503,7 +519,7 @@ class UploadClipMixin:
             List of users to be tagged on this upload, default is empty list.
         location: Location, optional
             Location tag for this upload, default is None
-        extra_data: Dict[str, str], optional
+        extra_data: Dict[str, object], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
 
         Returns

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -251,3 +251,96 @@ class ClientFeedMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertUploadedMediaHasMusic(media)
         finally:
             self.cleanup_uploaded_media(media)
+
+
+class ClientTrialReelUploadLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for Trial Reel upload live tests")
+        try:
+            self.cl = self.trial_reel_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def trial_reel_account(self):
+        accounts = self.fresh_accounts(5)
+        for client in accounts:
+            if self.trial_clips_enabled(client):
+                return client
+        self.skipTest("No fresh account has trial_clips_enabled")
+
+    def trial_clips_enabled(self, client):
+        result = client.private_request(f"users/{client.user_id}/info/")
+        user = result.get("user") or {}
+        return bool(user.get("trial_clips_enabled"))
+
+    def make_clip_mp4(self):
+        try:
+            import imageio_ffmpeg
+        except ImportError:
+            self.skipTest("imageio_ffmpeg is required to generate a Trial Reel fixture")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as tmp:
+            path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+
+        try:
+            subprocess.run(
+                [
+                    imageio_ffmpeg.get_ffmpeg_exe(),
+                    "-y",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=c=purple:s=720x1280:r=30:d=2",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "sine=frequency=440:duration=2",
+                    "-shortest",
+                    "-c:v",
+                    "libx264",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "64k",
+                    str(path),
+                ],
+                check=True,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            self.skipTest(f"Could not generate Trial Reel fixture: {exc}")
+        return path
+
+    def cleanup_uploaded_media(self, media):
+        if not media:
+            return
+        try:
+            self.assertTrue(self.cl.media_delete(media.id))
+        except Exception as exc:
+            print(f"Trial Reel upload cleanup media_delete failed: {exc.__class__.__name__} {exc}")
+
+    def test_clip_upload_trial_live(self):
+        path = self.make_clip_mp4()
+        media = None
+        try:
+            try:
+                media = self.cl.clip_upload(path, "Trial Reel live test", trial=True)
+            except UnknownError as exc:
+                if "not eligible for trial Clips" in str(exc):
+                    self.skipTest("Instagram rejected this account for trial Clips")
+                raise
+
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.media_type, 2)
+            self.assertEqual(media.product_type, "clips")
+        finally:
+            self.cleanup_uploaded_media(media)

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -256,22 +256,16 @@ class ClientFeedMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):
 class ClientTrialReelUploadLiveTestCase(_helpers.ClientPrivateTestCase):
     def __init__(self, *args, **kwargs):
         self.cl = None
+        self.clients = []
         return unittest.TestCase.__init__(self, *args, **kwargs)
 
     def setUp(self):
         if not TEST_ACCOUNTS_URL:
             self.skipTest("TEST_ACCOUNTS_URL is required for Trial Reel upload live tests")
         try:
-            self.cl = self.trial_reel_account()
+            self.clients = self.fresh_accounts(5)
         except RuntimeError as exc:
             self.skipTest(str(exc))
-
-    def trial_reel_account(self):
-        accounts = self.fresh_accounts(5)
-        for client in accounts:
-            if self.trial_clips_enabled(client):
-                return client
-        self.skipTest("No fresh account has trial_clips_enabled")
 
     def trial_clips_enabled(self, client):
         result = client.private_request(f"users/{client.user_id}/info/")
@@ -320,27 +314,39 @@ class ClientTrialReelUploadLiveTestCase(_helpers.ClientPrivateTestCase):
             self.skipTest(f"Could not generate Trial Reel fixture: {exc}")
         return path
 
-    def cleanup_uploaded_media(self, media):
+    def cleanup_uploaded_media(self, client, media):
         if not media:
             return
         try:
-            self.assertTrue(self.cl.media_delete(media.id))
+            self.assertTrue(client.media_delete(media.id))
         except Exception as exc:
             print(f"Trial Reel upload cleanup media_delete failed: {exc.__class__.__name__} {exc}")
 
     def test_clip_upload_trial_live(self):
         path = self.make_clip_mp4()
-        media = None
-        try:
+        rejected = 0
+        checked = 0
+
+        for client in self.clients:
+            if not self.trial_clips_enabled(client):
+                continue
+            checked += 1
+            media = None
             try:
-                media = self.cl.clip_upload(path, "Trial Reel live test", trial=True)
+                media = client.clip_upload(path, "Trial Reel live test", trial=True)
             except UnknownError as exc:
                 if "not eligible for trial Clips" in str(exc):
-                    self.skipTest("Instagram rejected this account for trial Clips")
+                    rejected += 1
+                    continue
                 raise
+            finally:
+                self.cleanup_uploaded_media(client, media)
 
             self.assertIsInstance(media, Media)
             self.assertEqual(media.media_type, 2)
             self.assertEqual(media.product_type, "clips")
-        finally:
-            self.cleanup_uploaded_media(media)
+            return
+
+        if checked:
+            self.skipTest(f"Instagram rejected {rejected}/{checked} trial_clips_enabled accounts for trial Clips")
+        self.skipTest("No fresh account has trial_clips_enabled")

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -374,6 +374,89 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(rupload_params["upload_media_duration_ms"], "6023")
         self.assertEqual(rupload_params["session_id"], rupload_params["upload_id"])
 
+    def test_clip_upload_trial_adds_trial_params_without_mutating_extra_data(self):
+        client = self.build_client()
+        client.last_json = {"media": self.build_media_payload()}
+        ok_response = Mock(status_code=200)
+        extra_data = {"share_to_facebook": 1}
+
+        with mock.patch(
+            "instagrapi.mixins.clip.analyze_video",
+            return_value=(Path("/tmp/thumb.jpg"), 720, 1280, 6.023),
+        ):
+            with mock.patch.object(client.private, "get", return_value=ok_response):
+                with mock.patch.object(
+                    client.private,
+                    "post",
+                    side_effect=[ok_response, ok_response],
+                ):
+                    with mock.patch.object(client, "clip_configure", return_value={"status": "ok"}) as clip_configure:
+                        with mock.patch(
+                            "builtins.open",
+                            mock.mock_open(read_data=b"video-bytes"),
+                        ):
+                            with mock.patch("time.sleep"):
+                                client.clip_upload(
+                                    Path("example.mp4"),
+                                    "caption",
+                                    trial=True,
+                                    trial_graduation_strategy="manual",
+                                    extra_data=extra_data,
+                                )
+
+        self.assertEqual(extra_data, {"share_to_facebook": 1})
+        self.assertEqual(clip_configure.call_args.args[8], "0")
+        configure_extra = clip_configure.call_args.kwargs["extra_data"]
+        self.assertEqual(configure_extra["share_to_facebook"], 1)
+        self.assertEqual(
+            configure_extra["trial_params"],
+            {"graduation_strategy": "manual"},
+        )
+
+    def test_clip_upload_trial_preserves_explicit_trial_params(self):
+        client = self.build_client()
+        client.last_json = {"media": self.build_media_payload()}
+        ok_response = Mock(status_code=200)
+        extra_data = {
+            "trial_params": {
+                "graduation_strategy": "ss_performance",
+                "custom_field": "1",
+            },
+        }
+
+        with mock.patch(
+            "instagrapi.mixins.clip.analyze_video",
+            return_value=(Path("/tmp/thumb.jpg"), 720, 1280, 6.023),
+        ):
+            with mock.patch.object(client.private, "get", return_value=ok_response):
+                with mock.patch.object(
+                    client.private,
+                    "post",
+                    side_effect=[ok_response, ok_response],
+                ):
+                    with mock.patch.object(client, "clip_configure", return_value={"status": "ok"}) as clip_configure:
+                        with mock.patch(
+                            "builtins.open",
+                            mock.mock_open(read_data=b"video-bytes"),
+                        ):
+                            with mock.patch("time.sleep"):
+                                client.clip_upload(
+                                    Path("example.mp4"),
+                                    "caption",
+                                    trial=True,
+                                    extra_data=extra_data,
+                                )
+
+        self.assertEqual(clip_configure.call_args.args[8], "0")
+        configure_extra = clip_configure.call_args.kwargs["extra_data"]
+        self.assertEqual(
+            configure_extra["trial_params"],
+            {
+                "graduation_strategy": "ss_performance",
+                "custom_field": "1",
+            },
+        )
+
     def test_video_story_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 


### PR DESCRIPTION
## Summary
Closes #2145.

Adds Trial Reels support to `clip_upload`:
- adds `trial` and `trial_graduation_strategy` parameters
- sends `trial_params={"graduation_strategy": "manual"}` by default for trial uploads
- forces `clips_share_preview_to_feed` to `"0"` for trial uploads
- preserves caller-provided `extra_data`, including explicit `trial_params` overrides

Docs now show the new parameters and note that Trial Reels are account-gated by Instagram.

## Live Coverage
The manual `Live Account Tests` workflow now includes Trial Reels in the `upload` target:
- `tests/live/test_upload.py::ClientTrialReelUploadLiveTestCase`
- the test generates a short MP4 fixture, filters fresh accounts by `trial_clips_enabled`, and tries `clip_upload(..., trial=True)`
- it retries across eligible-looking fresh accounts and skips only when Instagram rejects all of them at the server-side trial eligibility gate

## Test Coverage
All new code paths have regression coverage:
- normal `clip_upload` path remains covered by existing upload-flow tests
- `trial=True` adds default `trial_params` and does not mutate `extra_data`
- explicit `trial_params` in `extra_data` are preserved

Tests: added 2 regression test cases to `tests/regression/test_upload.py` and 1 live-account test class to `tests/live/test_upload.py`.

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed; design review skipped.

## Eval Results
No prompt-related files changed; evals skipped.

## Scope Drift
Scope Check: CLEAN

Intent: add Trial Reels upload support for Instagram Reels.
Delivered: `clip_upload` can now configure Trial Reels, with focused docs, regression tests, and manual live workflow coverage.

## Plan Completion
No plan file detected.

## Verification Results
- [x] `.venv/bin/python -m unittest tests.regression.test_upload` — 28 tests passed
- [x] `.venv/bin/python -m pytest tests/regression -q` — 186 passed, 1 warning, 3 subtests passed
- [x] `.venv/bin/python -m ruff check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py` — all checks passed
- [x] `env -u TEST_ACCOUNTS_URL .venv/bin/python -m pytest -q -rs tests/live/test_upload.py::ClientTrialReelUploadLiveTestCase` — 1 skipped as expected without live-test secret
- [x] `pytest -q -rs tests/live/test_upload.py::ClientTrialReelUploadLiveTestCase` on the live-test host — 1 skipped because Instagram rejected 5/5 `trial_clips_enabled` fresh accounts for trial Clips
- [x] `git diff --check HEAD~3..HEAD` — passed

## Test plan
- [x] Trial Reel configure payload includes `trial_params`
- [x] Trial Reel upload hides feed preview via `clips_share_preview_to_feed="0"`
- [x] Caller `extra_data` is not mutated
- [x] Caller-provided `trial_params` are not overwritten
- [x] Manual live `upload` workflow covers Trial Reel upload when an actually eligible account is available