### PR TITLE
Preserve raw Direct XMA payloads

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -40,6 +40,8 @@ Notes:
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_thread()` paginates internally until it collects `amount` messages or reaches the end of the thread.
 * `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
+* Shared XMA items such as `xma_clip`, `xma_media_share`, `xma_story_share`, and `xma_profile` keep their original payload in `message.raw_xma`. When Instagram includes `target_url`, the normalized link is also available through `message.xma_share`.
+* Disappearing direct photos and videos with `item_type == "raven_media"` are exposed through `message.visual_media`.
 * Media-changing direct endpoints are more sensitive to session quality than read-only inbox calls. Stable sessions loaded via `dump_settings()/load_settings()` are more reliable than browser-only `sessionid` reuse.
 
 Example of basic actions:

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -334,6 +334,16 @@ def _direct_timestamp_from_microseconds(timestamp):
     return datetime.datetime.fromtimestamp(int(timestamp) // 1_000_000)
 
 
+def _preserve_direct_raw_xma(data):
+    raw_xma = {
+        key: deepcopy(data[key])
+        for key in ("xma_clip", "xma_media_share", "xma_story_share", "xma_profile", "generic_xma")
+        if data.get(key)
+    }
+    if raw_xma:
+        data["raw_xma"] = raw_xma
+
+
 def _convert_direct_visual_media_timestamps(visual_media):
     if not visual_media:
         return
@@ -368,6 +378,7 @@ def _convert_direct_visual_media_timestamps(visual_media):
 
 def extract_reply_message(data):
     data["id"] = data.get("item_id")
+    _preserve_direct_raw_xma(data)
     if "media_share" in data:
         ms = data["media_share"]
         if not ms.get("code"):
@@ -397,6 +408,7 @@ def extract_reply_message(data):
 
 def extract_direct_message(data):
     data["id"] = data.get("item_id")
+    _preserve_direct_raw_xma(data)
     if "replied_to_message" in data:
         data["reply"] = extract_reply_message(data["replied_to_message"])
     if "media_share" in data:

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -857,6 +857,7 @@ class ReplyMessage(TypesBaseModel):
     felix_share: Optional[dict] = None
     xma_share: Optional[MediaXma] = None
     generic_xma: Optional[List[MediaXma]] = None
+    raw_xma: Optional[dict] = None
     clip: Optional[Media] = None
     placeholder: Optional[dict] = None
 
@@ -882,6 +883,7 @@ class DirectMessage(TypesBaseModel):
     felix_share: Optional[dict] = None
     xma_share: Optional[MediaXma] = None
     generic_xma: Optional[List[MediaXma]] = None
+    raw_xma: Optional[dict] = None
     clip: Optional[Media] = None
     placeholder: Optional[dict] = None
     client_context: Optional[str] = None

--- a/tests/regression/test_extractors.py
+++ b/tests/regression/test_extractors.py
@@ -79,6 +79,47 @@ class DirectExtractorRegressionTestCase(unittest.TestCase):
         self.assertEqual(str(message.generic_xma[0].video_url), "https://example.com/first")
         self.assertEqual(str(message.generic_xma[1].video_url), "https://example.com/second")
 
+    def test_xma_clip_without_target_url_keeps_raw_payload(self):
+        message = extract_direct_message(
+            {
+                "item_id": "1",
+                "user_id": "2",
+                "timestamp": 1761953663000000,
+                "item_type": "xma_clip",
+                "text": "",
+                "xma_clip": [
+                    {
+                        "title_text": "Shared reel",
+                        "preview_media_fbid": "123456789",
+                    }
+                ],
+            }
+        )
+
+        self.assertIsNone(message.xma_share)
+        self.assertEqual(message.raw_xma["xma_clip"][0]["preview_media_fbid"], "123456789")
+
+    def test_xma_media_share_keeps_raw_payload_when_normalized(self):
+        message = extract_direct_message(
+            {
+                "item_id": "1",
+                "user_id": "2",
+                "timestamp": 1761953663000000,
+                "item_type": "xma_media_share",
+                "text": "",
+                "xma_media_share": [
+                    {
+                        "target_url": "https://example.com/p/abc/",
+                        "title_text": "Shared post",
+                        "preview_media_fbid": "987654321",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(str(message.xma_share.video_url), "https://example.com/p/abc/")
+        self.assertEqual(message.raw_xma["xma_media_share"][0]["preview_media_fbid"], "987654321")
+
     def test_reply_visual_media_timestamp_uses_microseconds(self):
         message = extract_direct_message(
             {


### PR DESCRIPTION
## Summary
- keep original Direct XMA payloads in `DirectMessage.raw_xma` and `ReplyMessage.raw_xma`
- preserve shared `xma_clip`, `xma_media_share`, `xma_story_share`, `xma_profile`, and `generic_xma` data before normalization
- document where to find shared XMA payloads and disappearing `raven_media` visual media

Fixes #1137.
Related to #675.

## Verification
- RED: `.venv/bin/python -m pytest tests/regression/test_extractors.py::DirectExtractorRegressionTestCase::test_xma_clip_without_target_url_keeps_raw_payload tests/regression/test_extractors.py::DirectExtractorRegressionTestCase::test_xma_media_share_keeps_raw_payload_when_normalized -q` failed before the fix because `DirectMessage.raw_xma` did not exist
- GREEN: `.venv/bin/python -m pytest tests/regression/test_extractors.py::DirectExtractorRegressionTestCase::test_xma_clip_without_target_url_keeps_raw_payload tests/regression/test_extractors.py::DirectExtractorRegressionTestCase::test_xma_media_share_keeps_raw_payload_when_normalized -q`
- `.venv/bin/python -m pytest tests/regression/test_extractors.py tests/regression/test_direct.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m ruff check instagrapi/extractors.py instagrapi/types.py tests/regression/test_extractors.py`
- `.venv/bin/python -m ruff format --check instagrapi/extractors.py instagrapi/types.py tests/regression/test_extractors.py`
- `.venv/bin/python -m mkdocs build --strict`
