### PR TITLE
Accept override_app_version in Client constructor

### DIFF
--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -103,6 +103,7 @@ class Client(
         proxy: Optional[str] = None,
         delay_range: Optional[list] = None,
         logger=DEFAULT_LOGGER,
+        override_app_version: bool = False,
         **kwargs,
     ):
         self.request_timeout = kwargs.pop("request_timeout", 1)
@@ -115,6 +116,7 @@ class Client(
         super().__init__(**kwargs)
 
         self.settings = deepcopy(settings or {})
+        self.override_app_version = override_app_version
         self.logger = logger
         self.delay_range = delay_range
 

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -98,3 +98,18 @@ class CurrentAppProfileRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(client.device_settings["app_version"], config.DEFAULT_APP_VERSION)
         self.assertEqual(client.device_settings["version_code"], "961145276")
+
+    def test_constructor_override_app_version_replaces_saved_profile_with_current_default(self):
+        client = Client(
+            {
+                "device_settings": {
+                    "app_version": "385.0.0.47.74",
+                    "version_code": "378906843",
+                    "bloks_versioning_id": ("a8973d49a9cc6a6f65a4997c10216ce2a06f65a517010e64885e92029bb19221"),
+                },
+            },
+            override_app_version=True,
+        )
+
+        self.assertEqual(client.device_settings["app_version"], config.DEFAULT_APP_VERSION)
+        self.assertEqual(client.device_settings["version_code"], "961145276")


### PR DESCRIPTION
## Summary
- Add `override_app_version` as an explicit `Client(...)` constructor argument.
- Keep the default `False` so saved app profiles are still preserved unless explicitly overridden.
- Cover constructor-level override behavior in current app profile regression tests.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_current_app_profile.py -q`
- `.venv/bin/python -m pytest tests/regression/test_current_app_profile.py tests/regression/test_auth_story.py tests/regression/test_clip.py tests/regression/test_track.py tests/regression/test_upload.py -q`
- `.venv/bin/python -m ruff check instagrapi/__init__.py tests/regression/test_current_app_profile.py`
- `.venv/bin/python -m ruff format --check instagrapi/__init__.py tests/regression/test_current_app_profile.py`
