### PR TITLE
Refresh GraphQL query identifiers

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run user test
         if: github.event.inputs.test_target == 'user' || github.event.inputs.test_target == 'all'
-        run: pytest -sv tests/live/test_user.py::ClientUserTestCase
+        run: pytest -sv tests/live/test_user.py::ClientUserTestCase tests/live/test_user.py::ClientGraphQLQueryLiveTestCase
 
       - name: Run follow request live test
         if: github.event.inputs.test_target == 'user' || github.event.inputs.test_target == 'all'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,6 +66,7 @@ jobs:
           pytest -sv \
             tests/regression/test_extractors.py::ExtractorsRegressionTestCase \
             tests/regression/test_public.py::PublicRegressionTestCase \
+            tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase \
             tests/regression/test_direct.py::DirectMixinRegressionTestCase \
             tests/regression/test_challenge.py::ChallengeRegressionTestCase \
             tests/regression/test_comments.py::CommentRepliesRegressionTestCase \
@@ -74,6 +75,7 @@ jobs:
             tests/regression/test_download.py::DownloadRegressionTestCase \
             tests/regression/test_notes.py::NoteMixinRegressionTestCase \
             tests/regression/test_location.py::LocationMixinRegressionTestCase \
+            tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase \
             tests/regression/test_user.py::UserMixinRegressionTestCase \
             tests/regression/test_timeline.py::TimelineRegressionTestCase \
             tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase \

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -59,6 +59,9 @@ def extract_media_v1(data):
             media["image_versions2"]["candidates"],
             key=lambda o: o["height"] * o["width"],
         )[-1]["url"]
+        scrubber = media["image_versions2"].get("scrubber_spritesheet_info_candidates") or {}
+        if scrubber.get("default") and not scrubber["default"].get("sprite_urls"):
+            media["image_versions2"].pop("scrubber_spritesheet_info_candidates", None)
     if media["media_type"] == 8:
         # remove thumbnail_url and video_url for albums
         # see resources
@@ -67,8 +70,9 @@ def extract_media_v1(data):
     location = media.get("location")
     media["location"] = location and extract_location(location)
     media["user"] = extract_user_short(media.get("user"))
+    usertags = media.get("usertags") or {}
     media["usertags"] = sorted(
-        [extract_usertag(usertag) for usertag in media.get("usertags", {}).get("in", [])],
+        [extract_usertag(usertag) for usertag in usertags.get("in", [])],
         key=lambda tag: tag.user.pk,
     )
     media["like_count"] = media.get("like_count", 0)
@@ -78,7 +82,7 @@ def extract_media_v1(data):
     media["coauthor_producers"] = media.get("coauthor_producers", [])
     return Media(
         caption_text=(media.get("caption") or {}).get("text", ""),
-        resources=[extract_resource_v1(edge) for edge in media.get("carousel_media", [])],
+        resources=[extract_resource_v1(edge) for edge in media.get("carousel_media") or []],
         **media,
     )
 

--- a/instagrapi/mixins/graphql.py
+++ b/instagrapi/mixins/graphql.py
@@ -1,3 +1,4 @@
+import json
 import time
 from json.decoder import JSONDecodeError
 from typing import Dict, Optional
