### PR TITLE
feat: Use curl-impersonate

### DIFF
--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -2,6 +2,9 @@ import json
 import logging
 import time
 
+from curl_adapter import CurlCffiAdapter
+from curl_cffi import BrowserType, BrowserTypeLiteral
+
 try:
     from simplejson.errors import JSONDecodeError
 except ImportError:
@@ -42,21 +45,27 @@ class PublicRequestMixin:
     session_retry_backoff_factor = 2
     session_retry_statuses = [429, 500, 502, 503, 504]
     last_response_ts = 0
+    public_browser_type: BrowserTypeLiteral = "chrome146"
+    user_agents: dict[BrowserTypeLiteral, str] = {
+        "chrome146": f"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+    }
+    public_user_agent = user_agents[public_browser_type]
+    public_accept_language = "en-US"
 
     def __init__(self, *args, **kwargs):
         session = requests.Session()
         self.public = session
         self.public.verify = False  # fix SSLError/HTTPSConnectionPool
+        self.public_browser_type = kwargs.pop("browser_type", getattr(self, "browser_type", self.public_browser_type))
+        self.public_user_agent = kwargs.pop("public_user_agent", getattr(self, "public_user_agent", self.public_user_agent))
+        self.public_accept_language = kwargs.pop("public_accept_language", getattr(self, "public_accept_language", self.public_accept_language))
         self.public.headers.update(
             {
                 "Connection": "Keep-Alive",
                 "Accept": "*/*",
                 "Accept-Encoding": "gzip,deflate",
-                "Accept-Language": "en-US",
-                "User-Agent": (
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 "
-                    "(KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
-                ),
+                "Accept-Language": self.public_accept_language,
+                "User-Agent": self.public_user_agent,
             }
         )
         self.request_timeout = kwargs.pop("request_timeout", getattr(self, "request_timeout", self.request_timeout))
@@ -114,7 +123,8 @@ class PublicRequestMixin:
             )
 
     def _configure_public_session_retry(self):
-        adapter = HTTPAdapter(max_retries=self._build_public_session_retry_strategy())
+        # adapter = HTTPAdapter(max_retries=self._build_public_session_retry_strategy())
+        adapter = CurlCffiAdapter(impersonate_browser_type=self.public_browser_type)
         self.public.mount("https://", adapter)
         self.public.mount("http://", adapter)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "pydantic==2.13.4",
     "moviepy==1.0.3",
     "pycryptodomex==3.23.0",
+    "curl-adapter>=1.2.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Attempting to log in using 

```python
cl = Client()
cl.login("1fexd", "mypassword")
```

prints the following:

```
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): www.instagram.com:443
DEBUG:urllib3.connectionpool:https://www.instagram.com:443 "GET /api/v1/users/web_profile_info/?username=1fexd HTTP/1.1" 429 0
DEBUG:urllib3.util.retry:Incremented Retry for (url='/api/v1/users/web_profile_info/?username=1fexd'): Retry(total=2, connect=None, read=None, redirect=None, status=None)
DEBUG:urllib3.connectionpool:Retry: /api/v1/users/web_profile_info/?username=1fexd
DEBUG:urllib3.connectionpool:https://www.instagram.com:443 "GET /api/v1/users/web_profile_info/?username=1fexd HTTP/1.1" 429 0
DEBUG:urllib3.util.retry:Incremented Retry for (url='/api/v1/users/web_profile_info/?username=1fexd'): Retry(total=1, connect=None, read=None, redirect=None, status=None)
DEBUG:urllib3.connectionpool:Retry: /api/v1/users/web_profile_info/?username=1fexd
DEBUG:urllib3.connectionpool:https://www.instagram.com:443 "GET /api/v1/users/web_profile_info/?username=1fexd HTTP/1.1" 429 0
DEBUG:urllib3.util.retry:Incremented Retry for (url='/api/v1/users/web_profile_info/?username=1fexd'): Retry(total=0, connect=None, read=None, redirect=None, status=None)
DEBUG:urllib3.connectionpool:Retry: /api/v1/users/web_profile_info/?username=1fexd
DEBUG:urllib3.connectionpool:https://www.instagram.com:443 "GET /api/v1/users/web_profile_info/?username=1fexd HTTP/1.1" 429 0
WARNING:instagrapi:Public user lookup failed, falling back to private API: HTTPSConnectionPool(host='www.instagram.com', port=443): Max retries exceeded with url: /api/v1/users/web_profile_info/?username=1fexd (Caused by ResponseError('too many 429 error responses'))
```

Instagram seems to use TLS fingerprinting to detect whether a request actually comes from a browser; This PR is a quick PoC that integrates [curl-adapter](https://github.com/el1s7/curl-adapter) which uses [curl_cffi](https://github.com/lexiforest/curl_cffi) to spoof the TLS fingerprint.

Using this PR, the public user lookup works as expected:

```
DEBUG:public_request:public_request 200: https://www.instagram.com/api/v1/users/web_profile_info/?username=1fexd
INFO:public_request:[None] [200] GET https://www.instagram.com/api/v1/users/web_profile_info/?username=1fexd
```

Unfortunately, `CurlCffiAdapter` doesn't appear to support retrying failed requests, so it would either have to be implemented upstream or manually handled in `instagrapi`.