### PR TITLE
Add Direct message helper aliases

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -4,8 +4,11 @@
 | ------------------------------------------------------------------------- | ----------------------- | ----------------------------------
 | `direct_threads(amount: int = 20, selected_filter: str = "", box: str = "", thread_message_limit: Optional[int] = None)` <br> Note: `selected_filter` = `""`, `"flagged"` or `"unread"`; `box` = `""`, `"primary"` or `"general"` | List[DirectThread] | Get all threads from inbox
 | direct_pending_inbox(amount: int = 20)                                    | List[DirectThread]      | Get all threads from pending inbox
+| direct_requests(amount: int = 20)                                         | List[DirectThread]      | Get message request threads (pending inbox / invitations)
+| direct_request_approve(thread_id: int)                                    | bool                    | Approve a message request thread
 | direct_thread(thread_id: int, amount: int = 20)                           | DirectThread            | Get Thread with Messages
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread
+| direct_message(thread_id: int, message_id: int, amount: int = 20)         | DirectMessage           | Get one Message from Thread by id
 | direct_answer(thread_id: int, text: str)                                  | DirectMessage           | Add Message to exist Thread
 | direct_send(text: str, user_ids: List[int] = [], thread_ids: List[int] = [], reply_to_message: Optional[DirectMessage] = None) | DirectMessage | Send Message to Users or Threads, optionally as a reply
 | direct_send_reaction(thread_id: int, message_id: int, emoji: str = "❤", client_context: Optional[str] = None) | bool | Send an emoji reaction to a message
