### PR TITLE
Fix story location sticker upload

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -13,6 +13,7 @@ on:
           - upload
           - direct
           - timeline
+          - story-location
           - location
           - usertag
           - user
@@ -57,6 +58,10 @@ jobs:
       - name: Run timeline test
         if: github.event.inputs.test_target == 'timeline' || github.event.inputs.test_target == 'all'
         run: pytest -sv tests/live/test_timeline.py::ClientTimelineLiveTestCase
+
+      - name: Run story location sticker live test
+        if: github.event.inputs.test_target == 'story-location' || github.event.inputs.test_target == 'all'
+        run: pytest -sv tests/live/test_story.py::ClientStoryLocationStickerLiveTestCase
 
       - name: Run location test
         if: github.event.inputs.test_target == 'location' || github.event.inputs.test_target == 'all'

--- a/instagrapi/mixins/location.py
+++ b/instagrapi/mixins/location.py
@@ -163,6 +163,23 @@ class LocationMixin:
         }
         return json.dumps(data, separators=(",", ":"))
 
+    def location_story_sticker_id(self, location: Location) -> str:
+        """
+        Build location id for story sticker tap models.
+
+        Parameters
+        ----------
+        location: Location
+            An object of location
+
+        Returns
+        -------
+        str
+        """
+        if not location:
+            return ""
+        return str(location.external_id or location.pk or "")
+
     def location_info_a1(self, location_pk: int) -> Location:
         """
         Get a location using location pk

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -694,7 +694,7 @@ class UploadPhotoMixin:
                     "height": mention.height,
                     "rotation": 0.0,
                     "type": "location",
-                    "location_id": str(mention.location.pk),
+                    "location_id": self.location_story_sticker_id(mention.location),
                     "is_sticker": True,
                     "tap_state": 0,
                     "tap_state_str_id": "location_sticker_vibrant",

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -735,7 +735,7 @@ class UploadVideoMixin:
                     "height": mention.height,
                     "rotation": 0.0,
                     "type": "location",
-                    "location_id": str(mention.location.pk),
+                    "location_id": self.location_story_sticker_id(mention.location),
                     "is_sticker": True,
                     "tap_state": 0,
                     "tap_state_str_id": "location_sticker_vibrant",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -72,6 +72,7 @@ from instagrapi.types import (
     Story,
     StoryHashtag,
     StoryLink,
+    StoryLocation,
     StoryMedia,
     StoryMention,
     StorySticker,

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -176,6 +176,92 @@ class ClientStoryTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(self.cl.story_seen([story.pk]))
 
 
+class ClientStoryLocationStickerLiveTestCase(_helpers.ClientPrivateTestCase):
+    photo_path = Path("examples/background.png")
+
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for story location sticker live tests")
+        try:
+            self.cl = self.fresh_account()
+        except Exception as exc:
+            self.skipTest(str(exc))
+
+    def get_location(self):
+        location = self.cl.location_search(lat=59.939095, lng=30.315868)[0]
+        self.assertIsInstance(location, Location)
+        return location
+
+    def story_info_with_locations(self, story_pk):
+        last_story = None
+        for _ in range(5):
+            last_story = self.cl.story_info(story_pk)
+            self.assertIsInstance(last_story, Story)
+            if last_story.locations:
+                return last_story
+            time.sleep(3)
+        return last_story
+
+    def user_story_ids(self):
+        return {story.id for story in self.cl.user_stories(self.cl.user_id, amount=10)}
+
+    def uploaded_story(self, existing_story_ids):
+        for _ in range(5):
+            for story in self.cl.user_stories(self.cl.user_id, amount=10):
+                if story.id not in existing_story_ids:
+                    return story
+            time.sleep(3)
+        return None
+
+    def cleanup_uploaded_story(self, story):
+        if not story:
+            return
+        try:
+            self.assertTrue(self.cl.story_delete(story.id))
+        except Exception as exc:
+            print(f"Story location sticker live cleanup story_delete failed: {exc.__class__.__name__} {exc}")
+
+    def test_photo_story_location_sticker_round_trips_live(self):
+        location = self.get_location()
+        story = None
+        existing_story_ids = self.user_story_ids()
+        try:
+            upload_id, width, height = self.cl.photo_rupload(self.photo_path, for_story=True)
+            time.sleep(3)
+            configured = self.cl.photo_configure_to_story(
+                upload_id=upload_id,
+                width=width,
+                height=height,
+                caption="Story location sticker live test",
+                locations=[
+                    StoryLocation(
+                        location=location,
+                        x=0.5,
+                        y=0.5,
+                        width=0.5,
+                        height=0.1,
+                    )
+                ],
+            )
+            self.assertEqual(configured.get("status"), "ok")
+
+            story = self.uploaded_story(existing_story_ids)
+            self.assertIsInstance(story, Story)
+            info = self.story_info_with_locations(story.pk)
+            self.assertTrue(info.locations)
+            self.assertIsInstance(info.locations[0].location, Location)
+            self.assertTrue(info.locations[0].location.name)
+        finally:
+            self.cleanup_uploaded_story(story)
+
+
 # class BloksTestCase(_helpers.ClientPrivateTestCase):
 #
 #     def test_bloks_change_password(self):

--- a/tests/regression/test_story_configure.py
+++ b/tests/regression/test_story_configure.py
@@ -14,6 +14,30 @@ class StoryConfigureRegressionTestCase(unittest.TestCase):
         client.with_default_data = lambda data: data
         return client
 
+    def build_location(self):
+        return Location(
+            pk=213597007,
+            name="Palace Square",
+            address="Palace Square, Saint Petersburg",
+            lat=59.939166,
+            lng=30.315833,
+            external_id=107617247320879,
+            external_id_source="facebook_places",
+        )
+
+    def assert_story_location_model(self, data):
+        self.assertEqual(data["story_sticker_ids"], "location_sticker")
+
+        tap_models = json.loads(data["tap_models"])
+        self.assertEqual(len(tap_models), 1)
+        location_model = tap_models[0]
+        self.assertEqual(location_model["type"], "location")
+        self.assertTrue(location_model["is_sticker"])
+        self.assertEqual(location_model["tap_state"], 0)
+        self.assertEqual(location_model["tap_state_str_id"], "location_sticker_vibrant")
+        self.assertNotIn("location", location_model)
+        self.assertEqual(location_model["location_id"], "107617247320879")
+
     def test_photo_story_sticker_ids_include_all_stickers(self):
         client = self.build_client()
 
@@ -46,3 +70,59 @@ class StoryConfigureRegressionTestCase(unittest.TestCase):
             configure_args[1]["story_sticker_ids"],
             "hashtag_sticker,link_sticker_default",
         )
+
+    def test_photo_story_location_uses_external_location_id_tap_model(self):
+        client = self.build_client()
+        location = self.build_location()
+
+        with mock.patch.object(client, "location_complete", return_value=location):
+            with mock.patch.object(client, "private_request") as private_request:
+                private_request.return_value = {"status": "ok"}
+                client.photo_configure_to_story(
+                    upload_id="1",
+                    width=720,
+                    height=1280,
+                    caption="",
+                    locations=[
+                        StoryLocation(
+                            location=location,
+                            x=0.2,
+                            y=0.3,
+                            width=0.4,
+                            height=0.1,
+                        )
+                    ],
+                )
+
+        configure_args, _ = private_request.call_args
+        self.assertEqual(configure_args[0], "media/configure_to_story/")
+        self.assert_story_location_model(configure_args[1])
+
+    def test_video_story_location_uses_external_location_id_tap_model(self):
+        client = self.build_client()
+        location = self.build_location()
+
+        with mock.patch.object(client, "location_complete", return_value=location):
+            with mock.patch.object(client, "private_request") as private_request:
+                private_request.return_value = {"status": "ok"}
+                client.video_configure_to_story(
+                    upload_id="1",
+                    width=720,
+                    height=1280,
+                    duration=3,
+                    thumbnail=Path("thumbnail.jpg"),
+                    caption="",
+                    locations=[
+                        StoryLocation(
+                            location=location,
+                            x=0.2,
+                            y=0.3,
+                            width=0.4,
+                            height=0.1,
+                        )
+                    ],
+                )
+
+        configure_args, _ = private_request.call_args
+        self.assertEqual(configure_args[0], "media/configure_to_story/?video=1")
+        self.assert_story_location_model(configure_args[1])


### PR DESCRIPTION
## Summary
- send story location stickers with the external location id Instagram uses in `tap_models[].location_id` instead of the Instagram location pk
- add regression coverage for photo/video story configure payloads where `pk != external_id`
- add focused `story-location` live workflow target and round-trip live test for `story_info().locations`

## Verification
- `.venv/bin/python -m pytest -q tests/regression` -> 192 passed, 1 warning, 3 subtests passed
- `sk.test: pytest -sv tests/live/test_story.py::ClientStoryLocationStickerLiveTestCase` -> 1 passed, 2 warnings in 41.12s

Closes #2133