### PR TITLE
Fix Pydroid video uploads with provided thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Or install it into the active virtual environment:
 uv pip install instagrapi
 ```
 
+Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation,
+`StoryBuilder`, and video/audio composition still need executable `ffmpeg`; Android/Pydroid users should see
+[Pydroid and ffmpeg](docs/usage-guide/pydroid.md).
+
 ## Quick Start
 
 ``` python

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`Comment`](usage-guide/comment.md) - Comments to Media
   * [`Highlight`](usage-guide/highlight.md) - Highlights
   * [`Notes`](usage-guide/notes.md) - Notes
+  * [`Pydroid and ffmpeg`](usage-guide/pydroid.md) - Android/Pydroid video upload setup
   * [`Story`](usage-guide/story.md) - Story
   * [`StoryArchiveDay`](usage-guide/story.md) - Story archive day shell
   * [`StoryLink`](usage-guide/story.md) - Link sticker

--- a/docs/usage-guide/fundamentals.md
+++ b/docs/usage-guide/fundamentals.md
@@ -33,6 +33,7 @@ use an internal fallback chain and choose the best currently working path for th
   * [`Comment`](comment.md) - Comments to Media
   * [`Highlight`](highlight.md) - Highlights
   * [`Notes`](notes.md) - Direct Notes
+  * [`Pydroid and ffmpeg`](pydroid.md) - Android/Pydroid video upload setup
   * [`Story`](story.md) - Story
   * [`StoryArchiveDay`](story.md) - Story archive day shell
   * [`StoryLink`](story.md) - Story link sticker

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -313,6 +313,8 @@ Upload medias to your feed. Common arguments:
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
 
+For video uploads in Android/Pydroid environments, pass `thumbnail=...` to avoid automatic thumbnail generation or configure executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md).
+
 
 In `extra_data`, you can pass additional media settings, for example:
 

--- a/docs/usage-guide/pydroid.md
+++ b/docs/usage-guide/pydroid.md
@@ -1,0 +1,89 @@
+# Pydroid and ffmpeg
+
+Android/Pydroid can run many `instagrapi` flows, but video helpers need special care because Android apps often cannot execute arbitrary binaries from shared storage.
+
+## What needs ffmpeg
+
+`instagrapi` does not need ffmpeg for login, reads, photo uploads, downloads, or normal API requests.
+
+For standard MP4 files, `instagrapi` can read video width, height, and duration with its built-in MP4 parser. If you also pass a thumbnail file, these upload helpers do not need MoviePy/ffmpeg just to analyze the upload:
+
+```python
+from pathlib import Path
+
+cl.video_upload(Path("video.mp4"), "caption", thumbnail=Path("thumb.jpg"))
+cl.clip_upload(Path("reel.mp4"), "caption", thumbnail=Path("thumb.jpg"))
+cl.igtv_upload(Path("video.mp4"), "title", "caption", thumbnail=Path("thumb.jpg"))
+cl.video_upload_to_story(Path("story.mp4"), thumbnail=Path("thumb.jpg"))
+```
+
+MoviePy/ffmpeg is still required when `instagrapi` has to render or extract media:
+
+* automatic thumbnail generation when `thumbnail` is not provided
+* `StoryBuilder`
+* `prepare_video()`
+* `clip_upload_as_reel_with_music()` and other audio/video composition helpers
+* video album uploads, because album video items currently generate thumbnails internally
+* non-standard MP4 files that the built-in parser cannot read
+
+## Error
+
+If ffmpeg is missing or cannot be executed, video thumbnail generation can fail with:
+
+```text
+RuntimeError: No ffmpeg exe could be found. Install ffmpeg on your system, or set the IMAGEIO_FFMPEG_EXE environment variable.
+```
+
+Current `instagrapi` upload helpers raise a clearer error for this thumbnail path:
+
+```text
+Could not generate video thumbnail. Pass thumbnail=... or install ffmpeg / set IMAGEIO_FFMPEG_EXE.
+```
+
+## Fix
+
+The most reliable Pydroid setup is to pre-process the video outside Pydroid and pass both files:
+
+* `video.mp4` - MP4 file accepted by Instagram, usually H.264 video with AAC audio
+* `thumb.jpg` - JPEG thumbnail for the upload
+
+Then call the upload method with `thumbnail=Path("thumb.jpg")`.
+
+If you need automatic thumbnail generation or StoryBuilder inside Pydroid, install an ffmpeg binary that the Pydroid app can execute and set `IMAGEIO_FFMPEG_EXE` before running the upload:
+
+```python
+import os
+
+os.environ["IMAGEIO_FFMPEG_EXE"] = "/absolute/path/to/ffmpeg"
+```
+
+Verify the same Python process can execute it:
+
+```python
+import os
+import subprocess
+
+subprocess.run([os.environ["IMAGEIO_FFMPEG_EXE"], "-version"], check=True)
+```
+
+If this raises `PermissionError`, the file exists but Android is not allowing Pydroid to execute it. A binary placed under shared storage such as `/storage/emulated/0/...` can hit that limitation. Move ffmpeg to a location executable by the app or use a Pydroid package/plugin that provides an executable binary.
+
+## Minimal upload example
+
+```python
+from pathlib import Path
+
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+media = cl.clip_upload(
+    Path("reel.mp4"),
+    "Uploaded from Pydroid",
+    thumbnail=Path("reel-thumb.jpg"),
+)
+print(media.pk)
+```
+
+If you omit `thumbnail=...`, Pydroid must have a working ffmpeg executable so `instagrapi` can capture a frame from the video.

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -86,6 +86,7 @@ Notes:
 * `links`, `hashtags`, `locations`, `stickers`, `medias`, and `polls` are all part of the story sticker payload.
 * Link stickers are supported through `StoryLink`; this is no longer the old Instagram "swipe up" flow.
 * For story uploads, use a 9:16 asset or build one with `StoryBuilder`.
