### PR TITLE
Update default Android app profile

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -69,6 +69,7 @@ jobs:
             tests/regression/test_direct.py::DirectMixinRegressionTestCase \
             tests/regression/test_challenge.py::ChallengeRegressionTestCase \
             tests/regression/test_comments.py::CommentRepliesRegressionTestCase \
+            tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase \
             tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase \
             tests/regression/test_download.py::DownloadRegressionTestCase \
             tests/regression/test_notes.py::NoteMixinRegressionTestCase \

--- a/instagrapi/config.py
+++ b/instagrapi/config.py
@@ -1,9 +1,9 @@
 API_DOMAIN = "i.instagram.com"
 
-# Instagram 134.0.0.26.121
-# Android (26/8.0.0;
-# 480dpi; 1080x1920; Xiaomi;
-# MI 5s; capricorn; qcom; en_US; 205280538)
+# Instagram 428.0.0.47.67
+# Android (34/14;
+# 489dpi; 1344x2992; Genymobile/Google;
+# Pixel 8 Pro; motion_phone_arm64; vbox86; en_US; 961145276)
 USER_AGENT_BASE = (
     "Instagram {app_version} "
     "Android ({android_version}/{android_release}; "
@@ -13,16 +13,22 @@ USER_AGENT_BASE = (
 
 # Default device profile (hardware/system) and app version settings.
 DEVICE_SETTINGS = {
-    "android_version": 26,
-    "android_release": "8.0.0",
-    "dpi": "480dpi",
-    "resolution": "1080x1920",
-    "manufacturer": "OnePlus",
-    "device": "devitron",
-    "model": "6T Dev",
-    "cpu": "qcom",
+    "android_version": 34,
+    "android_release": "14",
+    "dpi": "489dpi",
+    "resolution": "1344x2992",
+    "manufacturer": "Genymobile/Google",
+    "device": "motion_phone_arm64",
+    "model": "Pixel 8 Pro",
+    "cpu": "vbox86",
 }
+DEFAULT_APP_VERSION = "428.0.0.47.67"
 APP_SETTINGS = {
+    DEFAULT_APP_VERSION: {
+        "app_version": DEFAULT_APP_VERSION,
+        "version_code": "961145276",
+        "bloks_versioning_id": "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+    },
     "364.0.0.35.86": {
         "app_version": "364.0.0.35.86",
         "version_code": "374010953",

--- a/instagrapi/config.py
+++ b/instagrapi/config.py
@@ -2,8 +2,8 @@ API_DOMAIN = "i.instagram.com"
 
 # Instagram 428.0.0.47.67
 # Android (34/14;
-# 489dpi; 1344x2992; Genymobile/Google;
-# Pixel 8 Pro; motion_phone_arm64; vbox86; en_US; 961145276)
+# 480dpi; 1344x2992; Google/google;
+# Pixel 8 Pro; husky; husky; en_US; 961145276)
 USER_AGENT_BASE = (
     "Instagram {app_version} "
     "Android ({android_version}/{android_release}; "
@@ -15,12 +15,12 @@ USER_AGENT_BASE = (
 DEVICE_SETTINGS = {
     "android_version": 34,
     "android_release": "14",
-    "dpi": "489dpi",
+    "dpi": "480dpi",
     "resolution": "1344x2992",
-    "manufacturer": "Genymobile/Google",
-    "device": "motion_phone_arm64",
+    "manufacturer": "Google/google",
+    "device": "husky",
     "model": "Pixel 8 Pro",
-    "cpu": "vbox86",
+    "cpu": "husky",
 }
 DEFAULT_APP_VERSION = "428.0.0.47.67"
 APP_SETTINGS = {

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -305,7 +305,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
     ig_www_claim = ""  # e.g. hmac.AR2uidim8es5kYgDiNxY0UG_ZhffFFSt8TGCV5eA1VYYsMNx
 
     def __init__(self):
-        self.bloks_versioning_id = "ce555e5500576acd8e84a66018f54a05720f2dce29f0bb5a1f97f0c10d6fac48"
+        self.bloks_versioning_id = config.APP_SETTINGS[config.DEFAULT_APP_VERSION]["bloks_versioning_id"]
         self.user_agent = None
         self.settings = None
         self.override_app_version = False
@@ -803,6 +803,9 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 return app_values[idx]
             return random.choice(app_values)
 
+        def default_settings() -> Dict:
+            return config.APP_SETTINGS.get(config.DEFAULT_APP_VERSION) or pick_by_seed()
+
         if app:
             if isinstance(app, str):
                 matched = config.APP_SETTINGS.get(app)
@@ -814,11 +817,11 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         else:
             app_version = self.device_settings.get("app_version")
             matched = config.APP_SETTINGS.get(app_version) if app_version else None
-            if matched:
+            if matched and not override_app_version:
                 apply_settings(matched)
             else:
                 if override_app_version or not app_version:
-                    apply_settings(pick_by_seed())
+                    apply_settings(default_settings())
 
         if override_app_version:
             self.set_user_agent()

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -199,7 +199,7 @@ class PrivateRequestMixin:
             "X-MID": self.mid,  # e.g. X--ijgABABFjLLQ1NTEe0A6JSN7o, YRwa1QABBAF-ZA-1tPmnd0bEniTe
             "Accept-Encoding": "gzip, deflate",  # ignore zstd
             "Host": self.domain,
-            "X-FB-HTTP-Engine": "Liger",
+            "X-FB-HTTP-Engine": "Tigon/MNS/TCP",
             "Connection": "keep-alive",
             # "Pragma": "no-cache",
             # "Cache-Control": "no-cache",

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -15,8 +15,8 @@ class CurrentAppProfileRegressionTestCase(unittest.TestCase):
         self.assertEqual(
             client.user_agent,
             (
-                "Instagram 428.0.0.47.67 Android (34/14; 489dpi; 1344x2992; "
-                "Genymobile/Google; Pixel 8 Pro; motion_phone_arm64; vbox86; en_US; 961145276)"
+                "Instagram 428.0.0.47.67 Android (34/14; 480dpi; 1344x2992; "
+                "Google/google; Pixel 8 Pro; husky; husky; en_US; 961145276)"
             ),
         )
 
@@ -28,12 +28,12 @@ class CurrentAppProfileRegressionTestCase(unittest.TestCase):
             {
                 "android_version": 34,
                 "android_release": "14",
-                "dpi": "489dpi",
+                "dpi": "480dpi",
                 "resolution": "1344x2992",
-                "manufacturer": "Genymobile/Google",
-                "device": "motion_phone_arm64",
+                "manufacturer": "Google/google",
+                "device": "husky",
                 "model": "Pixel 8 Pro",
-                "cpu": "vbox86",
+                "cpu": "husky",
                 "app_version": "428.0.0.47.67",
                 "version_code": "961145276",
                 "bloks_versioning_id": "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -1,0 +1,62 @@
+from instagrapi import config
+from tests.helpers import *
+
+
+class CurrentAppProfileRegressionTestCase(unittest.TestCase):
+    def test_default_client_uses_current_android_app_profile(self):
+        client = Client()
+
+        self.assertEqual(client.device_settings["app_version"], config.DEFAULT_APP_VERSION)
+        self.assertEqual(client.device_settings["version_code"], "961145276")
+        self.assertEqual(
+            client.bloks_versioning_id,
+            "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+        )
+        self.assertTrue(client.user_agent.startswith("Instagram 428.0.0.47.67 Android "))
+        self.assertTrue(client.user_agent.endswith("; 961145276)"))
+
+    def test_private_headers_use_current_android_transport_values(self):
+        client = Client()
+
+        self.assertEqual(client.private.headers["X-FB-HTTP-Engine"], "Tigon/MNS/TCP")
+        self.assertEqual(client.private.headers["X-IG-Capabilities"], "3brTv10=")
+        self.assertEqual(client.private.headers["X-IG-App-ID"], "567067343352427")
+        self.assertEqual(
+            client.private.headers["X-Bloks-Version-Id"],
+            "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+        )
+
+    def test_saved_legacy_app_profile_is_not_overridden_by_default(self):
+        client = Client(
+            {
+                "device_settings": {
+                    "app_version": "385.0.0.47.74",
+                    "version_code": "378906843",
+                    "bloks_versioning_id": ("a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221"),
+                },
+            }
+        )
+
+        self.assertEqual(client.device_settings["app_version"], "385.0.0.47.74")
+        self.assertEqual(client.device_settings["version_code"], "378906843")
+        self.assertEqual(
+            client.bloks_versioning_id,
+            "a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221",
+        )
+
+    def test_override_app_version_replaces_saved_profile_with_current_default(self):
+        client = Client(
+            {
+                "device_settings": {
+                    "app_version": "385.0.0.47.74",
+                    "version_code": "378906843",
+                    "bloks_versioning_id": ("a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221"),
+                },
+            }
+        )
+
+        client.override_app_version = True
+        client.set_app()
+
+        self.assertEqual(client.device_settings["app_version"], config.DEFAULT_APP_VERSION)
+        self.assertEqual(client.device_settings["version_code"], "961145276")

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -12,8 +12,46 @@ class CurrentAppProfileRegressionTestCase(unittest.TestCase):
             client.bloks_versioning_id,
             "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
         )
-        self.assertTrue(client.user_agent.startswith("Instagram 428.0.0.47.67 Android "))
-        self.assertTrue(client.user_agent.endswith("; 961145276)"))
+        self.assertEqual(
+            client.user_agent,
+            (
+                "Instagram 428.0.0.47.67 Android (34/14; 489dpi; 1344x2992; "
+                "Genymobile/Google; Pixel 8 Pro; motion_phone_arm64; vbox86; en_US; 961145276)"
+            ),
+        )
+
+    def test_default_device_profile_matches_current_android_baseline(self):
+        client = Client()
+
+        self.assertEqual(
+            client.device_settings,
+            {
+                "android_version": 34,
+                "android_release": "14",
+                "dpi": "489dpi",
+                "resolution": "1344x2992",
+                "manufacturer": "Genymobile/Google",
+                "device": "motion_phone_arm64",
+                "model": "Pixel 8 Pro",
+                "cpu": "vbox86",
+                "app_version": "428.0.0.47.67",
+                "version_code": "961145276",
+                "bloks_versioning_id": "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+            },
+        )
+
+    def test_set_app_can_apply_current_default_profile_explicitly(self):
+        client = Client()
+        client.set_app("385.0.0.47.74")
+
+        client.set_app(config.DEFAULT_APP_VERSION)
+
+        self.assertEqual(client.device_settings["app_version"], config.DEFAULT_APP_VERSION)
+        self.assertEqual(client.device_settings["version_code"], "961145276")
+        self.assertEqual(
+            client.bloks_versioning_id,
+            "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+        )
 
     def test_private_headers_use_current_android_transport_values(self):
         client = Client()


### PR DESCRIPTION
## Summary
- Add the current Instagram Android app profile as the default client app metadata.
- Update the default device/user-agent baseline and Bloks version id used by new clients.
- Switch the private request transport header to the current Android app value.
- Preserve saved sessions with an explicit legacy app profile unless `override_app_version=True` is requested.

Closes #2479 for the first default-profile slice. Login flow parity remains intentionally separate because the current app uses a broader Bloks-based login and 2FA path that needs a dedicated live-tested change.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_current_app_profile.py tests/regression/test_auth_story.py tests/regression/test_clip.py tests/regression/test_track.py -q`
- `.venv/bin/python -m pytest tests/regression -q -k 'not password_enrypt'`
- `.venv/bin/python -m ruff check instagrapi tests/regression/test_current_app_profile.py`

Note: full `tests/regression` currently has one network-dependent `password_enrypt` failure because the external password-key response did not include encryption headers in this local run.
