### PR TITLE
Add tagged media pagination and fix location cursor reset

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -32,6 +32,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | user_medias_paginated(user_id: str, amount: int = 0, end_cursor: str = "") | Tuple[List\[Media], str] | Get one page of user media and next cursor |
 | user_clips(user_id: str, amount: int = 0) | List\[Media] | Get clips/reels by user |
 | usertag_medias(user_id: str, amount: int = 0) | List\[Media] | Get media where a user is tagged |
+| usertag_medias_paginated(user_id: str, amount: int = 0, end_cursor: str = "") | Tuple[List\[Media], str] | Get one page of media where a user is tagged and next cursor |
 | media_info(media_pk: str, use_cache: bool = True) | Media | Return media info |
 | media_delete(media_id: str) | bool | Delete media |
 | media_edit(media_id: str, caption: str, title: str = "", usertags: List[Usertag] = [], location: Location = None) | dict | Edit caption, optional IGTV title, usertags, or location |
@@ -72,7 +73,9 @@ Low level methods:
 | user_videos_v1(user_id: str, amount: int = 0) | List\[Media] | Get user videos via private mobile API |
 | user_videos_paginated_v1(user_id: int, amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of videos |
 | usertag_medias_gql(user_id: str, amount: int = 0, sleep: int = 2) | List\[Media] | Get media where a user is tagged via public GraphQL API |
+| usertag_medias_paginated_gql(user_id: str, amount: int = 0, sleep: int = 2, end_cursor=None) | Tuple[List\[Media], str] | Get one public GraphQL page of media where a user is tagged |
 | usertag_medias_v1(user_id: str, amount: int = 0) | List\[Media] | Get media where a user is tagged via private mobile API |
+| usertag_medias_paginated_v1(user_id: str, amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of media where a user is tagged |
 | archive_medias_v1(amount: int = 0) | List\[Media] | Get archived media via private mobile API |
 | archive_medias_paginated_v1(amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of archived media |
 
@@ -218,6 +221,11 @@ True
 ['2021-06-09', '2019-10-16', '2019-10-14', '2019-06-13', '2019-06-06']
 ['2019-06-05', '2019-03-23', '2019-03-23', '2018-11-15', '2018-10-16']
 ['2018-10-16', '2018-10-11', '2018-10-09', '2018-10-09', '2018-08-02']
+
+# Resume tagged-media fetches from a stored cursor
+
+>>> tagged, end_cursor = client.usertag_medias_paginated(1903424587, 12, end_cursor="")
+>>> next_tagged, end_cursor = client.usertag_medias_paginated(1903424587, 12, end_cursor=end_cursor)
 
 >>> media_id = cl.media_id(1787135824035452364)
 >>> cl.media_like(media_id)

--- a/instagrapi/mixins/location.py
+++ b/instagrapi/mixins/location.py
@@ -347,7 +347,7 @@ class LocationMixin:
             data=data,
         )
         next_max_id = None
-        if result.get("next_page"):
+        if result.get("next_page") and result.get("next_max_id"):
             np = result.get("next_page")
             ids = result.get("next_media_ids")
             next_m_id = result.get("next_max_id")

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -1143,6 +1143,70 @@ class MediaMixin:
             medias = medias[:amount]
         return [extract_media_gql(media) for media in medias]
 
+    def usertag_medias_paginated_gql(
+        self, user_id: str, amount: int = 0, sleep: int = 2, end_cursor=None
+    ) -> Tuple[List[Media], str]:
+        """
+        Get a page of medias where a user is tagged (by Public GraphQL API)
+
+        Parameters
+        ----------
+        user_id: str
+        amount: int, optional
+            Maximum number of media to return, default is 0 (all medias)
+        sleep: int, optional
+            Kept for API symmetry with usertag_medias_gql; not used for a single page fetch.
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+
+        Returns
+        -------
+        Tuple[List[Media], str]
+            A tuple containing a list of medias and the next end_cursor value
+        """
+        amount = int(amount)
+        user_id = int(user_id)
+        variables = {
+            "id": user_id,
+            "first": 50 if not amount or amount > 50 else amount,
+        }
+        if end_cursor:
+            variables["after"] = end_cursor
+        data = self.public_graphql_request(variables, query_hash="be13233562af2d229b008d2976b998b5")
+        page_info = json_value(data, "user", "edge_user_to_photos_of_you", "page_info", default={})
+        edges = json_value(data, "user", "edge_user_to_photos_of_you", "edges", default=[])
+        medias = [edge["node"] for edge in edges]
+        if amount:
+            medias = medias[:amount]
+        return [extract_media_gql(media) for media in medias], page_info.get("end_cursor")
+
+    def usertag_medias_paginated_v1(
+        self, user_id: str, amount: int = 0, end_cursor: str = ""
+    ) -> Tuple[List[Media], str]:
+        """
+        Get a page of medias where a user is tagged (by Private Mobile API)
+
+        Parameters
+        ----------
+        user_id: str
+        amount: int, optional
+            Maximum number of media to return, default is 0 (all medias)
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+
+        Returns
+        -------
+        Tuple[List[Media], str]
+            A tuple containing a list of medias and the next end_cursor value
+        """
+        amount = int(amount)
+        user_id = int(user_id)
+        result = self.private_request(f"usertags/{user_id}/feed/", params={"max_id": end_cursor})
+        items = result.get("items", [])
+        if amount:
+            items = items[:amount]
+        return [extract_media_v1(media) for media in items], result.get("next_max_id") or ""
+
     def usertag_medias_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get medias where a user is tagged (by Private Mobile API)
@@ -1179,6 +1243,31 @@ class MediaMixin:
         if amount:
             medias = medias[:amount]
         return [extract_media_v1(media) for media in medias]
+
+    def usertag_medias_paginated(self, user_id: str, amount: int = 0, end_cursor: str = "") -> Tuple[List[Media], str]:
+        """
+        Get a page of medias where a user is tagged
+
+        Parameters
+        ----------
+        user_id: str
+        amount: int, optional
+            Maximum number of media to return, default is 0 (all medias)
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+
+        Returns
+        -------
+        Tuple[List[Media], str]
+            A tuple containing a list of medias and the next end_cursor value
+        """
+        amount = int(amount)
+        user_id = int(user_id)
+        try:
+            medias, end_cursor = self.usertag_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
+        except ClientError:
+            medias, end_cursor = self.usertag_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
+        return medias, end_cursor
 
     def usertag_medias(self, user_id: str, amount: int = 0) -> List[Media]:
         """

--- a/tests/regression/test_hardening.py
+++ b/tests/regression/test_hardening.py
@@ -195,3 +195,19 @@ class HardeningRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(medias, ["m1", "m2"])
         self.assertEqual(client.location_medias_v1_chunk.call_count, 2)
+
+    def test_location_medias_v1_chunk_stops_when_next_max_id_is_missing(self):
+        client = Client()
+        client.private_request = Mock(
+            return_value={
+                "next_page": 335,
+                "next_media_ids": [],
+                "next_max_id": None,
+                "sections": [],
+            }
+        )
+
+        medias, next_max_id = client.location_medias_v1_chunk(123, tab_key="recent")
+
+        self.assertEqual(medias, [])
+        self.assertIsNone(next_max_id)

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -92,3 +92,98 @@ class CheckOffensiveCommentV2RegressionTestCase(unittest.TestCase):
         # No authorization_data → user_id property returns None.
         with self.assertRaises(AssertionError):
             client.media_check_offensive_comment_v2("9_8", "rude")
+
+
+class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
+    def _media_v1_payload(self, pk="1"):
+        return {
+            "pk": pk,
+            "id": f"{pk}_2",
+            "code": "abc",
+            "taken_at": 1710000000,
+            "media_type": 1,
+            "user": {
+                "pk": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "image_versions2": {"candidates": [{"url": "https://example.com/x.jpg", "width": 100, "height": 100}]},
+        }
+
+    def _media_gql_payload(self, pk="1"):
+        return {
+            "__typename": "GraphImage",
+            "id": pk,
+            "shortcode": "abc",
+            "taken_at_timestamp": 1710000000,
+            "owner": {
+                "id": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "display_resources": [{"src": "https://example.com/x.jpg", "config_width": 100, "config_height": 100}],
+            "edge_media_to_comment": {"count": 0},
+            "edge_media_preview_like": {"count": 0},
+            "edge_media_to_caption": {"edges": []},
+            "edge_media_to_tagged_user": {"edges": []},
+        }
+
+    def test_usertag_medias_paginated_gql_returns_page_and_cursor(self):
+        client = Client()
+        payload = self._media_gql_payload()
+
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            return_value={
+                "user": {
+                    "edge_user_to_photos_of_you": {
+                        "page_info": {"end_cursor": "next-page"},
+                        "edges": [{"node": payload}],
+                    }
+                }
+            },
+        ) as public_graphql_request:
+            medias, end_cursor = client.usertag_medias_paginated_gql("123", amount=1, end_cursor="cursor-1")
+
+        public_graphql_request.assert_called_once_with(
+            {"id": 123, "first": 1, "after": "cursor-1"},
+            query_hash="be13233562af2d229b008d2976b998b5",
+        )
+        self.assertEqual(end_cursor, "next-page")
+        self.assertEqual([media.pk for media in medias], ["1"])
+
+    def test_usertag_medias_paginated_v1_returns_page_and_cursor(self):
+        client = Client()
+        payload = self._media_v1_payload()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"items": [payload], "next_max_id": "next-page"},
+        ) as private_request:
+            medias, end_cursor = client.usertag_medias_paginated_v1("123", amount=1, end_cursor="cursor-1")
+
+        private_request.assert_called_once_with("usertags/123/feed/", params={"max_id": "cursor-1"})
+        self.assertEqual(end_cursor, "next-page")
+        self.assertEqual([media.pk for media in medias], ["1"])
+
+    def test_usertag_medias_paginated_falls_back_to_v1(self):
+        client = Client()
+
+        with mock.patch.object(
+            client,
+            "usertag_medias_paginated_gql",
+            side_effect=ClientError("public unavailable"),
+        ) as gql:
+            with mock.patch.object(
+                client,
+                "usertag_medias_paginated_v1",
+                return_value=(["m1"], "next-page"),
+            ) as v1:
+                medias, end_cursor = client.usertag_medias_paginated("123", amount=5, end_cursor="cursor-1")
+
+        gql.assert_called_once_with(123, 5, end_cursor="cursor-1")
+        v1.assert_called_once_with(123, 5, end_cursor="cursor-1")
+        self.assertEqual(medias, ["m1"])
+        self.assertEqual(end_cursor, "next-page")


### PR DESCRIPTION
## Summary
- add paginated tagged-media helpers for public GraphQL and private v1 APIs
- keep the public `usertag_medias_paginated(...)` fallback behavior aligned with `usertag_medias(...)`
- stop `location_medias_v1_chunk(...)` from returning an encoded cursor when Instagram omits `next_max_id`
- document the new tagged-media pagination API

Closes #2033.
Fixes #2055.

## Tests
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/media.py instagrapi/mixins/location.py tests/regression/test_media.py tests/regression/test_hardening.py`
- `git diff --check`