+* Android/Pydroid users should pass `thumbnail=...` for video stories or configure ffmpeg. See [Pydroid and ffmpeg](pydroid.md).
 * Anonymous public story fetch is not guaranteed. If the public/web story path fails, reliable story retrieval usually requires an authenticated session.
 
 

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -11,6 +11,7 @@ from instagrapi import config
 from instagrapi.exceptions import ClientError, ClipConfigureError, ClipNotUpload
 from instagrapi.types import Location, Media, Track, Usertag
 from instagrapi.utils import date_time_original
+from instagrapi.video_util import analyze_video_for_upload
 
 try:
     from PIL import Image
@@ -574,25 +575,7 @@ def analyze_video(path: Path, thumbnail: Path = None) -> tuple:
     Tuple
         A tuple with (thumbail path, width, height, duration)
     """
-    try:
-        import moviepy.editor as mp
-    except ImportError:
-        try:
-            import moviepy as mp
-        except ImportError:
-            raise Exception("Please install moviepy>=1.0.3 and retry")
-
-    print(f'Analyzing CLIP file "{path}"')
-    with contextlib.ExitStack() as stack:
-        video = mp.VideoFileClip(str(path))
-        stack.enter_context(contextlib.closing(video))
-        width, height = video.size
-        if not thumbnail:
-            thumbnail = f"{path}.jpg"
-            print(f'Generating thumbnail "{thumbnail}"...')
-            video.save_frame(thumbnail, t=(video.duration / 2))
-            crop_thumbnail(thumbnail)
-    return thumbnail, width, height, video.duration
+    return analyze_video_for_upload(path, thumbnail, label="CLIP", crop_thumbnail=crop_thumbnail)
 
 
 def crop_thumbnail(path: Path) -> bool:

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -22,6 +22,7 @@ from instagrapi.types import (
     UserShort,
 )
 from instagrapi.utils import dumps
+from instagrapi.video_util import read_video_metadata, read_video_metadata_with_moviepy
 
 SELECTED_FILTERS = ("flagged", "unread")
 SEARCH_MODES = ("raven", "universal")
@@ -634,24 +635,15 @@ class DirectMixin:
     def _direct_video_metadata(self, path: Path) -> Tuple[int, int, float]:
         width, height, duration_sec = 720, 1280, 1.0
         try:
-            import moviepy.editor as mp
-        except ImportError:
+            metadata = read_video_metadata(path)
+        except Exception:
             try:
-                import moviepy as mp
+                metadata = read_video_metadata_with_moviepy(path)
             except ImportError:
                 return width, height, duration_sec
-
-        video = None
-        try:
-            video = mp.VideoFileClip(str(path))
-            width, height = video.size
-            duration_sec = float(video.duration or duration_sec)
-        except Exception:  # noqa: BLE001
-            return width, height, duration_sec
-        finally:
-            if video:
-                video.close()
-        return width, height, duration_sec
+            except Exception:  # noqa: BLE001
+                return width, height, duration_sec
+        return metadata.width, metadata.height, metadata.duration or duration_sec
 
     def _direct_thread_id_from_user_ids(self, user_ids: List[int], media_kind: str) -> int:
         thread = self.direct_thread_by_participants(user_ids)

--- a/instagrapi/mixins/igtv.py
+++ b/instagrapi/mixins/igtv.py
@@ -1,4 +1,3 @@
-import contextlib
 import json
 import random
 import time
@@ -10,6 +9,7 @@ from instagrapi import config
 from instagrapi.exceptions import ClientError, IGTVConfigureError, IGTVNotUpload
 from instagrapi.types import Location, Media, Usertag
 from instagrapi.utils import date_time_original
+from instagrapi.video_util import analyze_video_for_upload
 
 try:
     from PIL import Image
@@ -284,25 +284,7 @@ def analyze_video(path: Path, thumbnail: Path = None) -> tuple:
     Tuple
         A tuple with (thumbail path, width, height, duration)
     """
