### PR TITLE
Add Direct group thread creation helper

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -17,6 +17,7 @@
 | direct_message_unlike(thread_id: int, message_id: int, client_context: Optional[str] = None) | bool | Remove your heart reaction from a message
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
 | direct_thread_by_participants(user_ids: List[int])                        | DirectThread            | Get thread by user_id
+| direct_thread_create(user_ids: List[int], title: str = "")                | str                     | Create a group thread and return its thread id
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
 | direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a group thread title
 | direct_media_share(media_id: str, user_ids: List[int])                    | DirectMessage           | Share a media to list of users
@@ -122,6 +123,10 @@ True
 
 >>> cl.direct_thread_by_participants([cl.user_id])
 DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[DirectMessage(id=30076214123123123123123864, user_id=1903424587, thread_id=None, timestamp=datetime.datetime(2021, 8, 31, 18, 33, 49, 107154, ...)
+
+>>> thread_id = cl.direct_thread_create([user_id_1, user_id_2], title="New group")
+>>> cl.direct_thread(thread_id, amount=1)
+DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[...], ...)
 
 >>> cl.direct_thread_update_title(thread.id, "New group title")
 True

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1492,6 +1492,43 @@ class DirectMixin:
         )
         return result.get("status", "") == "ok"
 
+    def direct_thread_create(self, user_ids: List[int], title: str = "") -> str:
+        """
+        Create a group Direct thread.
+
+        Parameters
+        ----------
+        user_ids: List[int]
+            List of unique identifiers of users to add to the group thread.
+            Instagram group threads require at least two recipients besides
+            the authenticated user.
+        title: str, optional
+            Initial group thread title.
+
+        Returns
+        -------
+        str
+            Created Direct thread id.
+        """
+        assert self.user_id, "Login required"
+        assert len(user_ids) >= 2, "Group threads require at least two recipient user_ids"
+
+        result = self.private_request(
+            "direct_v2/create_group_thread/",
+            data={
+                "_uuid": self.uuid,
+                "_uid": str(self.user_id),
+                "client_context": self.generate_mutation_token(),
+                "is_partnership_folder": "false",
+                "recipient_users": dumps([int(uid) for uid in user_ids]),
+                "thread_title": title,
+            },
+        )
+        thread_id = result.get("thread_id") or result.get("thread", {}).get("thread_id")
+        if not thread_id:
+            raise ClientError("Create group thread response missing thread_id", **result)
+        return str(thread_id)
+
     def direct_media_share(
         self,
         media_id: str,

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -286,22 +286,13 @@ class ClientDirectThreadLiveTestCase(_helpers.ClientPrivateTestCase):
     def test_direct_thread_update_title_live(self):
         initial_title = f"instagrapi-title-{int(time.time())}"
         updated_title = f"{initial_title}-updated"
-        token = self.cl.generate_mutation_token()
         thread_id = None
 
         try:
-            created = self.cl.private_request(
-                "direct_v2/create_group_thread/",
-                data={
-                    "_uuid": self.cl.uuid,
-                    "_uid": self.cl.user_id,
-                    "client_context": token,
-                    "is_partnership_folder": "false",
-                    "recipient_users": dumps([int(client.user_id) for client in self.recipient_clients]),
-                    "thread_title": initial_title,
-                },
+            thread_id = self.cl.direct_thread_create(
+                [int(client.user_id) for client in self.recipient_clients],
+                title=initial_title,
             )
-            thread_id = created.get("thread_id") or created.get("thread", {}).get("thread_id")
             self.assertTrue(thread_id)
 
             self.assertTrue(self.cl.direct_thread_update_title(thread_id, updated_title))

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -24,6 +24,45 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
             with_signature=False,
         )
 
+    def test_direct_thread_create_posts_group_payload(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(client, "private_request", return_value={"thread_id": "3402823668417103"}) as private,
+        ):
+            result = client.direct_thread_create([42, "43"], title="Group title")
+
+        self.assertEqual(result, "3402823668417103")
+        private.assert_called_once_with(
+            "direct_v2/create_group_thread/",
+            data={
+                "_uuid": "uuid-1",
+                "_uid": "1",
+                "client_context": "mutation-token",
+                "is_partnership_folder": "false",
+                "recipient_users": "[42,43]",
+                "thread_title": "Group title",
+            },
+        )
+
+    def test_direct_thread_create_accepts_nested_thread_id_response(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(
+                client,
+                "private_request",
+                return_value={"thread": {"thread_id": "3402823668417104"}},
+            ),
+        ):
+            result = client.direct_thread_create([42, 43])
+
+        self.assertEqual(result, "3402823668417104")
+
     def test_direct_message_returns_matching_message_by_id(self):
         client = self.build_client()
         first = DirectMessage(id="111", user_id="1", timestamp=datetime.fromtimestamp(1))


### PR DESCRIPTION
## Summary
- add direct_thread_create() for Direct group thread creation
- reuse the public helper in the Direct group title live test
- document group thread creation in the Direct usage guide

## Tests
- .venv/bin/python -m pytest tests/regression/test_direct.py -q
- .venv/bin/python -m pytest tests/regression/test_extractors.py tests/regression/test_direct.py -q
- .venv/bin/python -m pytest tests/regression -q
- .venv/bin/ruff check instagrapi/mixins/direct.py tests/regression/test_direct.py tests/live/test_direct.py
- .venv/bin/python -m mkdocs build --strict
- sk.test: .venv/bin/python -m pytest tests/live/test_direct.py::ClientDirectThreadLiveTestCase::test_direct_thread_update_title_live -q

Fixes #1408
Related #1668