@@ -14,6 +15,54 @@ from instagrapi.exceptions import (
 
 
 class PrivateGraphQLRequestMixin:
+    def _merge_incremental_graphql_payload(self, base: Dict, payload: Dict) -> None:
+        path = payload.get("path")
+        if not isinstance(path, list) or not path or "data" not in payload:
+            return
+        target = base
+        if path and path[0] != "data":
+            target = base.get("data", {})
+        elif path and path[0] == "data":
+            path = path[1:]
+        if not path:
+            return
+        try:
+            for key in path[:-1]:
+                target = target[key]
+        except (KeyError, IndexError, TypeError):
+            return
+        key = path[-1]
+        value = payload["data"]
+        if isinstance(target, list):
+            if not isinstance(key, int):
+                return
+            try:
+                current = target[key]
+            except IndexError:
+                return
+            if isinstance(current, dict) and isinstance(value, dict):
+                current.update(value)
+            else:
+                target[key] = value
+            return
+        current = target.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            current.update(value)
+        else:
+            target[key] = value
+
+    def _json_from_graphql_response(self, response):
+        try:
+            return response.json()
+        except JSONDecodeError:
+            chunks = [json.loads(line) for line in response.text.splitlines() if line.strip()]
+            if not chunks:
+                raise
+            body = chunks[0]
+            for chunk in chunks[1:]:
+                self._merge_incremental_graphql_payload(body, chunk)
+            return body
+
     def private_graphql_request(self, data: Dict, headers: Optional[Dict] = None, domain: Optional[str] = None) -> Dict:
         self.last_response = None
         self.last_json = {}
@@ -36,7 +85,7 @@ class PrivateGraphQLRequestMixin:
             self.request_log(response)
             self.last_response = response
             response.raise_for_status()
-            self.last_json = response.json()
+            self.last_json = self._json_from_graphql_response(response)
         except JSONDecodeError as exc:
             url = response.url if response else url
             raise ClientJSONDecodeError(

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -29,6 +29,7 @@ from instagrapi.utils.ids import InstagramIdCodec
 from instagrapi.utils.serialization import json_value
 
 MEDIA_INFO_DOC_ID = "8845758582119845"
+IG_PROFILE_TIMELINE_DOC_ID = "56030350814417327502004290437"
 
 
 class MediaMixin:
@@ -37,6 +38,125 @@ class MediaMixin:
     """
 
     _medias_cache = {}  # pk -> object
+
+    @staticmethod
+    def _find_profile_timeline_payload(data):
+        if not isinstance(data, dict):
+            return None
+        if "profile_grid_items" in data:
+            return data
+        for value in data.values():
+            found = MediaMixin._find_profile_timeline_payload(value)
+            if found:
+                return found
+        return None
+
+    @staticmethod
+    def _normalize_xdt_profile_media(media: Dict) -> Dict:
+        media = deepcopy(media)
+        user = media.get("user") or {}
+        if "pk" not in user and user.get("id"):
+            user["pk"] = user["id"]
+        media["user"] = user
+        media_id = str(media.get("id") or media.get("pk") or "")
+        if "pk" not in media and media_id:
+            media["pk"] = media_id.split("_", 1)[0]
+        if media_id and "_" not in media_id and user.get("pk"):
+            media["id"] = f"{media_id}_{user['pk']}"
+        if "taken_at" not in media and "1ltaken_at" in media:
+            media["taken_at"] = media["1ltaken_at"]
+        return media
+
+    def _user_medias_paginated_app_gql(self, user_id: str, amount: int = 0, end_cursor=None) -> Tuple[List[Media], str]:
+        count = 50 if not amount or amount > 50 else amount
+        variables = {
+            "request_media_chunk": True,
+            "skip_clips_captions_fields": False,
+            "fetch_profile_grid_items": True,
+            "exclude_comment": "false",
+            "request_hints_chunk": False,
+            "include_unseen_media_ids": False,
+            "exclude_pinned_posts": False,
+            "enable_carousel_media_count_in_deferred": True,
+            "include_fb_mentioned_users": False,
+            "include_attribution_ui_data": True,
+            "include_profile_grid_rendering_option": False,
+            "count": count,
+            "initial_count_carousel_media": 5,
+            "exclude_collaborative_posts": False,
+            "include_is_photo_comments_composer_enabled_for_author": False,
+            "include_associated_highlights": False,
+            "include_attribution_ui_data_v2": True,
+            "include_media_notes_fields": True,
+            "include_eligible_insights_entrypoints": False,
+            "include_accessibility_caption_for_carousel": True,
+            "defer_maybe_non_essential_lightweight_fields": False,
+            "num_previews_for_associated_highlights": 3,
+            "include_videos_for_associated_highlights": False,
+            "exclude_user": False,
+            "defer_hints_chunk": False,
+            "exclude_highlights": True,
+            "include_ring_creator_fields": False,
+            "include_timeline_ordered_edge": False,
+            "user_id": str(user_id),
+            "exclude_besties_content": True,
+            "force_compute_user_tags": False,
+            "enable_profile_fm_integration": False,
+            "include_is_unseen_by_viewer": False,
+        }
+        if end_cursor:
+            variables["max_id"] = end_cursor
+        data = {
+            "method": "post",
+            "pretty": "false",
+            "format": "json",
+            "server_timestamps": "true",
+            "locale": self.locale,
+            "fb_api_req_friendly_name": "IGProfileTimelineQuery",
+            "fb_api_caller_class": "graphservice",
+            "client_doc_id": IG_PROFILE_TIMELINE_DOC_ID,
+            "variables": json.dumps(variables, separators=(",", ":")),
+        }
+        response = self.private_graphql_request(
+            data,
+            headers={"X-FB-Friendly-Name": "IGProfileTimelineQuery"},
+        )
+        timeline = self._find_profile_timeline_payload(response.get("data", response))
+        if not timeline:
+            raise ClientGraphqlError("Missing profile timeline payload in IGProfileTimelineQuery response")
+        medias = []
+        for item in timeline.get("profile_grid_items") or []:
+            media = item.get("media") if isinstance(item, dict) else None
+            if not media:
+                continue
+            medias.append(extract_media_v1(self._normalize_xdt_profile_media(media)))
+        end_cursor = None
+        if timeline.get("more_available"):
+            end_cursor = timeline.get("next_max_id") or timeline.get("profile_grid_items_cursor")
+        if amount:
+            medias = medias[:amount]
+        return medias, end_cursor
+
+    def _user_medias_paginated_public_gql(
+        self, user_id: str, amount: int = 0, end_cursor=None
+    ) -> Tuple[List[Media], str]:
+        amount = int(amount)
+        user_id = int(user_id)
+        medias = []
+        variables = {
+            "id": user_id,
+            "first": 50 if not amount or amount > 50 else amount,
+        }
+        variables["after"] = end_cursor
+        data = self.public_graphql_request(variables, query_hash="e7e2f4da4b02303f74f0841279e52d76")
+        page_info = json_value(data, "user", "edge_owner_to_timeline_media", "page_info", default={})
+        edges = json_value(data, "user", "edge_owner_to_timeline_media", "edges", default=[])
+        for edge in edges:
+            medias.append(edge["node"])
+        end_cursor = page_info.get("end_cursor")
+        if amount:
+            medias = medias[:amount]
+        return ([extract_media_gql(media) for media in medias], end_cursor)
 
     def _extract_configured_media_or_raise(self, configured, exception_cls, context: str):
         media = None
@@ -540,23 +660,10 @@ class MediaMixin:
             A tuple containing a list of medias and the next end_cursor value
         """
         amount = int(amount)
-        user_id = int(user_id)
-        medias = []
-        variables = {
-            "id": user_id,
-            "first": 50 if not amount or amount > 50 else amount,
-            # These are Instagram restrictions, you can only specify <= 50
-        }
-        variables["after"] = end_cursor
-        data = self.public_graphql_request(variables, query_hash="e7e2f4da4b02303f74f0841279e52d76")
-        page_info = json_value(data, "user", "edge_owner_to_timeline_media", "page_info", default={})
-        edges = json_value(data, "user", "edge_owner_to_timeline_media", "edges", default=[])
-        for edge in edges:
-            medias.append(edge["node"])
-        end_cursor = page_info.get("end_cursor")
-        if amount:
-            medias = medias[:amount]
-        return ([extract_media_gql(media) for media in medias], end_cursor)
+        try:
+            return self._user_medias_paginated_app_gql(user_id, amount, end_cursor=end_cursor)
+        except ClientError:
+            return self._user_medias_paginated_public_gql(user_id, amount, end_cursor=end_cursor)
 
     def user_medias_gql(self, user_id: str, amount: int = 0, sleep: int = 0) -> List[Media]:
         """

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -8,7 +8,6 @@ from requests.exceptions import RequestException
 
 from instagrapi.exceptions import (
     ClientError,
-    ClientGraphqlError,
     ClientJSONDecodeError,
     ClientLoginRequired,
     ClientNotFoundError,
@@ -19,45 +18,11 @@ from instagrapi.exceptions import (
 )
 from instagrapi.extractors import extract_user_gql, extract_user_short, extract_user_v1
 from instagrapi.types import Relationship, RelationshipShort, User, UserShort
-from instagrapi.utils.auth import generate_jazoest
-from instagrapi.utils.serialization import dumps, json_value
+from instagrapi.utils.serialization import json_value
 
 MAX_USER_COUNT = 200
 INFO_FROM_MODULES = ("self_profile", "feed_timeline", "reel_feed_timeline")
-GRAPHQL_WEB_API_URL = "https://www.instagram.com/api/graphql"
-GQL_STUFF = {
-    "av": "17841464591314721",
-    "__d": "www",
-    "__user": "0",
-    "__a": "1",
-    "__req": "q",
-    "__hs": "19768.HYP:instagram_web_pkg.2.1..0.1",
-    "dpr": "2",
-    "__ccg": "UNKNOWN",
-    "__rev": "1011444902",
-    "__s": "x82a1q:agr3gd:4nh4nl",
-    "__hsi": "7335888108907652597",
-    "__dyn": (
-        "7xeUjG1mxu1syUbFp40NonwgU7SbzEdF8aUco2qwJxS0k24o0B-"
-        "q1ew65xO0FE2awt81s8hwGwQwoEcE7O2l0Fwqo31w9O7U2cxe0E"
-        "UjwGzEaE7622362W2K0zK5o4q3y1Sx-0iS2Sq2-azqwt8dUaob8"
-        "2cwMwrUdUbGwmk0KU6O1FwlE6PhA6bxy4VUKUnAwHw"
-    ),
-    "__csr": (
-        "g9cj5kxfs8lifTitQDqhdhalmDEAJaKBRJFdkAGHBkPy9HgCA-A"
-        "rtucm5bCBBGpyAoz-mLJpXJufKWGQ9hHhAhnKECuFUZ3Q8Jkmmp"
-        "eWyGAzkEj_CjyoZUgK-E8bwYzaxy00ktMGx20XU3gw4KAo3MChU"
-        "jw3N80poolwiA1d7G2yu2ucxi1nwEw16OE1JsS043Etw63wkSEgg1Mu00yiU"
-    ),
-    "__comet_req": "7",
-    "lsd": "6b2800R9u4biJOYjcdXFEI",
-    "__spin_r": "1011444902",
-    "__spin_b": "trunk",
-    "__spin_t": "1708019550",
-    "fb_api_caller_class": "RelayModern",
-    "fb_api_req_friendly_name": "PolarisProfilePageContentQuery",
-    "server_timestamps": "true",
-}
+USER_WEB_PROFILE_DOC_ID = "26762473490008061"
 
 logger = logging.getLogger(__name__)
 
@@ -122,17 +87,7 @@ class UserMixin:
             cache = self._userhorts_cache.get(user_id)
             if cache:
                 return cache
-        variables = {
-            "user_id": str(user_id),
-            "include_reel": True,
-        }
-        try:
-            data = self.public_graphql_request(variables, query_hash="ad99dd9d3646cc3c0dda65debcd266a7")
-            if not data["user"]:
-                raise UserNotFound(user_id=user_id, **data)
-            user = extract_user_short(data["user"]["reel"]["user"])
-        except ClientGraphqlError:
-            user = extract_user_short(self.user_web_profile_info_gql(user_id))
+        user = extract_user_short(self.user_web_profile_info_gql(user_id))
         self._userhorts_cache[user_id] = user
         return user
 
@@ -165,7 +120,6 @@ class UserMixin:
         user_id = str(user_id)
         if not self.inject_sessionid_to_public():
             raise ClientLoginRequired("Session is required for web profile GraphQL")
-        doc_id = "26762473490008061"
         variables = {
             "enable_integrity_filters": True,
             "id": user_id,
@@ -174,37 +128,14 @@ class UserMixin:
             "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
             "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
         }
-        headers = {
-            "Origin": "https://www.instagram.com",
-            "Authority": "www.instagram.com",
-            "Sec-Fetch-Site": "same-origin",
-            "X-FB-Friendly-Name": "PolarisProfilePageContentQuery",
-        }
-        body = self.public_request(
-            GRAPHQL_WEB_API_URL,
-            data={
-                "variables": dumps(variables),
-                "doc_id": doc_id,
-                "fb_dtsg": self.fb_dtsg,
-                "jazoest": generate_jazoest(self.phone_id),
-                **GQL_STUFF,
-            },
-            headers=headers,
-            update_headers=False,
-            return_json=True,
+        data = self.public_doc_id_graphql_request(
+            USER_WEB_PROFILE_DOC_ID,
+            variables,
+            referer=f"https://www.instagram.com/{user_id}/",
+            headers={"X-FB-Friendly-Name": "PolarisProfilePageContentQuery"},
         )
-        if errs := body.get("errors"):
-            if "data" not in body:
-                summary = errs[0].get("summary")
-                description = errs[0].get("description")
-                raise ClientGraphqlError(
-                    "GraphQL user profile fallback failed. Summary: '{}'. Description: '{}'".format(
-                        summary, description
-                    )
-                )
-        data = body.get("data")
         if not data or not data.get("user"):
-            raise UserNotFound(user_id=user_id, **body)
+            raise UserNotFound(user_id=user_id, **(data or {}))
         return data["user"]
 
     def username_from_user_id_gql(self, user_id: str) -> str:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,6 +33,7 @@ from tests.live.test_totp import TOTPTestCase
 from tests.live.test_upload import ClientFeedMusicUploadLiveTestCase, ClienUploadTestCase
 from tests.live.test_user import (
     ClientFollowRequestLiveTestCase,
+    ClientGraphQLQueryLiveTestCase,
     ClientUserExtendTestCase,
     ClientUserTestCase,
 )
@@ -51,6 +52,8 @@ from tests.regression.test_location import LocationMixinRegressionTestCase
 from tests.regression.test_media import (
     CheckOffensiveCommentV2RegressionTestCase,
     MediaInfoV2RegressionTestCase,
+    UserMediasGraphQLRegressionTestCase,
+    UsertagMediasPaginationRegressionTestCase,
 )
 from tests.regression.test_notes import NoteMixinRegressionTestCase
 from tests.regression.test_public import (

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -10,6 +10,26 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(list(followers.values())[0], UserShort)
 
 
+class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
+    def test_user_short_gql(self):
+        user = self.cl.user_short_gql("25025320", use_cache=False)
+        self.assertIsInstance(user, UserShort)
+        self.assertEqual(user.pk, "25025320")
+        self.assertEqual(user.username, "instagram")
+
+    def test_username_from_user_id(self):
+        self.assertEqual(self.cl.username_from_user_id(25025320), "instagram")
+
+    def test_user_medias_gql(self):
+        user_id = self.user_id_from_username("instagram")
+        medias = self.cl.user_medias_gql(user_id, amount=2, sleep=0)
+        self.assertGreater(len(medias), 0)
+        media = medias[0]
+        self.assertIsInstance(media, Media)
+        for field in REQUIRED_MEDIA_FIELDS:
+            self.assertTrue(hasattr(media, field))
+
+
 class ClientUsertagPaginationLiveTestCase(_helpers.ClientPrivateTestCase):
     def __init__(self, *args, **kwargs):
         self.cl = None

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -1,3 +1,5 @@
+import json
+
 from tests.helpers import *
 
 
@@ -9,12 +11,17 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
             "code": "abc",
             "taken_at": 1710000000,
             "media_type": 1,
+            "usertags": None,
+            "carousel_media": None,
             "user": {
                 "pk": "2",
                 "username": "example",
                 "profile_pic_url": "https://example.com/profile.jpg",
             },
-            "image_versions2": {"candidates": [{"url": "https://example.com/x.jpg", "width": 100, "height": 100}]},
+            "image_versions2": {
+                "candidates": [{"url": "https://example.com/x.jpg", "width": 100, "height": 100}],
+                "scrubber_spritesheet_info_candidates": {"default": {"video_length": 15.4}},
+            },
         }
 
     def test_media_info_v2_strips_userid_suffix(self):
@@ -107,7 +114,10 @@ class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
                 "username": "example",
                 "profile_pic_url": "https://example.com/profile.jpg",
             },
-            "image_versions2": {"candidates": [{"url": "https://example.com/x.jpg", "width": 100, "height": 100}]},
+            "image_versions2": {
+                "candidates": [{"url": "https://example.com/x.jpg", "width": 100, "height": 100}],
+                "scrubber_spritesheet_info_candidates": {"default": {"video_length": 15.4}},
+            },
         }
 
     def _media_gql_payload(self, pk="1"):
@@ -187,3 +197,54 @@ class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
         v1.assert_called_once_with(123, 5, end_cursor="cursor-1")
         self.assertEqual(medias, ["m1"])
         self.assertEqual(end_cursor, "next-page")
+
+
+class UserMediasGraphQLRegressionTestCase(unittest.TestCase):
+    def _xdt_media_payload(self):
+        return {
+            "id": "1",
+            "code": "abc",
+            "1ltaken_at": 1710000000,
+            "media_type": 1,
+            "usertags": None,
+            "carousel_media": None,
+            "user": {
+                "pk": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "image_versions2": {"candidates": [{"url": "https://example.com/x.jpg", "width": 100, "height": 100}]},
+        }
+
+    def test_user_medias_paginated_gql_uses_app_timeline_doc_id(self):
+        client = Client()
+        response = {
+            "data": {
+                "xdt_api__v1__profile_timeline": {
+                    "profile_grid_items": [{"media": self._xdt_media_payload()}],
+                    "more_available": True,
+                    "next_max_id": "next-page",
+                }
+            }
+        }
+
+        with mock.patch.object(client, "private_graphql_request", return_value=response) as private_graphql:
+            with mock.patch.object(
+                client,
+                "public_graphql_request",
+                side_effect=AssertionError("legacy query_hash should not be used"),
+            ) as public_graphql:
+                medias, end_cursor = client.user_medias_paginated_gql("123", amount=1, end_cursor="cursor-1")
+
+        private_graphql.assert_called_once()
+        public_graphql.assert_not_called()
+        data = private_graphql.call_args.args[0]
+        variables = json.loads(data["variables"])
+        self.assertEqual(data["fb_api_req_friendly_name"], "IGProfileTimelineQuery")
+        self.assertEqual(data["client_doc_id"], "56030350814417327502004290437")
+        self.assertEqual(variables["user_id"], "123")
+        self.assertEqual(variables["count"], 1)
+        self.assertEqual(variables["max_id"], "cursor-1")
+        self.assertEqual(end_cursor, "next-page")
+        self.assertEqual([media.pk for media in medias], ["1"])
+        self.assertEqual(medias[0].id, "1_2")

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -238,3 +238,26 @@ class PrivateGraphQLRequestRegressionTestCase(unittest.TestCase):
             client.private.headers["Content-Type"],
             "application/x-www-form-urlencoded; charset=UTF-8",
         )
+
+    def test_private_graphql_request_accepts_incremental_json_lines(self):
+        client = Client()
+        client.request_timeout = 0
+        data = {
+            "fb_api_req_friendly_name": "ExampleQuery",
+            "variables": "{}",
+        }
+        response = Mock()
+        response.url = "https://i.instagram.com/graphql/query"
+        response.text = (
+            '{"data":{"timeline":{"items":[{"media":{"id":"1"}}]}},"status":"ok"}\n'
+            '{"path":["timeline","items",0,"media"],"data":{"code":"abc"}}\n'
+        )
+        response.json.side_effect = JSONDecodeError("Extra data", response.text, 68)
+        response.raise_for_status.return_value = None
+
+        with mock.patch.object(client, "request_log"):
+            with mock.patch.object(client.private, "post", return_value=response):
+                result = client.private_graphql_request(data)
+
+        self.assertEqual(result["data"]["timeline"]["items"][0]["media"]["id"], "1")
+        self.assertEqual(result["data"]["timeline"]["items"][0]["media"]["code"], "abc")

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -57,6 +57,60 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(user.username, "instagram")
         fallback.assert_called_once_with("25025320")
 
+    def test_user_short_gql_uses_web_profile_doc_id_without_legacy_query_hash(self):
+        client = Client()
+        web_user = {
+            "id": "25025320",
+            "username": "instagram",
+            "full_name": "Instagram",
+            "is_private": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+        }
+
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            side_effect=AssertionError("legacy query_hash should not be used"),
+        ) as legacy_query:
+            with mock.patch.object(client, "user_web_profile_info_gql", return_value=web_user) as profile_query:
+                user = client.user_short_gql("25025320", use_cache=False)
+
+        self.assertEqual(user.username, "instagram")
+        profile_query.assert_called_once_with("25025320")
+        legacy_query.assert_not_called()
+
+    def test_user_web_profile_info_gql_uses_public_doc_id_endpoint(self):
+        client = Client()
+        client._fb_dtsg = "token"
+        web_user = {
+            "id": "25025320",
+            "username": "instagram",
+            "full_name": "Instagram",
+            "is_private": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+        }
+
+        with mock.patch.object(client, "inject_sessionid_to_public", return_value=True):
+            with mock.patch.object(
+                client,
+                "public_request",
+                side_effect=AssertionError("legacy /api/graphql endpoint should not be used"),
+            ):
+                with mock.patch.object(
+                    client,
+                    "public_doc_id_graphql_request",
+                    return_value={"user": web_user},
+                ) as doc_id_request:
+                    user = client.user_web_profile_info_gql("25025320")
+
+        self.assertEqual(user["username"], "instagram")
+        doc_id_request.assert_called_once()
+        args, kwargs = doc_id_request.call_args
+        self.assertEqual(args[0], "26762473490008061")
+        self.assertEqual(args[1]["id"], "25025320")
+        self.assertEqual(args[1]["render_surface"], "PROFILE")
+        self.assertEqual(kwargs["referer"], "https://www.instagram.com/25025320/")
+
     def test_user_info_by_username_gql_parses_web_profile_without_update_headers_kwarg(
         self,
     ):


### PR DESCRIPTION
## Summary
- move `user_short_gql` off the stale web `query_hash` path and onto the current profile `doc_id` request
- move `user_medias_gql` to the current app `IGProfileTimelineQuery` `client_doc_id`, keeping the legacy public query as fallback
- parse app GraphQL incremental JSON-lines responses and normalize nullable XDT media fields
- add regression and live coverage for the refreshed GraphQL paths

Closes #2493

## Tests
- `ruff check .`
- `ruff format --check .`
- `pytest -sv tests/regression/test_extractors.py::ExtractorsRegressionTestCase tests/regression/test_public.py::PublicRegressionTestCase tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase tests/regression/test_direct.py::DirectMixinRegressionTestCase tests/regression/test_challenge.py::ChallengeRegressionTestCase tests/regression/test_comments.py::CommentRepliesRegressionTestCase tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase tests/regression/test_download.py::DownloadRegressionTestCase tests/regression/test_notes.py::NoteMixinRegressionTestCase tests/regression/test_location.py::LocationMixinRegressionTestCase tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase tests/regression/test_user.py::UserMixinRegressionTestCase tests/regression/test_timeline.py::TimelineRegressionTestCase tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase tests/regression/test_upload.py::UploadRegressionTestCase`
- `pytest -sv tests/live/test_user.py::ClientGraphQLQueryLiveTestCase` on `sk.test`