@@ -21,6 +24,7 @@
 | direct_profile_share(user_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage      | Share a user profile to list of users
 | direct_thread_mark_unread(thread_id: int)                                 | bool                    | Mark a thread as unread
 | direct_message_delete(thread_id: int, message_id: int)                    | bool                    | Delete a message from thread
+| direct_message_unsend(thread_id: int, message_id: int)                    | bool                    | Unsend a message from thread
 | direct_thread_mute(thread_id: int, revert: bool = False)                  | bool                    | Mute the thread
 | direct_thread_unmute(thread_id: int)                                      | bool                    | Unmute the thread
 | direct_thread_mute_video_call(thread_id: int, revert: bool = False)       | bool                    | Mute video call for the thread
@@ -33,7 +37,9 @@
 Notes:
 
 * For `direct_send()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
+* Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_thread()` paginates internally until it collects `amount` messages or reaches the end of the thread.
+* `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
 * Media-changing direct endpoints are more sensitive to session quality than read-only inbox calls. Stable sessions loaded via `dump_settings()/load_settings()` are more reliable than browser-only `sessionid` reuse.
 
 Example of basic actions:
@@ -67,6 +73,10 @@ DirectThread(
     ...
 )
 
+>>> request = cl.direct_requests(1)[0]
+>>> cl.direct_request_approve(request.id)
+True
+
 >>> cl.direct_thread(thread.id, 1)
 DirectThread(
     pk=18103276039108479,
@@ -82,6 +92,9 @@ DirectThread(
 )
 
 >>> message = cl.direct_messages(thread.id, 1)[0]
+DirectMessage(id=300712312341231237412312312360, user_id=12312312, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 20, 28, 754135, tzinfo=datetime.timezone.utc), item_type='text', is_shh_mode=False, reactions=None, text='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua', animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
+
+>>> cl.direct_message(thread.id, message.id)
 DirectMessage(id=300712312341231237412312312360, user_id=12312312, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 20, 28, 754135, tzinfo=datetime.timezone.utc), item_type='text', is_shh_mode=False, reactions=None, text='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua', animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 
 >>> cl.direct_answer(thread.id, 'Hello!')
@@ -121,6 +134,9 @@ DirectMessage(id=30076291231321231369939116032, user_id=None, thread_id=34028231
 DirectMessage(id=30076291231231230352896, user_id=None, thread_id=3402812312312310641298762, timestamp=datetime.datetime(2021, 8, 31, 19, 48, 38, 482706, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 
 >>> cl.direct_message_delete(thread.id, message.pk)
+True
+
+>>> cl.direct_message_unsend(thread.id, message.id)
 True
 
 >>> photo_path = cl.photo_download(cl.media_pk_from_url('https://www.instagram.com/p/BgqFyjqloOr/'))

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -6,7 +6,12 @@ import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from instagrapi.exceptions import ClientError, ClientNotFoundError, DirectThreadNotFound
+from instagrapi.exceptions import (
+    ClientError,
+    ClientNotFoundError,
+    DirectMessageNotFound,
+    DirectThreadNotFound,
+)
 from instagrapi.extractors import (
     extract_direct_media,
     extract_direct_message,
@@ -181,6 +186,22 @@ class DirectMixin:
             threads = threads[:amount]
         return threads
 
+    def direct_requests(self, amount: int = 20) -> List[DirectThread]:
+        """
+        Get Direct message request threads, also known as pending inbox or invitations.
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of threads to return, default is 20
+
+        Returns
+        -------
+        List[DirectThread]
+            A list of objects of DirectThread
+        """
+        return self.direct_pending_inbox(amount)
+
     def direct_pending_chunk(self, cursor: str = None) -> Tuple[List[DirectThread], str]:
         """
         Get direct threads of Pending inbox. Chunk
@@ -235,6 +256,22 @@ class DirectMixin:
             with_signature=False,
         )
         return result.get("status", "") == "ok"
+
+    def direct_request_approve(self, thread_id: int) -> bool:
+        """
+        Approve a Direct message request thread.
+
+        Parameters
+        ----------
+        thread_id: int
+            ID of thread to approve
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        return self.direct_pending_approve(thread_id)
 
     def direct_spam_inbox(self, amount: int = 20) -> List[DirectThread]:
         """
@@ -357,6 +394,36 @@ class DirectMixin:
         """
         assert self.user_id, "Login required"
         return self.direct_thread(thread_id, amount).messages
+
+    def direct_message(self, thread_id: int, message_id: int, amount: int = 20) -> DirectMessage:
+        """
+        Get a Direct message from a thread by message id.
+
+        Parameters
+        ----------
+        thread_id: int
+            Unique identifier of a Direct Message thread
+
+        message_id: int
+            Unique identifier of a Direct Message item
+
+        amount: int, optional
+            Maximum number of latest messages to scan, default is 20
+
+        Returns
+        -------
+        DirectMessage
+            An object of DirectMessage
+        """
+        message_id = str(message_id)
+        for message in self.direct_messages(thread_id, amount):
+            if message.id == message_id:
+                return message
+        raise DirectMessageNotFound(
+            f"Direct message {message_id} not found in thread {thread_id}",
+            thread_id=thread_id,
+            message_id=message_id,
+        )
 
     def direct_answer(self, thread_id: int, text: str) -> DirectMessage:
         """
@@ -1581,6 +1648,24 @@ class DirectMixin:
         data.pop("device_id", None)
         result = self.private_request(f"direct_v2/threads/{thread_id}/items/{message_id}/delete/", data=data)
         return result["status"] == "ok"
+
+    def direct_message_unsend(self, thread_id: int, message_id: int) -> bool:
+        """
+        Unsend a message from a Direct thread.
+
+        Parameters
+        ----------
+        thread_id: int
+            Id of thread
+        message_id: int
+            Id of message
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        return self.direct_message_delete(thread_id, message_id)
 
     def direct_thread_mute(self, thread_id: int, revert: bool = False) -> bool:
         """

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import DirectMessageNotFound
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -140,9 +141,9 @@ class ClientDirectMediaLiveTestCase(_helpers.ClientPrivateTestCase):
             if not getattr(message, "id", None):
                 continue
             try:
-                client.direct_message_delete(thread_id, message.id)
+                client.direct_message_unsend(thread_id, message.id)
             except Exception as exc:
-                print(f"Direct media live cleanup direct_message_delete failed: {exc.__class__.__name__} {exc}")
+                print(f"Direct media live cleanup direct_message_unsend failed: {exc.__class__.__name__} {exc}")
         for client in clients:
             try:
                 client.direct_thread_hide(thread_id)
@@ -150,11 +151,10 @@ class ClientDirectMediaLiveTestCase(_helpers.ClientPrivateTestCase):
                 print(f"Direct media live cleanup direct_thread_hide failed: {exc.__class__.__name__} {exc}")
 
     def direct_message_by_id(self, client, thread_id, message_id, amount=10):
-        thread = client.direct_thread(thread_id, amount=amount)
-        for message in thread.messages:
-            if str(message.id) == str(message_id):
-                return message
-        return None
+        try:
+            return client.direct_message(thread_id, message_id, amount=amount)
+        except DirectMessageNotFound:
+            return None
 
     def direct_message_has_reaction(self, message, sender_id, emoji="❤"):
         reactions = getattr(message, "reactions", None)

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import DirectMessageNotFound
 from tests.helpers import *
 
 
@@ -22,6 +23,55 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
             data={"_uuid": "uuid-1", "title": "Updated title"},
             with_signature=False,
         )
+
+    def test_direct_message_returns_matching_message_by_id(self):
+        client = self.build_client()
+        first = DirectMessage(id="111", user_id="1", timestamp=datetime.fromtimestamp(1))
+        expected = DirectMessage(id="222", user_id="1", timestamp=datetime.fromtimestamp(2))
+
+        with mock.patch.object(client, "direct_messages", return_value=[first, expected]) as direct_messages:
+            result = client.direct_message(123, "222", amount=50)
+
+        self.assertIs(result, expected)
+        direct_messages.assert_called_once_with(123, 50)
+
+    def test_direct_message_raises_when_message_is_missing(self):
+        client = self.build_client()
+        message = DirectMessage(id="111", user_id="1", timestamp=datetime.fromtimestamp(1))
+
+        with mock.patch.object(client, "direct_messages", return_value=[message]):
+            with self.assertRaises(DirectMessageNotFound) as ctx:
+                client.direct_message(123, 222, amount=1)
+
+        self.assertIn("222", str(ctx.exception))
+
+    def test_direct_message_unsend_delegates_to_delete_endpoint(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "direct_message_delete", return_value=True) as delete:
+            result = client.direct_message_unsend(123, 456)
+
+        self.assertTrue(result)
+        delete.assert_called_once_with(123, 456)
+
+    def test_direct_requests_uses_pending_inbox(self):
+        client = self.build_client()
+        expected = [Mock(spec=DirectThread)]
+
+        with mock.patch.object(client, "direct_pending_inbox", return_value=expected) as pending:
+            result = client.direct_requests(amount=7)
+
+        self.assertIs(result, expected)
+        pending.assert_called_once_with(7)
+
+    def test_direct_request_approve_delegates_to_pending_approve(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "direct_pending_approve", return_value=True) as approve:
+            result = client.direct_request_approve(123)
+
+        self.assertTrue(result)
+        approve.assert_called_once_with(123)
 
     def make_temp_file(self, suffix, content):
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:


### PR DESCRIPTION
## Summary
- add `direct_message(thread_id, message_id, amount=20)` to fetch one Direct message by id
- add clearer message request aliases: `direct_requests()` and `direct_request_approve()`
- add `direct_message_unsend()` as the public unsend-style alias for the existing Direct item delete endpoint
- update Direct docs and live Direct coverage to use the new helpers

Fixes #1401
Fixes #1922
Fixes #2101

## Verification
- `.venv/bin/python -m pytest tests/regression/test_direct.py::DirectMixinRegressionTestCase -q` -> 19 passed
- `.venv/bin/python -m pytest tests/regression/test_direct.py tests/regression/test_extractors.py -q` -> 26 passed
- `.venv/bin/python -m ruff check instagrapi tests/regression/test_direct.py tests/live/test_direct.py && .venv/bin/python -m ruff format --check instagrapi tests/regression/test_direct.py tests/live/test_direct.py` -> passed
- `.venv/bin/python -m mkdocs build --strict` -> passed
- `sk.test: .venv/bin/python -m pytest -sv tests/live/test_direct.py::ClientDirectMediaLiveTestCase` -> 2 passed