### PR TITLE
Fix media_info_gql doc_id fallback

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ cl.video_upload_to_story(
 
 ### Requests
 
-* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`) or `_a1` (example `https://www.instagram.com/example/?__a=1`)
+* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`) or `_a1` (example `https://www.instagram.com/example/?__a=1`). Some `_gql` helpers use newer `doc_id` queries when Instagram disables legacy `query_hash` endpoints.
 * `Private` (authorized request via mobile api) methods have `_v1` suffix
 
 Public web flows are not guaranteed. Instagram can change or block them independently of the library, and some helpers can only work reliably with an authenticated session.

--- a/docs/usage-guide/fundamentals.md
+++ b/docs/usage-guide/fundamentals.md
@@ -5,7 +5,7 @@ This section provides detailed descriptions of all the ways `instagrapi` can be 
 
 ## Public vs Private Requests
 
-* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`) or `_a1` (example `https://www.instagram.com/example/?__a=1`)
+* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`) or `_a1` (example `https://www.instagram.com/example/?__a=1`). Some `_gql` helpers use newer `doc_id` queries when Instagram disables legacy `query_hash` endpoints.
 * `Private` (authorized request via mobile api) methods have `_v1` suffix
 
 Public web flows are opportunistic, not guaranteed. Instagram can change or block them independently of the library.

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -61,7 +61,7 @@ Low level methods:
 | Method | Return | Description |
 | --- | --- | --- |
 | media_info_a1(media_pk: str, max_id: str = None) | Media | Get media from PK via public web API |
-| media_info_gql(media_pk: str) | Media | Get media from PK via public GraphQL API |
+| media_info_gql(media_pk: str) | Media | Get media from PK via public GraphQL API. Falls back from legacy `query_hash` to the newer `doc_id` media query when available. |
 | media_info_v1(media_pk: str) | Media | Get media from PK via private mobile API |
 | media_info_v2(media_id: str) | Media | Alternative source for media info via `discover/media_metadata/` (`media_or_ad` payload). Useful as fallback when `media_info_v1` fails on certain ad-tagged or sponsored media. Strips `_userid` suffix automatically. |
 | user_medias_gql(user_id: str, amount: int = 0, sleep: int = 0) | List\[Media] | Get user media via public GraphQL API |
@@ -238,6 +238,7 @@ True
 Notes:
 
 * High-level `media_info()` prefers public paths and falls back to private/mobile when needed.
+* For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.
 

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -39,6 +39,11 @@ from .types import (
 from .utils import InstagramIdCodec, json_value
 
 MEDIA_TYPES_GQL = {"GraphImage": 1, "GraphVideo": 2, "GraphSidecar": 8, "StoryVideo": 2}
+XDT_MEDIA_TYPES_GQL = {
+    "XDTGraphImage": "GraphImage",
+    "XDTGraphVideo": "GraphVideo",
+    "XDTGraphSidecar": "GraphSidecar",
+}
 
 
 def extract_media_v1(data):
@@ -103,6 +108,7 @@ def extract_media_v1_xma(data):
 def extract_media_gql(data):
     """Extract media from GraphQL"""
     media = deepcopy(data)
+    media["__typename"] = XDT_MEDIA_TYPES_GQL.get(media.get("__typename"), media.get("__typename"))
     user = extract_user_short(media["owner"])
     # if "full_name" in user:
     #     user = extract_user_short(user)
@@ -138,7 +144,14 @@ def extract_media_gql(data):
         location=extract_location(location) if location else None,
         user=user,
         view_count=media.get("video_view_count", 0),
-        comment_count=json_value(media, "edge_media_to_comment", "count"),
+        play_count=media.get("play_count", media.get("video_play_count")),
+        has_liked=media.get("has_liked", media.get("viewer_has_liked")),
+        comment_count=json_value(
+            media,
+            "edge_media_to_comment",
+            "count",
+            default=json_value(media, "edge_media_preview_comment", "count", default=0),
+        ),
         like_count=json_value(media, "edge_media_preview_like", "count"),
         caption_text=json_value(media, "edge_media_to_caption", "edges", 0, "node", "text", default=""),
         usertags=sorted(

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -8,6 +8,8 @@ from urllib.parse import urlparse
 
 from instagrapi.exceptions import (
     ClientError,
+    ClientForbiddenError,
+    ClientGraphqlError,
     ClientLoginRequired,
     ClientNotFoundError,
     ClientUnauthorizedError,
@@ -25,6 +27,8 @@ from instagrapi.extractors import (
 from instagrapi.types import Location, Media, UserShort, Usertag
 from instagrapi.utils.ids import InstagramIdCodec
 from instagrapi.utils.serialization import json_value
+
+MEDIA_INFO_DOC_ID = "8845758582119845"
 
 
 class MediaMixin:
@@ -240,8 +244,25 @@ class MediaMixin:
         }
         try:
             data = self.public_graphql_request(variables, query_hash="477b65a610463740ccdb83135b2014db")
-        except (ClientLoginRequired, ClientUnauthorizedError):
-            return self.media_info_a1(media_pk)
+        except (
+            ClientForbiddenError,
+            ClientGraphqlError,
+            ClientLoginRequired,
+            ClientNotFoundError,
+            ClientUnauthorizedError,
+        ):
+            try:
+                data = self.public_doc_id_graphql_request(
+                    MEDIA_INFO_DOC_ID,
+                    {"shortcode": shortcode},
+                    referer=f"https://www.instagram.com/p/{shortcode}/",
+                )
+            except (ClientForbiddenError, ClientLoginRequired, ClientUnauthorizedError):
+                return self.media_info_a1(media_pk)
+            media = data.get("xdt_shortcode_media") or data.get("shortcode_media")
+            if not media:
+                raise MediaNotFound(media_pk=media_pk, **data)
+            return extract_media_gql(media)
         if not data.get("shortcode_media"):
             raise MediaNotFound(media_pk=media_pk, **data)
         if data["shortcode_media"]["location"] and self.authorization:

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from typing import Any, Dict, Optional
 
 try:
     from simplejson.errors import JSONDecodeError
@@ -213,11 +214,12 @@ class PublicRequestMixin:
         update_headers=None,
     ):
         self.public_requests_count += 1
+        per_request_headers = None
         if headers:
             if update_headers in [None, True]:
                 self.public.headers.update(headers)
             elif update_headers is False:
-                pass
+                per_request_headers = headers
         if self.last_response_ts and (time.time() - self.last_response_ts) < 1.0:
             time.sleep(1.0)
         if self.request_timeout:
@@ -228,6 +230,7 @@ class PublicRequestMixin:
                     url,
                     data=data,
                     params=params,
+                    headers=per_request_headers,
                     proxies=self.public.proxies,
                     timeout=timeout,
                 )
@@ -235,6 +238,7 @@ class PublicRequestMixin:
                 response = self.public.get(
                     url,
                     params=params,
+                    headers=per_request_headers,
                     proxies=self.public.proxies,
                     stream=stream,
                     timeout=timeout,
@@ -373,6 +377,62 @@ class PublicRequestMixin:
             except JSONDecodeError:
                 pass
             raise ClientGraphqlError("Error: '{}'. Message: '{}'".format(e, message), response=e.response)
+
+    def public_doc_id_graphql_request(
+        self,
+        doc_id: str,
+        variables: Dict[str, Any],
+        referer: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        POST a doc_id-based GraphQL query to www.instagram.com/graphql/query/.
+
+        Newer Instagram web GraphQL endpoints use ``doc_id`` instead of the
+        legacy ``query_hash`` / ``query_id`` scheme. Returns the parsed
+        ``data`` payload.
+        """
+        data = {
+            "variables": json.dumps(variables, separators=(",", ":")),
+            "doc_id": doc_id,
+            "server_timestamps": "true",
+        }
+        inject_sessionid = getattr(self, "inject_sessionid_to_public", None)
+        if inject_sessionid:
+            inject_sessionid()
+        merged_headers = {
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "en-US,en;q=0.8",
+            "Referer": referer or "https://www.instagram.com/",
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+            ),
+        }
+        csrftoken = self.public.cookies.get("csrftoken")
+        if csrftoken:
+            merged_headers["X-CSRFToken"] = csrftoken
+        if headers:
+            merged_headers.update(headers)
+        body_json = self.public_request(
+            self.GRAPHQL_PUBLIC_API_URL,
+            data=data,
+            headers=merged_headers,
+            update_headers=False,
+            return_json=True,
+        )
+        if "data" not in body_json:
+            errors = body_json.get("errors") or []
+            summary = errors[0].get("summary") if errors else None
+            description = errors[0].get("description") if errors else None
+            raise ClientGraphqlError(
+                "Missing 'data' in doc_id GraphQL response (doc_id={}). Summary: '{}'. Description: '{}'".format(
+                    doc_id,
+                    summary,
+                    description,
+                )
+            )
+        return body_json["data"]
 
 
 class TopSearchesPublicMixin:

--- a/tests/live/test_public.py
+++ b/tests/live/test_public.py
@@ -2,7 +2,7 @@ from tests import helpers as _helpers
 from tests.helpers import *
 
 
-class ClientPublicTestCase(_helpers.BaseClientMixin, unittest.TestCase):
+class ClientPublicTestCase(_helpers.ClientPrivateTestCase):
     cl = None
 
     def assertDict(self, obj, data):
@@ -15,27 +15,16 @@ class ClientPublicTestCase(_helpers.BaseClientMixin, unittest.TestCase):
                 self.assertEqual(obj[key], value)
 
     def test_media_info_gql(self):
-        media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/BVDOOolFFxg/")
+        media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/C_BM2yAN4Rm/")
         m = self.cl.media_info_gql(media_pk)
         self.assertIsInstance(m, Media)
-        media = {
-            "pk": 1532130876531694688,
-            "id": "1532130876531694688_25025320",
-            "code": "BVDOOolFFxg",
-            "taken_at": datetime(2017, 6, 7, 19, 37, 35, tzinfo=UTC()),
-            "media_type": 1,
-            "product_type": "",
-            "thumbnail_url": "https://...",
-            "location": None,
-            "comment_count": 6,
-            "like_count": 79,
-            "has_liked": None,
-            "caption_text": "#creepy #creepyclothing",
-            "usertags": [],
-            "video_url": None,
-            "view_count": 0,
-            "video_duration": 0.0,
-            "title": "",
-            "resources": [],
-        }
-        self.assertDict(m.dict(), media)
+        self.assertEqual(m.pk, "3441088131388376166")
+        self.assertEqual(m.code, "C_BM2yAN4Rm")
+        self.assertEqual(m.media_type, 2)
+        self.assertEqual(m.product_type, "clips")
+        self.assertGreaterEqual(m.comment_count, 3)
+        self.assertGreaterEqual(m.play_count, 1)
+        self.assertGreaterEqual(m.view_count, 0)
+        self.assertGreaterEqual(m.like_count, -1)
+        self.assertTrue(m.thumbnail_url)
+        self.assertTrue(m.video_url)

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import ClientForbiddenError, ClientNotFoundError
 from tests.helpers import *
 
 
@@ -21,6 +22,51 @@ class PublicRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(body["status"], "ok")
         post.assert_called_once()
+
+    def test_public_request_passes_non_persistent_headers_per_request(self):
+        client = Client()
+        response = Mock()
+        response.headers = {"Content-Length": "0"}
+        response.raw.tell.return_value = 0
+        response.status_code = 200
+        response.url = "https://www.instagram.com/graphql/query/"
+        response.json.return_value = {"status": "ok", "data": {"media": {}}}
+        response.raise_for_status.return_value = None
+
+        headers = {"User-Agent": "temporary-agent"}
+        original_user_agent = client.public.headers.get("User-Agent")
+        with mock.patch.object(client.public, "post", return_value=response) as post:
+            client.public_request(
+                "https://www.instagram.com/graphql/query/",
+                data={"doc_id": "1"},
+                headers=headers,
+                update_headers=False,
+                return_json=True,
+            )
+
+        post.assert_called_once()
+        self.assertEqual(post.call_args.kwargs["headers"], headers)
+        self.assertEqual(client.public.headers.get("User-Agent"), original_user_agent)
+
+    def test_public_doc_id_graphql_request_posts_doc_id_form(self):
+        client = Client()
+
+        with mock.patch.object(client, "public_request", return_value={"data": {"ok": True}}) as public_request:
+            data = client.public_doc_id_graphql_request(
+                "8845758582119845",
+                {"shortcode": "C_BM2yAN4Rm"},
+                referer="https://www.instagram.com/p/C_BM2yAN4Rm/",
+            )
+
+        self.assertEqual(data, {"ok": True})
+        public_request.assert_called_once()
+        kwargs = public_request.call_args.kwargs
+        self.assertEqual(kwargs["data"]["doc_id"], "8845758582119845")
+        self.assertEqual(kwargs["data"]["variables"], '{"shortcode":"C_BM2yAN4Rm"}')
+        self.assertEqual(kwargs["data"]["server_timestamps"], "true")
+        self.assertEqual(kwargs["headers"]["Referer"], "https://www.instagram.com/p/C_BM2yAN4Rm/")
+        self.assertFalse(kwargs["update_headers"])
+        self.assertTrue(kwargs["return_json"])
 
     def test_public_graphql_request_raises_client_graphql_error_when_data_missing(self):
         client = Client()
@@ -60,7 +106,7 @@ class PublicRegressionTestCase(unittest.TestCase):
         private_fallback.assert_not_called()
         self.assertIn("Incorrect Query", str(cm.exception))
 
-    def test_media_info_gql_falls_back_to_a1_on_public_401(self):
+    def test_media_info_gql_falls_back_to_a1_when_doc_id_is_unauthorized(self):
         client = Client()
         expected = Mock(spec=Media)
 
@@ -69,11 +115,74 @@ class PublicRegressionTestCase(unittest.TestCase):
             "public_graphql_request",
             side_effect=ClientUnauthorizedError("401", response=Mock(status_code=401)),
         ):
-            with mock.patch.object(client, "media_info_a1", return_value=expected) as fallback:
-                result = client.media_info_gql("2110901750722920960")
+            with mock.patch.object(
+                client,
+                "public_doc_id_graphql_request",
+                side_effect=ClientForbiddenError("403", response=Mock(status_code=403)),
+            ):
+                with mock.patch.object(client, "media_info_a1", return_value=expected) as fallback:
+                    result = client.media_info_gql("2110901750722920960")
 
         self.assertIs(result, expected)
         fallback.assert_called_once_with("2110901750722920960")
+
+    def test_media_info_gql_falls_back_to_doc_id_on_public_404(self):
+        client = Client()
+        media_payload = {
+            "__typename": "XDTGraphVideo",
+            "id": "2110901750722920960",
+            "shortcode": "B1LbfVPlwIA",
+            "taken_at_timestamp": 1565796000,
+            "owner": {
+                "id": "1903424587",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+                "is_private": False,
+            },
+            "display_resources": [
+                {
+                    "src": "https://example.com/thumbnail.jpg",
+                    "config_width": 360,
+                    "config_height": 640,
+                }
+            ],
+            "product_type": "clips",
+            "is_video": True,
+            "video_url": "https://example.com/video.mp4",
+            "video_duration": 13.3,
+            "video_view_count": 7694,
+            "video_play_count": 22346,
+            "edge_media_preview_comment": {"count": 3, "edges": []},
+            "edge_media_preview_like": {"count": -1, "edges": []},
+            "edge_media_to_caption": {"edges": [{"node": {"text": "caption"}}]},
+            "edge_media_to_tagged_user": {"edges": []},
+            "edge_media_to_sponsor_user": {"edges": []},
+            "viewer_has_liked": False,
+        }
+
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            side_effect=ClientNotFoundError("404", response=Mock(status_code=404)),
+        ):
+            with mock.patch.object(
+                client,
+                "public_doc_id_graphql_request",
+                return_value={"xdt_shortcode_media": media_payload},
+            ) as doc_id_request:
+                media = client.media_info_gql("2110901750722920960")
+
+        doc_id_request.assert_called_once_with(
+            "8845758582119845",
+            {"shortcode": "B1LbfVPlwIA"},
+            referer="https://www.instagram.com/p/B1LbfVPlwIA/",
+        )
+        self.assertEqual(media.media_type, 2)
+        self.assertEqual(media.comment_count, 3)
+        self.assertEqual(media.like_count, -1)
+        self.assertEqual(media.play_count, 22346)
+        self.assertEqual(media.view_count, 7694)
+        self.assertFalse(media.has_liked)
 
     def test_public_head_defaults_to_no_redirect_follow(self):
         client = Client()


### PR DESCRIPTION
## Summary
- add a `public_doc_id_graphql_request` helper for newer Instagram web GraphQL queries
- make `media_info_gql` fall back from the disabled legacy `query_hash` media query to the current `xdt_shortcode_media` doc_id path
- normalize XDT media payloads so Reels expose `play_count`, `view_count`, hidden-like `-1`, and preview comment counts consistently
- refresh the related live `media_info_gql` fixture to a current authenticated Reel flow
- document that hidden Reel like totals are not exposed when Instagram disables like/view counts

Fixes #2058. Relates #2010.

## Verification
- `.venv/bin/python -m ruff check instagrapi/extractors.py instagrapi/mixins/media.py instagrapi/mixins/public.py tests/regression/test_public.py`
- `.venv/bin/python -m pytest tests/regression/test_public.py tests/regression/test_media.py -q`
- `sk.test`: `.venv/bin/python -m pytest tests/live/test_public.py::ClientPublicTestCase::test_media_info_gql -q` -> `1 passed`
- `sk.test` live probe for `C_BM2yAN4Rm`: `media_info_gql` returned `play=22346`, `view=7694`, `like=-1`, `comment=3`