### PR TITLE
Add Direct group participant helper

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -54,7 +54,10 @@ jobs:
 
       - name: Run direct media test
         if: github.event.inputs.test_target == 'direct' || github.event.inputs.test_target == 'all'
-        run: pytest -sv tests/live/test_direct.py::ClientDirectMediaLiveTestCase
+        run: |
+          pytest -sv \
+            tests/live/test_direct.py::ClientDirectMediaLiveTestCase \
+            tests/live/test_direct.py::ClientDirectThreadLiveTestCase::test_direct_thread_add_users_live
 
       - name: Run timeline test
         if: github.event.inputs.test_target == 'timeline' || github.event.inputs.test_target == 'all'

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -18,6 +18,7 @@
 | direct_search(query: str)                                                 | List[DirectShortThread] | Search threads (for example by username)
 | direct_thread_by_participants(user_ids: List[int])                        | DirectThread            | Get thread by user_id
 | direct_thread_create(user_ids: List[int], title: str = "")                | str                     | Create a group thread and return its thread id
+| direct_thread_add_users(thread_id: int, user_ids: List[int])              | bool                    | Add users to a group thread
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
 | direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a group thread title
 | direct_media_share(media_id: str, user_ids: List[int])                    | DirectMessage           | Share a media to list of users
@@ -128,6 +129,9 @@ DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[Direc
 >>> thread_id = cl.direct_thread_create([user_id_1, user_id_2], title="New group")
 >>> cl.direct_thread(thread_id, amount=1)
 DirectThread(pk=178612312342, id=340282366812312312312341298762, messages=[...], ...)
+
+>>> cl.direct_thread_add_users(thread_id, [user_id_3])
+True
 
 >>> cl.direct_thread_update_title(thread.id, "New group title")
 True

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1514,6 +1514,33 @@ class DirectMixin:
         )
         return result.get("status", "") == "ok"
 
+    def direct_thread_add_users(self, thread_id: int, user_ids: List[int]) -> bool:
+        """
+        Add users to a group Direct thread.
+
+        Parameters
+        ----------
+        thread_id: int
+            ID of thread to add users to
+        user_ids: List[int]
+            List of unique identifiers of users to add to the group thread
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        assert user_ids, "At least one user_id required"
+
+        result = self.private_request(
+            f"direct_v2/threads/{thread_id}/add_user/",
+            data={"_uuid": self.uuid, "user_ids": dumps([str(uid) for uid in user_ids])},
+            with_signature=False,
+        )
+        return result.get("status", "") == "ok"
+
     def direct_thread_create(self, user_ids: List[int], title: str = "") -> str:
         """
         Create a group Direct thread.

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -315,9 +315,10 @@ class ClientDirectThreadLiveTestCase(_helpers.ClientPrivateTestCase):
     def setUp(self):
         if not TEST_ACCOUNTS_URL:
             self.skipTest("TEST_ACCOUNTS_URL is required for direct thread live tests")
-        accounts = self.fresh_accounts(3)
+        accounts = self.fresh_accounts(4)
         self.cl = accounts[0]
-        self.recipient_clients = accounts[1:]
+        self.recipient_clients = accounts[1:3]
+        self.add_client = accounts[3]
 
     def test_direct_thread_update_title_live(self):
         initial_title = f"instagrapi-title-{int(time.time())}"
@@ -334,6 +335,28 @@ class ClientDirectThreadLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(self.cl.direct_thread_update_title(thread_id, updated_title))
             thread = self.cl.direct_thread(thread_id, amount=1)
             self.assertEqual(thread.thread_title, updated_title)
+        finally:
+            if thread_id:
+                try:
+                    self.cl.direct_thread_hide(thread_id)
+                except Exception as exc:
+                    logger.warning("Direct thread cleanup failed: %s", exc)
+
+    def test_direct_thread_add_users_live(self):
+        title = f"instagrapi-add-users-{int(time.time())}"
+        thread_id = None
+
+        try:
+            thread_id = self.cl.direct_thread_create(
+                [int(client.user_id) for client in self.recipient_clients],
+                title=title,
+            )
+            self.assertTrue(thread_id)
+
+            self.assertTrue(self.cl.direct_thread_add_users(thread_id, [int(self.add_client.user_id)]))
+            thread = self.cl.direct_thread(thread_id, amount=1)
+            user_ids = {str(user.pk) for user in thread.users}
+            self.assertIn(str(self.add_client.user_id), user_ids)
         finally:
             if thread_id:
                 try:

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -24,6 +24,20 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
             with_signature=False,
         )
 
+    def test_direct_thread_add_users_posts_unsigned_user_ids(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private:
+            result = client.direct_thread_add_users(123, [42, "43"])
+
+        self.assertTrue(result)
+        private.assert_called_once_with(
+            "direct_v2/threads/123/add_user/",
+            data={"_uuid": "uuid-1", "user_ids": '["42","43"]'},
+            with_signature=False,
+        )
+
     def test_direct_thread_create_posts_group_payload(self):
         client = self.build_client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- add `direct_thread_add_users(thread_id, user_ids)` for adding participants to existing Direct group threads
- document the new Direct helper
- add regression and live coverage, and include the live test in the `direct` workflow target

## Verification
- `uv run pytest tests/regression/test_direct.py`
- `uv run ruff check --output-format=github .`
- `uv run ruff format --check .`
- `pytest tests/live/test_direct.py::ClientDirectThreadLiveTestCase::test_direct_thread_add_users_live -q` on the live test host: 1 passed in 122.63s

Closes #1393
Related #1777