-    try:
-        import moviepy.editor as mp
-    except ImportError:
-        try:
-            import moviepy as mp
-        except ImportError:
-            raise Exception("Please install moviepy>=1.0.3 and retry")
-
-    print(f'Analyzing IGTV file "{path}"')
-    with contextlib.ExitStack() as stack:
-        video = mp.VideoFileClip(str(path))
-        stack.enter_context(contextlib.closing(video))
-        width, height = video.size
-        if not thumbnail:
-            thumbnail = f"{path}.jpg"
-            print(f'Generating thumbnail "{thumbnail}"...')
-            video.save_frame(thumbnail, t=(video.duration / 2))
-            crop_thumbnail(thumbnail)
-    return thumbnail, width, height, video.duration
+    return analyze_video_for_upload(path, thumbnail, label="IGTV", crop_thumbnail=crop_thumbnail)
 
 
 def crop_thumbnail(path: Path) -> bool:

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -1,4 +1,3 @@
-import contextlib
 import random
 import time
 from pathlib import Path
@@ -30,6 +29,7 @@ from instagrapi.types import (
     Usertag,
 )
 from instagrapi.utils import date_time_original, dumps
+from instagrapi.video_util import analyze_video_for_upload
 
 
 class DownloadVideoMixin:
@@ -960,21 +960,5 @@ def analyze_video(path: Path, thumbnail: Path = None) -> tuple:
         (width, height, duration, thumbnail)
     """
 
-    try:
-        import moviepy.editor as mp
-    except ImportError:
-        try:
-            import moviepy as mp
-        except ImportError:
-            raise Exception("Please install moviepy>=1.0.3 and retry")
-
-    print(f'Analyzing video file "{path}"')
-    with contextlib.ExitStack() as stack:
-        video = mp.VideoFileClip(str(path))
-        stack.enter_context(contextlib.closing(video))
-        width, height = video.size
-        if not thumbnail:
-            thumbnail = f"{path}.jpg"
-            print(f'Generating thumbnail "{thumbnail}"...')
-            video.save_frame(thumbnail, t=(video.duration / 2))
-    return width, height, video.duration, thumbnail
+    thumbnail, width, height, duration = analyze_video_for_upload(path, thumbnail, label="video")
+    return width, height, duration, thumbnail

--- a/instagrapi/video_util.py
+++ b/instagrapi/video_util.py
@@ -1,0 +1,261 @@
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+THUMBNAIL_FFMPEG_MESSAGE = (
+    "Could not generate video thumbnail. Pass thumbnail=... or install ffmpeg / set IMAGEIO_FFMPEG_EXE."
+)
+METADATA_FFMPEG_MESSAGE = (
+    "Could not read video metadata with the MP4 parser and MoviePy/ffmpeg is unavailable. "
+    "Use a standard MP4 file, or install ffmpeg / set IMAGEIO_FFMPEG_EXE."
+)
+
+
+@dataclass(frozen=True)
+class VideoMetadata:
+    width: int
+    height: int
+    duration: float
+
+
+@dataclass
+class _TrackMetadata:
+    width: Optional[int] = None
+    height: Optional[int] = None
+    duration: Optional[float] = None
+    handler_type: Optional[str] = None
+
+
+def _iter_boxes(data: bytes):
+    pos = 0
+    end = len(data)
+    while pos + 8 <= end:
+        size, box_type = struct.unpack_from(">I4s", data, pos)
+        header_size = 8
+        if size == 1:
+            if pos + 16 > end:
+                raise ValueError("Invalid MP4 box with incomplete extended size")
+            size = struct.unpack_from(">Q", data, pos + 8)[0]
+            header_size = 16
+        elif size == 0:
+            size = end - pos
+        if size < header_size or pos + size > end:
+            raise ValueError("Invalid MP4 box size")
+        box_end = pos + size
+        yield box_type.decode("ascii", errors="replace"), data[pos + header_size : box_end]
+        pos = box_end
+
+
+def _read_moov(path: Path) -> bytes:
+    file_size = path.stat().st_size
+    with path.open("rb") as fp:
+        while fp.tell() + 8 <= file_size:
+            box_start = fp.tell()
+            header = fp.read(8)
+            if len(header) < 8:
+                break
+            size, box_type = struct.unpack(">I4s", header)
+            header_size = 8
+            if size == 1:
+                extended_size = fp.read(8)
+                if len(extended_size) < 8:
+                    raise ValueError("Invalid MP4 box with incomplete extended size")
+                size = struct.unpack(">Q", extended_size)[0]
+                header_size = 16
+            elif size == 0:
+                size = file_size - box_start
+            if size < header_size or box_start + size > file_size:
+                raise ValueError("Invalid MP4 box size")
+            payload_size = size - header_size
+            if box_type == b"moov":
+                return fp.read(payload_size)
+            fp.seek(payload_size, 1)
+    raise ValueError("MP4 metadata box 'moov' was not found")
+
+
+def _parse_mvhd(data: bytes) -> Optional[float]:
+    if not data:
+        return None
+    version = data[0]
+    if version == 0:
+        if len(data) < 20:
+            return None
+        timescale, duration = struct.unpack_from(">II", data, 12)
+    elif version == 1:
+        if len(data) < 32:
+            return None
+        timescale = struct.unpack_from(">I", data, 20)[0]
+        duration = struct.unpack_from(">Q", data, 24)[0]
+    else:
+        return None
+    if not timescale:
+        return None
+    return duration / timescale
+
+
+def _parse_tkhd(data: bytes) -> tuple[Optional[int], Optional[int]]:
+    if not data:
+        return None, None
+    version = data[0]
+    offset = 76 if version == 0 else 88 if version == 1 else None
+    if offset is None or len(data) < offset + 8:
+        return None, None
+    width_fixed, height_fixed = struct.unpack_from(">II", data, offset)
+    width = round(width_fixed / 65536)
+    height = round(height_fixed / 65536)
+    if width <= 0 or height <= 0:
+        return None, None
+    return width, height
+
+
+def _parse_hdlr(data: bytes) -> Optional[str]:
+    if len(data) < 12:
+        return None
+    return data[8:12].decode("ascii", errors="replace")
+
+
+def _parse_mdia(data: bytes, track: _TrackMetadata) -> None:
+    for box_type, payload in _iter_boxes(data):
+        if box_type == "mdhd":
+            track.duration = _parse_mvhd(payload)
+        elif box_type == "hdlr":
+            track.handler_type = _parse_hdlr(payload)
+
+
+def _parse_trak(data: bytes) -> _TrackMetadata:
+    track = _TrackMetadata()
+    for box_type, payload in _iter_boxes(data):
+        if box_type == "tkhd":
+            track.width, track.height = _parse_tkhd(payload)
+        elif box_type == "mdia":
+            _parse_mdia(payload, track)
+    return track
+
+
+def read_video_metadata(path: Path) -> VideoMetadata:
+    """
+    Read MP4 width, height, and duration without invoking MoviePy or ffmpeg.
+    """
+    moov = _read_moov(Path(path))
+    movie_duration = None
+    tracks = []
+    for box_type, payload in _iter_boxes(moov):
+        if box_type == "mvhd":
+            movie_duration = _parse_mvhd(payload)
+        elif box_type == "trak":
+            tracks.append(_parse_trak(payload))
+
+    video_track = next(
+        (
+            track
+            for track in tracks
+            if track.handler_type == "vide" and track.width is not None and track.height is not None
+        ),
+        None,
+    )
+    if video_track is None:
+        video_track = next(
+            (track for track in tracks if track.width is not None and track.height is not None),
+            None,
+        )
+    if video_track is None:
+        raise ValueError("MP4 video track dimensions were not found")
+
+    duration = movie_duration if movie_duration is not None else video_track.duration
+    if duration is None:
+        raise ValueError("MP4 video duration was not found")
+    return VideoMetadata(video_track.width, video_track.height, float(duration))
+
+
+def _ffmpeg_unavailable(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return (
+        isinstance(exc, ImportError)
+        or "ffmpeg" in message
+        or "imageio_ffmpeg_exe" in message
+        or "no ffmpeg exe" in message
+    )
+
+
+def _import_moviepy(error_message: str):
+    try:
+        import moviepy.editor as mp
+    except ImportError:
+        try:
+            import moviepy as mp
+        except ImportError as exc:
+            raise RuntimeError(error_message) from exc
+        except Exception as exc:
+            if _ffmpeg_unavailable(exc):
+                raise RuntimeError(error_message) from exc
+            raise
+    except Exception as exc:
+        if _ffmpeg_unavailable(exc):
+            raise RuntimeError(error_message) from exc
+        raise
+    return mp
+
+
+def read_video_metadata_with_moviepy(path: Path) -> VideoMetadata:
+    mp = _import_moviepy(METADATA_FFMPEG_MESSAGE)
+    video = None
+    try:
+        video = mp.VideoFileClip(str(path))
+        width, height = video.size
+        return VideoMetadata(width, height, float(video.duration))
+    except Exception as exc:
+        if _ffmpeg_unavailable(exc):
+            raise RuntimeError(METADATA_FFMPEG_MESSAGE) from exc
+        raise
+    finally:
+        if video:
+            video.close()
+
+
+def read_video_metadata_with_fallback(path: Path) -> VideoMetadata:
+    try:
+        return read_video_metadata(path)
+    except Exception:
+        return read_video_metadata_with_moviepy(path)
+
+
+def generate_video_thumbnail(
+    path: Path,
+    thumbnail: Path,
+    duration: Optional[float] = None,
+    crop_thumbnail: Optional[Callable[[Path], bool]] = None,
+) -> None:
+    mp = _import_moviepy(THUMBNAIL_FFMPEG_MESSAGE)
+    video = None
+    try:
+        video = mp.VideoFileClip(str(path))
+        frame_time = duration if duration is not None else float(video.duration)
+        video.save_frame(str(thumbnail), t=(frame_time / 2))
+    except Exception as exc:
+        if _ffmpeg_unavailable(exc):
+            raise RuntimeError(THUMBNAIL_FFMPEG_MESSAGE) from exc
+        raise
+    finally:
+        if video:
+            video.close()
+    if crop_thumbnail:
+        crop_thumbnail(thumbnail)
+
+
+def analyze_video_for_upload(
+    path: Path,
+    thumbnail: Path = None,
+    label: str = "video",
+    crop_thumbnail: Optional[Callable[[Path], bool]] = None,
+) -> tuple[Path, int, int, float]:
+    path = Path(path)
+    if thumbnail is not None:
+        thumbnail = Path(thumbnail)
+    print(f'Analyzing {label} file "{path}"')
+    metadata = read_video_metadata_with_fallback(path)
+    if thumbnail is None:
+        thumbnail = Path(f"{path}.jpg")
+        print(f'Generating thumbnail "{thumbnail}"...')
+        generate_video_thumbnail(path, thumbnail, duration=metadata.duration, crop_thumbnail=crop_thumbnail)
+    return thumbnail, metadata.width, metadata.height, metadata.duration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
     - Location: usage-guide/location.md
     - Media: usage-guide/media.md
     - Notes: usage-guide/notes.md
+    - Pydroid and ffmpeg: usage-guide/pydroid.md
     - Search: usage-guide/search.md
     - Story: usage-guide/story.md
     - Track: usage-guide/track.md

--- a/tests/regression/test_video_metadata.py
+++ b/tests/regression/test_video_metadata.py
@@ -1,0 +1,118 @@
+import builtins
+import struct
+
+from tests.helpers import *
+
+
+def _box(name: str, payload: bytes) -> bytes:
+    return struct.pack(">I4s", len(payload) + 8, name.encode("ascii")) + payload
+
+
+def _sample_mp4(width: int = 720, height: int = 1280, duration: float = 3.5) -> bytes:
+    timescale = 1000
+    duration_units = int(duration * timescale)
+    ftyp = _box("ftyp", b"isom\x00\x00\x00\x01isommp42")
+
+    mvhd = _box(
+        "mvhd",
+        b"\x00\x00\x00\x00" + b"\x00" * 8 + struct.pack(">II", timescale, duration_units),
+    )
+    tkhd_payload = bytearray(84)
+    tkhd_payload[0] = 0
+    tkhd_payload[3] = 3
+    struct.pack_into(">I", tkhd_payload, 76, width << 16)
+    struct.pack_into(">I", tkhd_payload, 80, height << 16)
+    tkhd = _box("tkhd", bytes(tkhd_payload))
+    mdhd = _box(
+        "mdhd",
+        b"\x00\x00\x00\x00" + b"\x00" * 8 + struct.pack(">II", timescale, duration_units),
+    )
+    hdlr = _box("hdlr", b"\x00\x00\x00\x00" + b"\x00" * 4 + b"vide")
+    mdia = _box("mdia", mdhd + hdlr)
+    trak = _box("trak", tkhd + mdia)
+    moov = _box("moov", mvhd + trak)
+    return ftyp + moov + _box("mdat", b"\x00" * 4)
+
+
+class VideoMetadataRegressionTestCase(unittest.TestCase):
+    def write_sample_mp4(self, folder: Path, name: str = "sample.mp4") -> Path:
+        path = folder / name
+        path.write_bytes(_sample_mp4())
+        return path
+
+    def block_moviepy_imports(self, exc):
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name.startswith("moviepy"):
+                raise exc
+            return real_import(name, *args, **kwargs)
+
+        return mock.patch("builtins.__import__", side_effect=blocked_import)
+
+    def test_mp4_metadata_parser_reads_dimensions_and_duration(self):
+        from instagrapi.video_util import read_video_metadata
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self.write_sample_mp4(Path(tmpdir))
+            metadata = read_video_metadata(path)
+
+        self.assertEqual(metadata.width, 720)
+        self.assertEqual(metadata.height, 1280)
+        self.assertAlmostEqual(metadata.duration, 3.5)
+
+    def test_analyze_video_with_thumbnail_does_not_import_moviepy(self):
+        import instagrapi.mixins.clip as clip_mixin
+        import instagrapi.mixins.igtv as igtv_mixin
+        import instagrapi.mixins.video as video_mixin
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            path = self.write_sample_mp4(tmpdir)
+            thumbnail = tmpdir / "thumb.jpg"
+            thumbnail.write_bytes(b"thumbnail")
+            with self.block_moviepy_imports(AssertionError("moviepy should not be imported")):
+                video_result = video_mixin.analyze_video(path, thumbnail=thumbnail)
+                clip_result = clip_mixin.analyze_video(path, thumbnail=thumbnail)
+                igtv_result = igtv_mixin.analyze_video(path, thumbnail=thumbnail)
+
+        self.assertEqual(video_result[0:2], (720, 1280))
+        self.assertAlmostEqual(video_result[2], 3.5)
+        self.assertEqual(video_result[3], thumbnail)
+        self.assertEqual(clip_result[0], thumbnail)
+        self.assertEqual(clip_result[1:3], (720, 1280))
+        self.assertAlmostEqual(clip_result[3], 3.5)
+        self.assertEqual(igtv_result[0], thumbnail)
+        self.assertEqual(igtv_result[1:3], (720, 1280))
+        self.assertAlmostEqual(igtv_result[3], 3.5)
+
+    def test_missing_thumbnail_reports_ffmpeg_fix(self):
+        import instagrapi.mixins.video as video_mixin
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self.write_sample_mp4(Path(tmpdir))
+            with self.block_moviepy_imports(ImportError("no moviepy")):
+                with self.assertRaises(RuntimeError) as ctx:
+                    video_mixin.analyze_video(path)
+
+        message = str(ctx.exception)
+        self.assertIn("thumbnail=", message)
+        self.assertIn("ffmpeg", message.lower())
+        self.assertIn("IMAGEIO_FFMPEG_EXE", message)
+
+    def test_missing_thumbnail_wraps_imageio_ffmpeg_error(self):
+        import instagrapi.mixins.video as video_mixin
+
+        imageio_error = RuntimeError(
+            "No ffmpeg exe could be found. Install ffmpeg on your system, "
+            "or set the IMAGEIO_FFMPEG_EXE environment variable."
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self.write_sample_mp4(Path(tmpdir))
+            with self.block_moviepy_imports(imageio_error):
+                with self.assertRaises(RuntimeError) as ctx:
+                    video_mixin.analyze_video(path)
+
+        message = str(ctx.exception)
+        self.assertIn("Pass thumbnail=...", message)
+        self.assertIn("IMAGEIO_FFMPEG_EXE", message)


### PR DESCRIPTION
## Summary
- add a pure-Python MP4 metadata reader for width, height, and duration
- use the parser in video, clip, IGTV, and direct video metadata paths so standard MP4 uploads with thumbnail=... do not need MoviePy/ffmpeg
- keep MoviePy/ffmpeg only for thumbnail generation and composition, with a clearer error telling users to pass thumbnail=... or configure IMAGEIO_FFMPEG_EXE
- add docs/usage-guide/pydroid.md plus README/media/story links

## Verification
- .venv/bin/python -m ruff check instagrapi tests/regression/test_video_metadata.py
- .venv/bin/python -m pytest -q tests/regression
- .venv/bin/python -m mkdocs build --strict

Related: #1308
Discussion: #1867