### PR TITLE
Normalize Direct recipient ids

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -38,6 +38,7 @@
 Notes:
 
 * For `direct_send()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
+* Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_thread()` paginates internally until it collects `amount` messages or reaches the end of the thread.
 * `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -41,6 +41,15 @@ SEND_ATTRIBUTES_MEDIA = (
 )
 BOXES = ("general", "primary")
 
+
+def _direct_id_list(ids) -> List[int]:
+    if ids is None:
+        return []
+    if isinstance(ids, (int, str)):
+        return [int(ids)]
+    return [int(item) for item in ids]
+
+
 try:
     from typing import Literal
 
@@ -478,6 +487,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -713,6 +724,7 @@ class DirectMixin:
         return metadata.width, metadata.height, metadata.duration or duration_sec
 
     def _direct_thread_id_from_user_ids(self, user_ids: List[int], media_kind: str) -> int:
+        user_ids = _direct_id_list(user_ids)
         thread = self.direct_thread_by_participants(user_ids)
         thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
         if not thread_id and isinstance(self.last_json, dict):
@@ -762,6 +774,8 @@ class DirectMixin:
             An object of DirectMessage.
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -976,6 +990,8 @@ class DirectMixin:
             An object of DirectMessage.
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -1130,6 +1146,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -1205,6 +1223,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -1252,6 +1272,7 @@ class DirectMixin:
             Dict with User's presences
         """
         assert self.user_id, "Login Required"
+        user_ids = _direct_id_list(user_ids)
         data = {
             "_uuid": self.uuid,
             "subscriptions_off": "false",
@@ -1417,6 +1438,7 @@ class DirectMixin:
             Some information about thread.
             List of UserShort under "users" key
         """
+        user_ids = _direct_id_list(user_ids)
         recipient_users = dumps([int(uid) for uid in user_ids])
         result = self.private_request(
             "direct_v2/threads/get_by_participants/",
@@ -1511,6 +1533,7 @@ class DirectMixin:
             Created Direct thread id.
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
         assert len(user_ids) >= 2, "Group threads require at least two recipient user_ids"
 
         result = self.private_request(
@@ -1558,6 +1581,7 @@ class DirectMixin:
         assert self.user_id, "Login required"
         token = self.generate_mutation_token()
         media_id = self.media_id(media_id)
+        user_ids = _direct_id_list(user_ids)
         recipient_users = dumps([[int(uid) for uid in user_ids]])
         kwargs = {
             "recipient_users": recipient_users,
@@ -1611,6 +1635,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
@@ -1795,6 +1821,8 @@ class DirectMixin:
             An object of DirectMessage
         """
         assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -41,6 +41,11 @@ class ClientDirectTestCase(_helpers.ClientPrivateTestCase):
         dm = self.cl.direct_send_photo(path="examples/kanada.jpg", user_ids=[instagram])
         self.assertIsInstance(dm, DirectMessage)
 
+    def test_direct_send_accepts_scalar_user_id_live(self):
+        instagram = self.user_id_from_username("instagram")
+        dm = self.cl.direct_send("Scalar recipient ping", user_ids=instagram)
+        self.assertIsInstance(dm, DirectMessage)
+
     def test_direct_send_video(self):
         instagram = self.user_id_from_username("instagram")
         path = self.cl.video_download(self.cl.media_pk_from_url("https://www.instagram.com/p/B3rFQPblq40/"))

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -167,6 +167,51 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["replied_to_client_context"], reply_to_message.client_context)
         self.assertEqual(data["client_context"], "mutation-token")
 
+    def test_direct_send_accepts_scalar_user_id(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(client, "private_request", return_value=self.direct_payload()) as private,
+        ):
+            client.direct_send("hello", user_ids="42")
+
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["recipient_users"]), [[42]])
+
+    def test_direct_send_accepts_scalar_thread_id(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(client, "private_request", return_value=self.direct_payload()) as private,
+        ):
+            client.direct_send("hello", thread_ids="340282366841710300949128149448121770626")
+
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [340282366841710300949128149448121770626])
+
+    def test_direct_media_share_accepts_scalar_user_id(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(client, "media_id", return_value="123_1"),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload() | {"status": "ok"}
+            ) as private,
+        ):
+            client.direct_media_share("123", user_ids=42)
+
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["recipient_users"]), [[42]])
+
     def test_direct_send_reaction_posts_reaction_payload(self):
         client = self.build_client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- accept scalar Direct recipient ids such as `user_ids=123` and `thread_ids=123`
- reuse the normalization across Direct send/share/presence/thread lookup helpers
- document scalar recipient ids in the Direct usage guide

## Verification
- RED: `.venv/bin/python -m pytest tests/regression/test_direct.py -q` failed before the fix for scalar `user_ids`/`thread_ids`
- `.venv/bin/python -m pytest tests/regression/test_direct.py -q`
- `.venv/bin/ruff check instagrapi/mixins/direct.py tests/regression/test_direct.py tests/live/test_direct.py`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m mkdocs build --strict`
- sk.test: `TEST_ACCOUNTS_URL=... /home/test/instagrapi/.venv/bin/python -m pytest tests/live/test_direct.py::ClientDirectTestCase::test_direct_send_accepts_scalar_user_id_live -q`

Related: #1890