### PR TITLE
Sync helper endpoints with aiograpi

### DIFF
--- a/docs/usage-guide/comment.md
+++ b/docs/usage-guide/comment.md
@@ -7,6 +7,14 @@ Post comment, viewing, like and unlike comments
 | media_comment(media_id: str, text: str, replied_to_comment_id: Optional[int] = None) | Comment | Add a new comment to media or reply to an existing comment |
 | media_comments(media_id: str, amount: int = 20) | List\[Comment] | Get comments for media; pass `amount=0` to keep paginating until exhaustion |
 | media_comments_chunk(media_id: str, max_amount: int, min_id: str = None) | Tuple[List\[Comment], str] | Get a paginated chunk of comments and the next `min_id` cursor |
+| media_comments_v1(media_id: str, amount: int = 20) | List\[Comment] | Get comments through the private mobile comments endpoint |
+| media_comments_v1_chunk(media_id: str, min_id: str = "", max_id: str = "") | Tuple[List\[Comment], str, str] | Get one private comments page and both cursors |
+| media_stream_comments_v1_chunk(media_id: str, min_id: str = "", max_id: str = "") | Tuple[List\[Comment], str, str] | Get one streamed comments page and both cursors |
+| media_comments_gql(media_pk: str, amount: int = 50, max_requests: int = 0) | List\[dict] | Get comments through the web GraphQL doc_id endpoint |
+| media_comments_gql_chunk(media_pk: str, end_cursor: str = "") | Tuple[List\[dict], str] | Get one web GraphQL comments page |
+| media_comments_threaded_gql(media_pk: str, comment_pk: str, amount: int = 0) | List\[dict] | Get threaded replies through the web GraphQL doc_id endpoint |
+| media_comments_threaded_gql_chunk(media_pk: str, comment_pk: str, end_cursor: str = "") | Tuple[List\[dict], str] | Get one threaded GraphQL comments page |
+| media_comment_infos(media_ids: List[str]) | dict | Bulk-fetch comment summaries for media ids |
 | media_comment_replies(media_id: str, comment_id: str, amount: int = 0) | List\[Comment] | Get replies for a parent media comment; pass `amount=0` to keep paginating until exhaustion |
 | media_comment_replies_chunk(media_id: str, comment_id: str, max_amount: int, min_id: str = None) | Tuple[List\[Comment], str] | Get a paginated chunk of replies and the next child cursor |
 | media_check_offensive_comment(media_id: str, text: str) | bool | Ask Instagram whether a comment text is considered offensive |
@@ -16,6 +24,8 @@ Post comment, viewing, like and unlike comments
 | comment_pin(media_id: str, comment_pk: int, revert: bool = False) | bool | Pin a comment on your media |
 | comment_unpin(media_id: str, comment_pk: int) | bool | Unpin a previously pinned comment |
 | comment_bulk_delete(media_id: str, comment_pks: List[int]) | bool | Delete one or more comments from your media |
+| comment_likers_gql(comment_pk: str, amount: int = 0) | List\[dict] | Get comment likers through public GraphQL |
+| comment_likers_gql_chunk(comment_pk: str, end_cursor: str = "") | Tuple[List\[dict], str] | Get one public GraphQL comment-likers page |
 
 
 Example:

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -30,6 +30,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_pk_from_url(url: str) | str | Return media PK from media URL; also handles `share/p/...` redirect URLs |
 | user_medias(user_id: str, amount: int = 0) | List\[Media] | Get user feed media |
 | user_medias_paginated(user_id: str, amount: int = 0, end_cursor: str = "") | Tuple[List\[Media], str] | Get one page of user media and next cursor |
+| user_medias_chunk(user_id: str, end_cursor: str = "") | Tuple[List\[Media], str] | Compatibility alias for one page of user media |
 | user_clips(user_id: str, amount: int = 0) | List\[Media] | Get clips/reels by user |
 | usertag_medias(user_id: str, amount: int = 0) | List\[Media] | Get media where a user is tagged |
 | usertag_medias_paginated(user_id: str, amount: int = 0, end_cursor: str = "") | Tuple[List\[Media], str] | Get one page of media where a user is tagged and next cursor |
@@ -42,11 +43,13 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_unlike(media_id: str) | bool | Unlike media |
 | media_seen(media_ids: List[str], skipped_media_ids: List[str] = []) | bool | Mark media as seen |
 | media_likers(media_id: str) | List\[UserShort] | Return users who liked this post |
+| media_likers_gql(media_pk: str, amount: int = 0) | List\[dict] | Return users who liked this post through the web GraphQL doc_id endpoint |
 | archive_medias(amount: int = 0) | List\[Media] | Get archived media from your account |
 | media_archive(media_id: str) | bool | Archive media |
 | media_unarchive(media_id: str) | bool | Unarchive media |
 | media_pin(media_pk: str) | bool | Pin media to profile |
 | media_unpin(media_pk: str) | bool | Unpin media from profile |
+| media_template_v1(media_id: str) | dict | Fetch a clip template payload for a Reel/clip media |
 | clip_pin(media_pk: str) | bool | Pin Reel to the Reels tab/profile Reels grid |
 | clip_unpin(media_pk: str) | bool | Unpin Reel from the Reels tab/profile Reels grid |
 | media_create_livestream(title: str = "Instagram Live") | dict | Create a new livestream and return stream metadata |
@@ -66,16 +69,21 @@ Low level methods:
 | media_info_v2(media_id: str) | Media | Alternative source for media info via `discover/media_metadata/` (`media_or_ad` payload). Useful as fallback when `media_info_v1` fails on certain ad-tagged or sponsored media. Strips `_userid` suffix automatically. |
 | user_medias_gql(user_id: str, amount: int = 0, sleep: int = 0) | List\[Media] | Get user media via public GraphQL API |
 | user_medias_paginated_gql(user_id: str, amount: int = 0, sleep: int = 2, end_cursor=None) | Tuple[List\[Media], str] | Get one public GraphQL page of user media |
+| user_medias_chunk_gql(user_id: str, sleep: int = 2, end_cursor=None, amount: int = 0) | Tuple[List\[Media], str] | Compatibility alias for one public GraphQL page of user media |
 | user_medias_v1(user_id: str, amount: int = 0) | List\[Media] | Get user media via private mobile API |
 | user_medias_paginated_v1(user_id: str, amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of user media |
+| user_medias_chunk_v1(user_id: str, end_cursor: str = "") | Tuple[List\[Media], str] | Compatibility alias for one private API page of user media |
 | user_clips_v1(user_id: str, amount: int = 0) | List\[Media] | Get user clips via private mobile API |
 | user_clips_paginated_v1(user_id: str, amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of clips |
+| user_clips_chunk_v1(user_id: str, end_cursor: str = "") | Tuple[List\[Media], str] | Compatibility alias for one private API page of clips |
 | user_videos_v1(user_id: str, amount: int = 0) | List\[Media] | Get user videos via private mobile API |
 | user_videos_paginated_v1(user_id: int, amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of videos |
+| user_videos_chunk_v1(user_id: str, end_cursor: str = "") | Tuple[List\[Media], str] | Compatibility alias for one private API page of videos |
 | usertag_medias_gql(user_id: str, amount: int = 0, sleep: int = 2) | List\[Media] | Get media where a user is tagged via public GraphQL API |
 | usertag_medias_paginated_gql(user_id: str, amount: int = 0, sleep: int = 2, end_cursor=None) | Tuple[List\[Media], str] | Get one public GraphQL page of media where a user is tagged |
 | usertag_medias_v1(user_id: str, amount: int = 0) | List\[Media] | Get media where a user is tagged via private mobile API |
 | usertag_medias_paginated_v1(user_id: str, amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of media where a user is tagged |
+| usertag_medias_v1_chunk(user_id: str, max_id: str = "") | Tuple[List\[Media], str] | Compatibility alias for one private API page of tagged media |
 | archive_medias_v1(amount: int = 0) | List\[Media] | Get archived media via private mobile API |
 | archive_medias_paginated_v1(amount: int = 0, end_cursor="") | Tuple[List\[Media], str] | Get one private API page of archived media |
 

--- a/docs/usage-guide/search.md
+++ b/docs/usage-guide/search.md
@@ -11,6 +11,9 @@ The `*_v2` methods hit the same `fbsearch/<tab>_serp/` endpoints the official In
 | `fbsearch_accounts_v2(query: str, page_token: str = None)` | `dict` | "Accounts" tab — `fbsearch/account_serp/`. Pagination via `next_page_token`. |
 | `fbsearch_reels_v2(query: str, reels_max_id: str = None, rank_token: str = None)` | `dict` | "Reels" tab — `fbsearch/reels_serp/`. |
 | `fbsearch_topsearch_v2(query: str, next_max_id: str = None, reels_max_id: str = None, rank_token: str = None)` | `dict` | Default "Top" blended tab — `fbsearch/top_serp/`. |
+| `fbsearch_item(item_id: str, search_surface: str, query: str, ...)` | `dict` | Generic `fbsearch/{item_id}/` tab helper with optional pagination cursors. |
+| `fbsearch_keyword_typeahead(query: str, timezone_offset: int = 0, count: int = 30)` | `dict` | Raw keyword/typeahead suggestions via `fbsearch/keyword_typeahead/`. |
+| `fbsearch_typeahead_stream(query: str, timezone_offset: int = 0, count: int = 30)` | `dict` | Raw streaming typeahead payload via `fbsearch/typeahead_stream/`. |
 | `fbsearch_typehead(query: str)` | `List[dict]` | Typeahead user suggestions, flattened from the `stream_rows` envelope returned by `fbsearch/typeahead_stream/`. |
 
 Example:
@@ -39,6 +42,8 @@ users = cl.fbsearch_typehead("py")
 | `search_hashtags(query: str)` | `List[Hashtag]` | Hashtag search via `tags/search/`. |
 | `search_music(query: str)` | `List[Track]` | Music/audio search via `music/audio_global_search/`. |
 | `fbsearch_topsearch_flat(query: str)` | `List[dict]` | Legacy flat top-search via `fbsearch/topsearch_flat/`. |
+| `web_search_topsearch(query: str)` | `dict` | Raw web top-search payload via `web/search/topsearch/`. |
+| `web_search_topsearch_hashtags(query: str)` | `List[Hashtag]` | Extract hashtags from the web top-search payload. |
 | `fbsearch_suggested_profiles(user_id: str)` | `List[UserShort]` | Suggested profiles via `fbsearch/accounts_recs/`. |
 | `fbsearch_recent()` | `List[Tuple[int, ...]]` | Recently searched items. |
 

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -12,6 +12,8 @@ View a list of a user's medias, following and followers
 | search_following(user_id: str, query: str)    | List[UserShort]       | Search by following                                          |
 | user_info(user_id: str)                       | User                  | Get user info                                                |
 | user_info_by_username(username: str)          | User                  | Get user info by username                                    |
+| user_about_v1(user_id: str)                   | About                 | Get "About this account" info                                |
+| user_guides_v1(user_id: int)                  | List[Guide]           | Get user's guides                                            |
 | user_follow(user_id: str)                     | bool                  | Follow user                                                  |
 | user_unfollow(user_id: str)                   | bool                  | Unfollow user                                                |
 | user_follow_requests(amount: int = 0)         | List[UserShort]       | Get pending incoming follow requests                         |
@@ -56,6 +58,7 @@ Streamed profile fetch (raw payloads, app-side surface):
 | user_stream_by_id_flat(user_id: str)          | dict                  | Same as `_v1` but `stream_rows[*].user` partials merged into a single dict |
 | user_stream_by_username_flat(username: str)   | dict                  | Same as `_v1` but `stream_rows[*].user` partials merged into a single dict |
 | user_web_profile_info_v1(username: str)       | dict                  | `users/web_profile_info/?username=...` via the private host (logged-in session, bypasses public-side rate limiting) |
+| feed_user_stream_item(item_id: str, is_pull_to_refresh: bool = False) | dict | Raw streamed feed payload for a user/profile grid item |
 
 Low level methods:
 
@@ -70,6 +73,13 @@ Low level methods:
 | user_following_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
 | search_followers_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by followers by Private Mobile API                                  |
 | search_following_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by following by Private Mobile API                                  |
+| user_info_by_username_a1(username: str)                                             | dict                        | Raw public A1 username payload                                             |
+| user_info_v2_gql(user_id: str)                                                      | User                        | Profile lookup through current doc_id GraphQL                              |
+| user_info_by_username_v2_gql(username: str)                                         | User                        | Resolve username through doc_id search, then fetch profile                 |
+| private_graphql_followers_list(user_id: str, rank_token: str, ...)                  | dict                        | Raw private mobile GraphQL followers list                                  |
+| private_graphql_following_list(user_id: str, rank_token: str, ...)                  | dict                        | Raw private mobile GraphQL following list                                  |
+| private_graphql_clips_profile(target_user_id: str, ...)                             | dict                        | Raw private mobile GraphQL profile Reels stream                            |
+| private_graphql_inbox_tray_for_user(user_id: str, ...)                              | dict                        | Raw private mobile GraphQL inbox tray query                                |
 
 The batch follow request helpers call the single-user approve/decline endpoints for
 each `user_id`; they do not implement an auto-approval policy.

--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -132,10 +132,15 @@ class Client(
                 scheme="http://" if not urlparse(self.proxy).scheme else "",
                 href=self.proxy,
             )
-            self.public.proxies = self.private.proxies = {
+            proxies = {
                 "http": proxy_href,
                 "https": proxy_href,
             }
+            self.public.proxies = self.private.proxies = proxies
+            if hasattr(self, "graphql"):
+                self.graphql.proxies = proxies
             return True
         self.public.proxies = self.private.proxies = {}
+        if hasattr(self, "graphql"):
+            self.graphql.proxies = {}
         return False

--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -327,6 +327,18 @@ class MediaUnavailable(PrivateError):
     """Media is unavailable"""
 
 
+class CommentUnavailable(PrivateError):
+    """Comment is unavailable"""
+
+
+class CommentNotFound(PrivateError):
+    message = "Comment not found"
+
+
+class CommentsDisabled(PrivateError):
+    message = "Comments disabled by author"
+
+
 class ValidationError(AssertionError):
     pass
 

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -5,6 +5,7 @@ import re
 from copy import deepcopy
 
 from .types import (
+    About,
     Account,
     Broadcast,
     Collection,
@@ -629,3 +630,46 @@ def extract_track(data):
     data["uri"] = html.unescape(items[0]) if items else None
     data["territory_validity_periods"] = data.get("territory_validity_periods") or {}
     return Track(**data)
+
+
+def _extract_about_lispy(c, data):
+    params = {}
+    try:
+        params["country"] = c.split('"')[1]
+    except IndexError:
+        pass
+    try:
+        s = str(data).split("space_evenly")[1].split("stretch")
+        try:
+            params["username"] = s[1].split("center")[1].split(": '")[1].split("',")[0]
+        except IndexError:
+            pass
+        try:
+            params["date"] = s[4].split("&")[1].split("'")[2]
+        except IndexError:
+            pass
+    except IndexError:
+        pass
+    return About(**params)
+
+
+def extract_about_v1(data):
+    c = json_value(data, "layout", "bloks_payload", "data", 0, "data")
+    params = {}
+    if c:
+        if "initial_lispy" in c:
+            return _extract_about_lispy(c["initial_lispy"], data)
+        params["country"] = c["initial"]
+    date_finded = False
+    dumped = json.dumps(data)
+    params["is_verified"] = '"Verified"' in dumped
+    ddata = dumped.split('")":')
+    for i, v in enumerate(ddata):
+        if '"bold"}' in v:
+            params["username"] = v.strip().split(",")[0][1:-1]
+        if date_finded:
+            params["date"] = v.strip().split(",")[0][1:-1]
+        if "Former usernames" in v:
+            params["former_usernames"] = ddata[i + 2].strip().split(",")[0][1:-1]
+        date_finded = '"Date joined"' in v
+    return About(**params)

--- a/instagrapi/mixins/comment.py
+++ b/instagrapi/mixins/comment.py
@@ -1,15 +1,244 @@
 import random
 from typing import List, Optional, Tuple
 
-from instagrapi.exceptions import ClientError, ClientNotFoundError, MediaNotFound
+from instagrapi.exceptions import ClientError, ClientNotFoundError, CommentNotFound, MediaNotFound
 from instagrapi.extractors import extract_comment
+from instagrapi.mixins.graphql import GQL_STUFF
 from instagrapi.types import Comment
+from instagrapi.utils.auth import generate_jazoest
+from instagrapi.utils.serialization import dumps
 
 
 class CommentMixin:
     """
     Helpers for managing comments on a Media
     """
+
+    def media_comments_threaded_gql_chunk(
+        self, media_pk: str, comment_pk: str, end_cursor: str = ""
+    ) -> Tuple[List[dict], str]:
+        """
+        Get threaded comments on a media
+
+        Parameters
+        ----------
+        comment_pk: str
+            Unique identifier of a Comment
+        end_cursor: str
+            Cursor
+
+        Returns
+        -------
+        Tuple[List[dict], str]
+            A list of objects of Comment
+        """
+        doc_id = "7171917939589632"
+        comments = []
+        media_pk = str(self.media_pk(media_pk))
+        variables = {
+            "after": end_cursor or None,
+            "before": None,
+            "first": 50,
+            "last": None,
+            "media_id": media_pk,
+            "parent_comment_id": str(comment_pk),
+            "is_chronological": None,
+        }
+        data = {
+            "variables": dumps(variables),
+            "doc_id": doc_id,
+            "fb_dtsg": self.fb_dtsg,
+            "jazoest": generate_jazoest(self.phone_id),
+            **GQL_STUFF,
+        }
+        resp = self.graphql_request(data=data)
+        if data := resp["data"]:
+            key = None
+            for key in data.keys():
+                if "comments" in key:
+                    break
+            item = data[key]
+            edges = item.get("edges", [])
+            if not edges:
+                raise CommentNotFound(**data)
+            for edge in edges:
+                comments.append(edge["node"])
+            page_info = item.get("page_info", {})
+            end_cursor = page_info.get("end_cursor") if page_info.get("has_next_page") else None
+            return comments, end_cursor
+        return [], ""
+
+    def media_comments_threaded_gql(self, media_pk: str, comment_pk: str, amount: int = 0) -> List[dict]:
+        """
+        Get threaded comments on a media
+        """
+        end_cursor = ""
+        comments = []
+        while True:
+            items, end_cursor = self.media_comments_threaded_gql_chunk(media_pk, comment_pk, end_cursor=end_cursor)
+            comments.extend(items)
+            if not end_cursor or len(items) == 0:
+                break
+            if amount and len(comments) >= amount:
+                break
+        if amount:
+            comments = comments[:amount]
+        return comments
+
+    def media_comments_gql_chunk(self, media_pk: str, end_cursor: str = "") -> Tuple[List[dict], str]:
+        """
+        Get comments on a media
+
+        Parameters
+        ----------
+        media_pk: str
+            Unique identifier of a Media
+        end_cursor: str
+            Cursor
+
+        Returns
+        -------
+        Tuple[List[dict], str]
+            A list of objects of Comment
+        """
+        media_pk = str(self.media_pk(media_pk))
+        comments = []
+        doc_id = "6974885689225067"
+        variables = {
+            "after": end_cursor or None,
+            "before": None,
+            "first": 50,
+            "last": None,
+            "media_id": media_pk,
+            "sort_order": "popular",
+        }
+        data = {
+            "variables": dumps(variables),
+            "doc_id": doc_id,
+            "fb_dtsg": self.fb_dtsg,
+            "jazoest": generate_jazoest(self.phone_id),
+            **GQL_STUFF,
+        }
+        resp = self.graphql_request(data=data)
+        if data := resp["data"]:
+            key = None
+            for key in data.keys():
+                if "comments" in key:
+                    break
+            item = data[key]
+            for edge in item.get("edges", []):
+                comments.append(edge["node"])
+            page_info = item.get("page_info", {})
+            end_cursor = page_info.get("end_cursor") if page_info.get("has_next_page") else None
+            return comments, end_cursor
+        return [], ""
+
+    def media_comments_gql(self, media_pk: str, amount: int = 50, max_requests: int = 0) -> List[dict]:
+        """
+        Get comments on a media
+        """
+        media_pk = self.media_pk(media_pk)
+        end_cursor = ""
+        comments = []
+        i = 0
+        while True:
+            i += 1
+            if max_requests and i > max_requests:
+                break
+            items, end_cursor = self.media_comments_gql_chunk(media_pk, end_cursor=end_cursor)
+            comments.extend(items)
+            if not end_cursor or len(items) == 0:
+                break
+            if amount and len(comments) >= amount:
+                break
+        if amount:
+            comments = comments[:amount]
+        return comments
+
+    def media_stream_comments_v1_chunk(
+        self, media_id: str, min_id: str = "", max_id: str = ""
+    ) -> Tuple[List[Comment], str, str]:
+        """
+        Get stream comments on a media
+        """
+        params = {
+            "can_support_threading": "true",
+            "inventory_source": "explore_story",
+            "analytics_module": "comments_v2_feed_timeline",
+            "is_carousel_bumped_post": "false",
+            "feed_position": "1",
+        }
+        if min_id:
+            params["min_id"] = min_id
+        if max_id:
+            params["max_id"] = max_id
+        result = self.private_request(
+            f"media/{media_id}/stream_comments/",
+            params=params,
+        )
+        comments = []
+        rows = result.get("stream_rows") or [result]
+        for row in rows:
+            for comment in row["comments"]:
+                comments.append(extract_comment(comment))
+        min_id = result.get("next_min_id") or result.get("min_id", "")
+        max_id = result.get("next_max_id") or result.get("max_id", "")
+        return comments, min_id, max_id
+
+    def media_comment_infos(self, media_ids: List[str]) -> dict:
+        """
+        Bulk-fetch comment summaries for one or more media items.
+        """
+        if isinstance(media_ids, (list, tuple)):
+            joined = ",".join(str(m) for m in media_ids)
+        else:
+            joined = str(media_ids)
+        params = {
+            "can_support_carousel_mentions": "false",
+            "media_ids": joined,
+        }
+        return self.private_request("media/comment_infos/", params=params)
+
+    def media_comments_v1_chunk(
+        self, media_id: str, min_id: str = "", max_id: str = ""
+    ) -> Tuple[List[Comment], str, str]:
+        """
+        Get comments on a media by Private Mobile API.
+        """
+        params = {"can_support_threading": "true", "permalink_enabled": "false"}
+        if min_id:
+            params["min_id"] = min_id
+        if max_id:
+            params["max_id"] = max_id
+        result = self.private_request(f"media/{media_id}/comments/", params=params)
+        comments = [extract_comment(comment) for comment in result.get("comments", [])]
+        min_id = result.get("next_min_id") or result.get("min_id", "")
+        max_id = result.get("next_max_id") or result.get("max_id", "")
+        return comments, min_id, max_id
+
+    def media_comments_v1(self, media_id: str, amount: int = 20) -> List[Comment]:
+        """
+        Get comments on a media by Private Mobile API.
+        """
+        comments = []
+        min_id, max_id = None, None
+        try:
+            while True:
+                items, min_id, max_id = self.media_comments_v1_chunk(media_id, min_id, max_id)
+                comments.extend(items)
+                if len(items) == 0:
+                    break
+                if amount and len(comments) > amount:
+                    break
+        except ClientNotFoundError as e:
+            raise MediaNotFound(e, media_id=media_id, **self.last_json)
+        except ClientError as e:
+            if "Media not found" in str(e):
+                raise MediaNotFound(e, media_id=media_id, **self.last_json)
+            raise e
+        if amount:
+            comments = comments[:amount]
+        return comments
 
     def media_comments(self, media_id: str, amount: int = 20) -> List[Comment]:
         """
@@ -398,3 +627,46 @@ class CommentMixin:
         }
         result = self.private_request(f"media/{media_id}/comment/bulk_delete/", self.with_action_data(data))
         return result["status"] == "ok"
+
+    def comment_likers_gql_chunk(self, comment_pk: str, end_cursor: str = "") -> Tuple[List[dict], str]:
+        """
+        Get likers of comment
+        """
+        comment_pk = str(comment_pk)
+        self.inject_sessionid_to_public()
+        likers = []
+        variables = {
+            "comment_id": str(comment_pk),
+            "first": 50,
+        }
+        query_hash = "5f0b1f6281e72053cbc07909c8d154ae"
+        if end_cursor:
+            variables["after"] = end_cursor
+        data = self.public_graphql_request(variables, query_hash=query_hash)
+        comment = data.get("comment") or {}
+        edge_liked_by = comment.get("edge_liked_by") or {}
+        for edge in edge_liked_by.get("edges") or []:
+            likers.append(edge["node"])
+        end_cursor = ""
+        if "page_info" in edge_liked_by:
+            page_info = edge_liked_by["page_info"]
+            end_cursor = page_info["end_cursor"] if page_info["has_next_page"] else None
+        return likers, end_cursor
+
+    def comment_likers_gql(self, comment_pk: str, amount: int = 0) -> List[dict]:
+        """
+        Get likers of comment
+        """
+        comment_pk = str(comment_pk)
+        end_cursor = ""
+        likers = []
+        while True:
+            items, end_cursor = self.comment_likers_gql_chunk(comment_pk, end_cursor=end_cursor)
+            likers.extend(items)
+            if not end_cursor or len(items) == 0:
+                break
+            if amount and len(likers) >= amount:
+                break
+        if amount:
+            likers = likers[:amount]
+        return likers

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -862,6 +862,43 @@ class DirectMixin:
         )
         return extract_direct_message(result["payload"])
 
+    def _messenger_rupload_headers(self, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        bearer = self.private.headers.get("Authorization") or self.authorization
+        user_id = str(self.user_id)
+        rur = self.private.headers.get("IG-U-RUR", "")
+        mid = self.private.headers.get("X-MID", "")
+
+        headers = {
+            "authorization": bearer,
+            "ig-intended-user-id": user_id,
+            "ig-u-ds-user-id": user_id,
+            # The real client may send zstd; requests cannot decode zstd, and
+            # rupload accepts gzip for these Direct attachment flows.
+            "accept-encoding": "gzip",
+            "accept-language": "en-US",
+            "priority": "u=6, i",
+            "user-agent": self.user_agent,
+            "x-fb-client-ip": "True",
+            "x-fb-friendly-name": "undefined:media-upload",
+            "x-fb-http-engine": "Tigon/MNS/TCP",
+            "x-fb-request-analytics-tags": (
+                '{"network_tags":{"product":"567067343352427",'
+                '"surface":"undefined","request_category":"media_upload",'
+                '"purpose":"none","retry_attempt":"0"}}'
+            ),
+            "x-fb-rmd": "state=URL_ELIGIBLE",
+            "x-fb-server-cluster": "True",
+            "x-tigon-is-retry": "False",
+            "x-ig-salt-ids": "51052545",
+        }
+        if rur:
+            headers["ig-u-rur"] = rur
+        if mid:
+            headers["x-mid"] = mid
+        if extra_headers:
+            headers.update(extra_headers)
+        return headers
+
     def _video_rupload(self, video_bytes: bytes, entity_name: str, waterfall_id: str) -> int:
         """Upload mp4 bytes to ``rupload.facebook.com/messenger_video/...`` and
         return the ``media_id`` used as ``attachment_fbid`` in the broadcast.
@@ -882,42 +919,16 @@ class DirectMixin:
         if getattr(self, "proxy", None):
             sess.proxies = {"http": self.proxy, "https": self.proxy}
 
-        bearer = self.private.headers.get("Authorization") or self.authorization
-        user_id = str(self.user_id)
-        rur = self.private.headers.get("IG-U-RUR", "")
-        mid = self.private.headers.get("X-MID", "")
-
-        headers = {
-            "authorization": bearer,
-            "ig-intended-user-id": user_id,
-            "ig-u-ds-user-id": user_id,
-            "accept-encoding": "gzip",
-            "accept-language": "en-US",
-            "priority": "u=6, i",
-            "user-agent": self.user_agent,
-            "video_type": "FILE_ATTACHMENT",
-            "segment-start-offset": "0",
-            "segment-type": "3",
-            "ephemeral_media_view_mode": "2",
-            "ig_raven_metadata": "{}",
-            "x_fb_video_waterfall_id": waterfall_id,
-            "x-fb-client-ip": "True",
-            "x-fb-friendly-name": "undefined:media-upload",
-            "x-fb-http-engine": "Tigon/MNS/TCP",
-            "x-fb-request-analytics-tags": (
-                '{"network_tags":{"product":"567067343352427",'
-                '"surface":"undefined","request_category":"media_upload",'
-                '"purpose":"none","retry_attempt":"0"}}'
-            ),
-            "x-fb-rmd": "state=URL_ELIGIBLE",
-            "x-fb-server-cluster": "True",
-            "x-tigon-is-retry": "False",
-            "x-ig-salt-ids": "51052545",
-        }
-        if rur:
-            headers["ig-u-rur"] = rur
-        if mid:
-            headers["x-mid"] = mid
+        headers = self._messenger_rupload_headers(
+            {
+                "video_type": "FILE_ATTACHMENT",
+                "segment-start-offset": "0",
+                "segment-type": "3",
+                "ephemeral_media_view_mode": "2",
+                "ig_raven_metadata": "{}",
+                "x_fb_video_waterfall_id": waterfall_id,
+            }
+        )
 
         # 1. fetch resumable offset
         r = sess.get(url, headers=headers, timeout=30)
@@ -1058,39 +1069,7 @@ class DirectMixin:
         if getattr(self, "proxy", None):
             sess.proxies = {"http": self.proxy, "https": self.proxy}
 
-        bearer = self.private.headers.get("Authorization") or self.authorization
-        user_id = str(self.user_id)
-        rur = self.private.headers.get("IG-U-RUR", "")
-        mid = self.private.headers.get("X-MID", "")
-
-        headers = {
-            "authorization": bearer,
-            "ig-intended-user-id": user_id,
-            "ig-u-ds-user-id": user_id,
-            # NOTE: real client sends zstd; requests cannot decode zstd so use
-            # gzip. The server honors either.
-            "accept-encoding": "gzip",
-            "accept-language": "en-US",
-            "priority": "u=6, i",
-            "user-agent": self.user_agent,
-            "audio_type": "FILE_ATTACHMENT",
-            "x-fb-client-ip": "True",
-            "x-fb-friendly-name": "undefined:media-upload",
-            "x-fb-http-engine": "Tigon/MNS/TCP",
-            "x-fb-request-analytics-tags": (
-                '{"network_tags":{"product":"567067343352427",'
-                '"surface":"undefined","request_category":"media_upload",'
-                '"purpose":"none","retry_attempt":"0"}}'
-            ),
-            "x-fb-rmd": "state=URL_ELIGIBLE",
-            "x-fb-server-cluster": "True",
-            "x-tigon-is-retry": "False",
-            "x-ig-salt-ids": "51052545",
-        }
-        if rur:
-            headers["ig-u-rur"] = rur
-        if mid:
-            headers["x-mid"] = mid
+        headers = self._messenger_rupload_headers({"audio_type": "FILE_ATTACHMENT"})
 
         # 1. fetch resumable offset
         r = sess.get(url, headers=headers, timeout=30)

--- a/instagrapi/mixins/fbsearch.py
+++ b/instagrapi/mixins/fbsearch.py
@@ -25,6 +25,15 @@ class FbSearchMixin:
             locations.append(extract_location(item["location"]))
         return locations
 
+    def web_search_topsearch(self, query: str) -> dict:
+        params = {
+            "search_surface": "web_top_search",
+            "context": "blended",
+            "include_reel": "true",
+            "query": query,
+        }
+        return self.private_request("web/search/topsearch/", params=params)
+
     def fbsearch_topsearch_flat(self, query: str) -> List[dict]:
         params = {
             "search_surface": "top_search_page",
@@ -71,6 +80,86 @@ class FbSearchMixin:
         }
         result = self.private_request("fbsearch/accounts_recs/", params=params)
         return result["users"]
+
+    def web_search_topsearch_hashtags(self, query: str) -> List[Hashtag]:
+        result = self.web_search_topsearch(query)
+        return [extract_hashtag_v1(item["hashtag"]) for item in result.get("hashtags", [])]
+
+    def fbsearch_item(
+        self,
+        item_id: str,
+        search_surface: str,
+        query: str,
+        timezone_offset: int = 0,
+        count: int = 30,
+        reels_page_index: int = None,
+        has_more_reels: str = None,
+        reels_max_id: str = None,
+        next_max_id: str = None,
+        rank_token: str = None,
+        page_index: int = None,
+        page_token: str = None,
+        paging_token: str = None,
+    ) -> dict:
+        params = {
+            "search_surface": search_surface,
+            "query": query,
+        }
+        if timezone_offset:
+            params["timezone_offset"] = timezone_offset
+        if count:
+            params["count"] = count
+        if reels_page_index is not None:
+            params["reels_page_index"] = reels_page_index
+        if has_more_reels:
+            params["has_more_reels"] = has_more_reels
+        if reels_max_id:
+            params["reels_max_id"] = reels_max_id
+        if next_max_id:
+            params["next_max_id"] = next_max_id
+        if rank_token:
+            params["rank_token"] = rank_token
+        if page_index is not None:
+            params["page_index"] = page_index
+        if page_token:
+            params["page_token"] = page_token
+        if paging_token:
+            params["paging_token"] = paging_token
+        return self.private_request(f"fbsearch/{item_id}/", params=params)
+
+    def fbsearch_keyword_typeahead(
+        self,
+        query: str,
+        timezone_offset: int = 0,
+        count: int = 30,
+    ) -> dict:
+        params = {
+            "search_surface": "typeahead_search_page",
+            "query": query,
+            "context": "blended",
+        }
+        if timezone_offset:
+            params["timezone_offset"] = timezone_offset
+        if count:
+            params["count"] = count
+        return self.private_request("fbsearch/keyword_typeahead/", params=params)
+
+    def fbsearch_typeahead_stream(
+        self,
+        query: str,
+        timezone_offset: int = 0,
+        count: int = 30,
+    ) -> dict:
+        params = {
+            "search_surface": "typeahead_search_page",
+            "query": query,
+            "context": "blended",
+        }
+        if timezone_offset:
+            params["timezone_offset"] = timezone_offset
+        if count:
+            params["count"] = count
+        return self.private_request("fbsearch/typeahead_stream/", params=params)
 
     def fbsearch_recent(self) -> List[Tuple[int, Union[UserShort, Hashtag, Dict]]]:
         """

--- a/instagrapi/mixins/graphql.py
+++ b/instagrapi/mixins/graphql.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import time
 from json.decoder import JSONDecodeError
 from typing import Dict, Optional
@@ -7,14 +8,93 @@ import requests
 
 from instagrapi import config
 from instagrapi.exceptions import (
+    ChallengeRequired,
+    ClientBadRequestError,
     ClientConnectionError,
     ClientError,
+    ClientForbiddenError,
     ClientGraphqlError,
     ClientJSONDecodeError,
+    ClientLoginRequired,
+    ClientNotFoundError,
+    ClientThrottledError,
+    ClientUnauthorizedError,
+    FeedbackRequired,
+    LoginRequired,
+    PrivateAccount,
+    RateLimitError,
+    SentryBlock,
+    UserNotFound,
 )
+from instagrapi.utils.logging import truncate_log_text
+from instagrapi.utils.timing import random_delay
+
+GRAPHQL_API_URL = "https://www.instagram.com/api/graphql"
+PRIVATE_GRAPHQL_QUERY_URL = "https://i.instagram.com/graphql/query"
+
+GQL_STUFF = {
+    "av": "17841464591314721",
+    "__d": "www",
+    "__user": "0",
+    "__a": "1",
+    "__req": "q",
+    "__hs": "19768.HYP:instagram_web_pkg.2.1..0.1",
+    "dpr": "2",
+    "__ccg": "UNKNOWN",
+    "__rev": "1011444902",
+    "__s": "x82a1q:agr3gd:4nh4nl",
+    "__hsi": "7335888108907652597",
+    "__dyn": (
+        "7xeUjG1mxu1syUbFp40NonwgU7SbzEdF8aUco2qwJxS0k24o0B-"
+        "q1ew65xO0FE2awt81s8hwGwQwoEcE7O2l0Fwqo31w9O7U2cxe0E"
+        "UjwGzEaE7622362W2K0zK5o4q3y1Sx-0iS2Sq2-azqwt8dUaob8"
+        "2cwMwrUdUbGwmk0KU6O1FwlE6PhA6bxy4VUKUnAwHw"
+    ),
+    "__csr": (
+        "g9cj5kxfs8lifTitQDqhdhalmDEAJaKBRJFdkAGHBkPy9HgCA-A"
+        "rtucm5bCBBGpyAoz-mLJpXJufKWGQ9hHhAhnKECuFUZ3Q8Jkmmp"
+        "eWyGAzkEj_CjyoZUgK-E8bwYzaxy00ktMGx20XU3gw4KAo3MChU"
+        "jw3N80poolwiA1d7G2yu2ucxi1nwEw16OE1JsS043Etw63wkSEgg1Mu00yiU"
+    ),
+    "__comet_req": "7",
+    "lsd": "6b2800R9u4biJOYjcdXFEI",
+    "__spin_r": "1011444902",
+    "__spin_b": "trunk",
+    "__spin_t": "1708019550",
+    "fb_api_caller_class": "RelayModern",
+    "fb_api_req_friendly_name": "PolarisPostCommentsPaginationQuery",
+    "server_timestamps": "true",
+}
 
 
 class PrivateGraphQLRequestMixin:
+    _fb_dtsg = None
+    graphql_requests_count = 0
+    last_graphql_response = None
+    last_graphql_json = {}
+    request_logger = logging.getLogger("graphql_request")
+
+    def __init__(self, *args, **kwargs):
+        self.graphql = requests.Session()
+        self.graphql.verify = False
+        self.graphql.headers.update(
+            {
+                "Connection": "Keep-Alive",
+                "Accept": "*/*",
+                "Accept-Encoding": "gzip,deflate",
+                "Accept-Language": "en-US,en;q=0.9",
+                "origin": "https://www.instagram.com",
+                "authority": "www.instagram.com",
+                "sec-fetch-site": "same-origin",
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/121.0.0.0 Safari/537.36"
+                ),
+            }
+        )
+        super().__init__(*args, **kwargs)
+
     def _merge_incremental_graphql_payload(self, base: Dict, payload: Dict) -> None:
         path = payload.get("path")
         if not isinstance(path, list) or not path or "data" not in payload:
@@ -51,6 +131,26 @@ class PrivateGraphQLRequestMixin:
         else:
             target[key] = value
 
+    @property
+    def fb_dtsg(self):
+        if not self._fb_dtsg:
+            self._fb_dtsg = self.fetch_fb_dtsg()
+        return self._fb_dtsg
+
+    def fetch_fb_dtsg(self):
+        self.inject_sessionid_to_public()
+        response = self.graphql.get(GRAPHQL_API_URL, proxies=self.graphql.proxies)
+        html = response.content.decode() if response.content else ""
+        if html:
+            s = html.find("__eqmc")
+            e = s + 1000
+            eqmc = html[s:e]
+            s, e = eqmc.find("{"), eqmc.find("</script>")
+            eqmc = eqmc[s:e]
+            if eqmc:
+                return json.loads(eqmc)["f"]
+        return None
+
     def _json_from_graphql_response(self, response):
         try:
             return response.json()
@@ -62,6 +162,115 @@ class PrivateGraphQLRequestMixin:
             for chunk in chunks[1:]:
                 self._merge_incremental_graphql_payload(body, chunk)
             return body
+
+    def graphql_request(
+        self,
+        data=None,
+        params=None,
+        headers=None,
+        return_json=True,
+        retries_count=1,
+        retries_timeout=2,
+    ):
+        kwargs = dict(data=data, params=params, headers=headers, return_json=return_json)
+        assert retries_count <= 10, "Retries count is too high"
+        assert retries_timeout <= 600, "Retries timeout is too high"
+        self.inject_sessionid_to_public()
+        for iteration in range(retries_count):
+            try:
+                if self.delay_range:
+                    random_delay(delay_range=self.delay_range)
+                return self._send_graphql_request(**kwargs)
+            except (
+                ClientLoginRequired,
+                ClientNotFoundError,
+                ClientBadRequestError,
+            ) as e:
+                raise e
+            except ClientError as e:
+                msg = str(e)
+                if all(
+                    (
+                        isinstance(e, ClientConnectionError),
+                        "SOCKSHTTPSConnectionPool" in msg,
+                        "Max retries exceeded with url" in msg,
+                        "Failed to establish a new connection" in msg,
+                    )
+                ):
+                    raise e
+                if retries_count > iteration + 1:
+                    time.sleep(retries_timeout)
+                else:
+                    raise e
+
+    def _send_graphql_request(self, data=None, params=None, headers=None, return_json=False):
+        self.last_graphql_response = None
+        self.graphql_requests_count += 1
+        if headers:
+            self.graphql.headers.update(headers)
+        if self.last_response_ts and (time.time() - self.last_response_ts) < 1.0:
+            time.sleep(1.0)
+        try:
+            if data is not None:
+                response = self.graphql.post(
+                    GRAPHQL_API_URL,
+                    data=data,
+                    params=params,
+                    proxies=self.graphql.proxies,
+                )
+            else:
+                response = self.graphql.get(
+                    GRAPHQL_API_URL,
+                    params=params,
+                    proxies=self.graphql.proxies,
+                )
+            self.request_logger.debug("graphql_request %s: %s", response.status_code, response.url)
+            self.request_logger.info(
+                "GraphQL: [%s] [%s] %s %s",
+                self.graphql.proxies.get("https"),
+                response.status_code,
+                "POST" if data else "GET",
+                response.url,
+            )
+            self.last_graphql_response = response
+            response.raise_for_status()
+            if return_json:
+                self.last_graphql_json = response.json()
+                return self.last_graphql_json
+            return response.text
+        except JSONDecodeError as e:
+            url = str(response.url)
+            if "/login/" in url:
+                raise ClientLoginRequired(e, response=response)
+            self.request_logger.error(
+                "Status %s: JSONDecodeError in graphql_request (url=%s) >>> %s",
+                response.status_code,
+                url,
+                truncate_log_text(response.text),
+            )
+            raise ClientJSONDecodeError(
+                "JSONDecodeError {0!s} while opening {1!s}".format(e, url),
+                response=response,
+            )
+        except requests.HTTPError as e:
+            status_code = getattr(self.last_graphql_response, "status_code", None)
+            if status_code == 401:
+                exc = ClientUnauthorizedError
+            elif status_code == 403:
+                exc = ClientForbiddenError
+            elif status_code == 400:
+                exc = ClientBadRequestError
+            elif status_code == 429:
+                exc = ClientThrottledError
+            elif status_code == 404:
+                exc = ClientNotFoundError
+            else:
+                exc = ClientError
+            raise exc(e, response=self.last_graphql_response)
+        except requests.ConnectionError as e:
+            raise ClientConnectionError("{} {}".format(e.__class__.__name__, str(e)))
+        finally:
+            self.last_response_ts = time.time()
 
     def private_graphql_request(self, data: Dict, headers: Optional[Dict] = None, domain: Optional[str] = None) -> Dict:
         self.last_response = None
@@ -101,3 +310,155 @@ class PrivateGraphQLRequestMixin:
         if self.last_json.get("status") == "fail":
             raise ClientError(response=response, **self.last_json)
         return self.last_json
+
+    def private_graphql_query_request(
+        self,
+        friendly_name: str,
+        root_field_name: str,
+        variables: dict = None,
+        client_doc_id: str = None,
+        priority: str = None,
+        extra_headers: dict = None,
+    ) -> dict:
+        data = {
+            "method": "post",
+            "pretty": "false",
+            "format": "json",
+            "server_timestamps": "true",
+            "locale": "user",
+            "fb_api_req_friendly_name": friendly_name,
+            "enable_canonical_naming": "true",
+            "enable_canonical_variable_overrides": "true",
+            "enable_canonical_naming_ambiguous_type_prefixing": "true",
+            "variables": json.dumps(variables or {}, separators=(",", ":")),
+        }
+        if client_doc_id:
+            data["client_doc_id"] = client_doc_id
+        headers = {
+            "X-FB-Friendly-Name": friendly_name,
+            "X-Root-Field-Name": root_field_name,
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        }
+        if client_doc_id:
+            headers["X-Client-Doc-Id"] = str(client_doc_id)
+        if priority:
+            headers["Priority"] = priority
+        if extra_headers:
+            headers.update(extra_headers)
+        merged = dict(self.base_headers)
+        merged.update(headers)
+        if self.authorization:
+            merged.setdefault("Authorization", self.authorization)
+        self.last_json = {}
+        response = self.private.post(
+            PRIVATE_GRAPHQL_QUERY_URL,
+            data=data,
+            headers=merged,
+            proxies=self.private.proxies,
+        )
+        self.last_response = response
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            try:
+                body_json = response.json()
+                if isinstance(body_json, dict):
+                    self.last_json = body_json
+                    last_json = body_json
+                else:
+                    last_json = {}
+            except Exception:
+                last_json = {}
+            message = ""
+            error_type = None
+            if isinstance(last_json, dict):
+                message = (last_json.get("message") or "").lower()
+                error_type = last_json.get("error_type")
+            if message == "login_required":
+                raise LoginRequired(e, response=response, **last_json)
+            if message == "challenge_required":
+                raise ChallengeRequired(**last_json)
+            if message == "feedback_required":
+                raise FeedbackRequired(e, response=response, **last_json)
+            if error_type == "rate_limit_error":
+                raise RateLimitError(e, response=response, **last_json)
+            if message == "user_blocked":
+                raise SentryBlock(e, response=response, **last_json)
+            if "not authorized to view user" in message:
+                raise PrivateAccount(e, response=response, **last_json)
+            if "unable to fetch followers" in message or "error generating user info response" in message:
+                raise UserNotFound(e, response=response, **last_json)
+            if getattr(response, "status_code", None) == 404 and getattr(response, "content", None) == b"Not Found":
+                raise ChallengeRequired(**last_json)
+            status_code = getattr(response, "status_code", None)
+            if status_code == 400:
+                exc = ClientBadRequestError
+            elif status_code == 401:
+                exc = ClientUnauthorizedError
+            elif status_code == 403:
+                exc = ClientForbiddenError
+            elif status_code == 404:
+                exc = ClientNotFoundError
+            elif status_code == 429:
+                exc = ClientThrottledError
+            else:
+                exc = ClientError
+            raise exc(e, response=response, **last_json)
+        try:
+            body = response.json()
+        except JSONDecodeError:
+            text = response.text.strip()
+            rows = [json.loads(item if item.endswith('"}') else f'{item}"}}') for item in text.split('"}\n') if item]
+            body = {"stream_rows": rows}
+        self.last_json = body
+        return body
+
+    def private_graphql_memories_pog(
+        self,
+        client_doc_id: str = "4160563056814166588457451196",
+        direct_region_hint: str = None,
+    ) -> dict:
+        extra_headers = None
+        if direct_region_hint:
+            extra_headers = {"ig-u-ig-direct-region-hint": direct_region_hint}
+        return self.private_graphql_query_request(
+            friendly_name="MemoriesPogQuery",
+            root_field_name="xdt_get_story_memories_pog",
+            variables={"request": {"user_id": 0}},
+            client_doc_id=client_doc_id,
+            extra_headers=extra_headers,
+        )
+
+    def private_graphql_realtime_region_hint(
+        self,
+        client_doc_id: str = "52232106018313849661757113193",
+    ) -> dict:
+        return self.private_graphql_query_request(
+            friendly_name="IGRealtimeRegionHintQuery",
+            root_field_name="xdt_igd_msg_region",
+            variables={},
+            client_doc_id=client_doc_id,
+            priority="u=3, i",
+        )
+
+    def private_graphql_top_audio_trends_eligible_categories(
+        self,
+        client_doc_id: str = "10243243298540497152200027985",
+    ) -> dict:
+        return self.private_graphql_query_request(
+            friendly_name="GetTopAudioTrendsEligibleCategories",
+            root_field_name="xdt_top_audio_trends_eligible_tabs",
+            variables={},
+            client_doc_id=client_doc_id,
+        )
+
+    def private_graphql_update_inbox_tray_last_seen(
+        self,
+        client_doc_id: str = "41048505499858972910914091441",
+    ) -> dict:
+        return self.private_graphql_query_request(
+            friendly_name="UpdateInboxTrayLastSeenTimestamp",
+            root_field_name="__typename",
+            variables={},
+            client_doc_id=client_doc_id,
+        )

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -24,9 +24,11 @@ from instagrapi.extractors import (
     extract_media_v1,
     extract_user_short,
 )
+from instagrapi.mixins.graphql import GQL_STUFF
 from instagrapi.types import Location, Media, UserShort, Usertag
+from instagrapi.utils.auth import generate_jazoest
 from instagrapi.utils.ids import InstagramIdCodec
-from instagrapi.utils.serialization import json_value
+from instagrapi.utils.serialization import dumps, json_value
 
 MEDIA_INFO_DOC_ID = "8845758582119845"
 IG_PROFILE_TIMELINE_DOC_ID = "56030350814417327502004290437"
@@ -665,6 +667,14 @@ class MediaMixin:
         except ClientError:
             return self._user_medias_paginated_public_gql(user_id, amount, end_cursor=end_cursor)
 
+    def user_medias_chunk_gql(
+        self, user_id: str, sleep: int = 2, end_cursor=None, amount: int = 0
+    ) -> Tuple[List[Media], str]:
+        """
+        Compatibility alias for aiograpi's original chunk naming.
+        """
+        return self.user_medias_paginated_gql(user_id, amount=amount, sleep=sleep, end_cursor=end_cursor)
+
     def user_medias_gql(self, user_id: str, amount: int = 0, sleep: int = 0) -> List[Media]:
         """
         Get a user's media by Public Graphql API
@@ -747,6 +757,12 @@ class MediaMixin:
             medias = medias[:amount]
         return ([extract_media_v1(media) for media in medias], next_max_id)
 
+    def user_videos_chunk_v1(self, user_id: str, end_cursor: str = "") -> Tuple[List[Media], str]:
+        """
+        Compatibility alias for aiograpi's original chunk naming.
+        """
+        return self.user_videos_paginated_v1(user_id, amount=50, end_cursor=end_cursor)
+
     def user_videos_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get a user's video by Private Mobile API
@@ -827,6 +843,12 @@ class MediaMixin:
             medias = medias[:amount]
         return ([extract_media_v1(media) for media in medias], next_max_id)
 
+    def user_medias_chunk_v1(self, user_id: str, end_cursor: str = "") -> Tuple[List[Media], str]:
+        """
+        Compatibility alias for aiograpi's original chunk naming.
+        """
+        return self.user_medias_paginated_v1(user_id, amount=33, end_cursor=end_cursor)
+
     def user_medias_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get a user's media by Private Mobile API
@@ -903,6 +925,12 @@ class MediaMixin:
                 self.logger.exception(e)
             medias, end_cursor = self.user_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
         return medias, end_cursor
+
+    def user_medias_chunk(self, user_id: str, end_cursor: str = "") -> Tuple[List[Media], str]:
+        """
+        Compatibility alias for aiograpi's original chunk naming.
+        """
+        return self.user_medias_paginated(user_id, amount=0, end_cursor=end_cursor)
 
     def user_pinned_medias(self, user_id) -> List[Media]:
         """
@@ -1015,6 +1043,12 @@ class MediaMixin:
             medias = medias[:amount]
         return ([extract_media_v1(media["media"]) for media in medias], next_max_id)
 
+    def user_clips_chunk_v1(self, user_id: str, end_cursor: str = "") -> Tuple[List[Media], str]:
+        """
+        Compatibility alias for aiograpi's original chunk naming.
+        """
+        return self.user_clips_paginated_v1(user_id, amount=50, end_cursor=end_cursor)
+
     def user_clips_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get a user's clip (reels) by Private Mobile API
@@ -1121,6 +1155,29 @@ class MediaMixin:
         media_id = self.media_id(media_id)
         result = self.private_request(f"media/{media_id}/likers/")
         return [extract_user_short(u) for u in result["users"]]
+
+    def media_likers_gql_chunk(self, media_pk: str, end_cursor: str = "") -> List[dict]:
+        """
+        Get media likers through the web GraphQL doc_id endpoint.
+        """
+        data = {
+            "variables": dumps({"id": media_pk}),
+            "doc_id": "24452425501069647",
+            "fb_dtsg": self.fb_dtsg,
+            "jazoest": generate_jazoest(self.phone_id),
+            **GQL_STUFF,
+        }
+        resp = self.graphql_request(data=data)
+        return resp.get("data", {}).get("xdt_api__v1__likes__media_id__likers", {}).get("users", [])
+
+    def media_likers_gql(self, media_pk: str, amount: int = 0) -> List[dict]:
+        """
+        Get media likers through the web GraphQL doc_id endpoint.
+        """
+        likers = self.media_likers_gql_chunk(self.media_pk(media_pk))
+        if amount:
+            likers = likers[:amount]
+        return likers
 
     def media_archive(self, media_id: str, revert: bool = False) -> bool:
         """
@@ -1336,6 +1393,12 @@ class MediaMixin:
             items = items[:amount]
         return [extract_media_v1(media) for media in items], result.get("next_max_id") or ""
 
+    def usertag_medias_v1_chunk(self, user_id: str, max_id: str = "") -> Tuple[List[Media], str]:
+        """
+        Compatibility alias for aiograpi's original chunk naming.
+        """
+        return self.usertag_medias_paginated_v1(user_id, amount=0, end_cursor=max_id)
+
     def usertag_medias_v1(self, user_id: str, amount: int = 0) -> List[Media]:
         """
         Get medias where a user is tagged (by Private Mobile API)
@@ -1509,6 +1572,17 @@ class MediaMixin:
         A boolean value
         """
         return self.media_pin(media_pk, True)
+
+    def media_template_v1(self, media_id: str):
+        """
+        Fetch a clip template (remix-from-template) for a clip media.
+        """
+        data = {
+            "should_show_friends_media_at_top": "false",
+            "template_clips_media_id": media_id,
+            "_uuid": self.uuid,
+        }
+        return self.private_request("clips/template/", data=data)
 
     def media_create_livestream(self, title="Instagram Live"):
         """

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -304,7 +304,7 @@ class PublicRequestMixin:
         finally:
             self.last_response_ts = time.time()
 
-    def public_a1_request(self, endpoint, data=None, params=None, headers=None):
+    def public_a1_request(self, endpoint, data=None, params=None, headers=None, full=False):
         url = (self.PUBLIC_API_URL + str(endpoint)).replace(
             ".com//", ".com/"
         )  # (jarrodnorwell) fixed KeyError: 'data', fixed // error
@@ -312,6 +312,8 @@ class PublicRequestMixin:
         params.update({"__a": 1, "__d": "dis"})
 
         response = self.public_request(url, data=data, params=params, headers=headers, return_json=True)
+        if full:
+            return response
         return response.get("graphql") or response
 
     def public_a1_request_user_info_by_username(self, username, data=None, params=None):

--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -98,6 +98,22 @@ class SignUpMixin:
             },
         )
 
+    def check_username(self, username):
+        return self.private_request("users/check_username/", data={"username": username, "_uuid": self.uuid})
+
+    def check_phone_number(self, phone_number: str):
+        return self.private_request(
+            "accounts/check_phone_number/",
+            data={
+                "phone_id": self.phone_id,
+                "login_nonce_map": "{}",
+                "phone_number": phone_number,
+                "guid": self.uuid,
+                "device_id": self.android_device_id,
+                "prefill_shown": "False",
+            },
+        )
+
     def send_verify_email(self, email) -> dict:
         """Send request to receive code to email"""
         return self.private_request(

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -16,9 +16,15 @@ from instagrapi.exceptions import (
     UnknownError,
     UserNotFound,
 )
-from instagrapi.extractors import extract_user_gql, extract_user_short, extract_user_v1
-from instagrapi.types import Relationship, RelationshipShort, User, UserShort
-from instagrapi.utils.serialization import json_value
+from instagrapi.extractors import (
+    extract_about_v1,
+    extract_guide_v1,
+    extract_user_gql,
+    extract_user_short,
+    extract_user_v1,
+)
+from instagrapi.types import About, Guide, Relationship, RelationshipShort, User, UserShort
+from instagrapi.utils.serialization import dumps, json_value
 
 MAX_USER_COUNT = 200
 INFO_FROM_MODULES = ("self_profile", "feed_timeline", "reel_feed_timeline")
@@ -183,6 +189,13 @@ class UserMixin:
             username = self.user_info_v1(user_id).username
         return username
 
+    def user_info_by_username_a1(self, username: str) -> dict:
+        """
+        Get raw public A1 user object from username.
+        """
+        username = str(username).lower()
+        return self.public_a1_request(f"/{username}/", full=True)
+
     def user_info_by_username_gql(self, username: str) -> User:
         """
         Get user object from user name
@@ -229,6 +242,57 @@ class UserMixin:
             )["data"]["user"]
         )
         return data
+
+    def _inject_sessionid_for_v2_gql(self) -> None:
+        try:
+            self.inject_sessionid_to_public()
+        except Exception as exc:
+            logger.debug("Unable to inject sessionid into public session: %r", exc)
+
+    def user_info_v2_gql(self, user_id: str) -> User:
+        """
+        Get user object via the PolarisProfilePageContentQuery doc_id.
+        """
+        variables = {
+            "id": str(user_id),
+            "render_surface": "PROFILE",
+            "__relay_internal__pv__PolarisCannesGuardianExperienceEnabledrelayprovider": True,
+            "__relay_internal__pv__PolarisCASB976ProfileEnabledrelayprovider": False,
+            "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
+        }
+        self._inject_sessionid_for_v2_gql()
+        data = self.public_doc_id_graphql_request("25980296051578533", variables)
+        user_data = (data or {}).get("user")
+        if user_data is None:
+            raise UserNotFound("User not found", user_id=user_id)
+        return extract_user_v1(self._normalize_polaris_profile(user_data))
+
+    def user_info_by_username_v2_gql(self, username: str) -> User:
+        """
+        Resolve username via doc_id search, then fetch profile by user id.
+        """
+        username = str(username).lower()
+        self._inject_sessionid_for_v2_gql()
+        data = self.public_doc_id_graphql_request("26347858941511777", {"hasQuery": True, "query": username})
+        users = ((data or {}).get("xdt_api__v1__fbsearch__non_profiled_serp") or {}).get("users") or []
+        for user in users:
+            if (user.get("username") or "").lower() == username:
+                return self.user_info_v2_gql(user.get("pk") or user.get("id"))
+        raise UserNotFound("User not found", username=username)
+
+    @staticmethod
+    def _normalize_polaris_profile(user_data: dict) -> dict:
+        normalized = dict(user_data)
+        if "pk" not in normalized and "id" in normalized:
+            normalized["pk"] = normalized["id"]
+        if "is_business" not in normalized and "is_business_account" in normalized:
+            normalized["is_business"] = normalized["is_business_account"]
+        if "category" not in normalized and "category_name" in normalized:
+            normalized["category"] = normalized["category_name"]
+        friendship = normalized.get("friendship_status") or {}
+        normalized.setdefault("followed_by_viewer", friendship.get("following", False))
+        normalized.setdefault("follows_viewer", friendship.get("followed_by", False))
+        return normalized
 
     def user_info_by_username_v1(self, username: str) -> User:
         """
@@ -357,6 +421,28 @@ class UserMixin:
                 raise UserNotFound(e, user_id=user_id, **self.last_json)
             raise e
         return extract_user_v1(result["user"])
+
+    def user_about_v1(self, user_id: str) -> About:
+        """
+        Get about info from user id.
+        """
+        user_id = str(user_id)
+        bk = dumps({"bloks_version": self.bloks_versioning_id, "styles_id": "instagram"})
+        data = {
+            "referer_type": "ProfileMore",
+            "target_user_id": user_id,
+            "bk_client_context": bk,
+            "bloks_versioning_id": self.bloks_versioning_id,
+        }
+        try:
+            self.bloks_action("com.instagram.interactions.about_this_account", data)
+        except ClientNotFoundError as e:
+            raise UserNotFound(e, user_id=user_id, **self.last_json)
+        except ClientError as e:
+            if "User not found" in str(e):
+                raise UserNotFound(e, user_id=user_id, **self.last_json)
+            raise e
+        return extract_about_v1(self.last_json)
 
     def user_info(self, user_id: str, use_cache: bool = True) -> User:
         """
@@ -1485,6 +1571,14 @@ class UserMixin:
         user = extract_user_short(result.get("user", {}))
         return (user, creator_info)
 
+    def user_guides_v1(self, user_id: int) -> List[Guide]:
+        """
+        Get guides by user_id.
+        """
+        user_id = int(user_id)
+        result = self.private_request(f"guides/user/{user_id}/")
+        return [extract_guide_v1(item) for item in (result.get("guides") or [])]
+
     def chaining(self, user_id: str) -> dict:
         """
         Get suggested users for a target user_id.
@@ -1737,6 +1831,156 @@ class UserMixin:
         if data := result.get("data", {}):
             return data
         raise UserNotFound("Username not found", username=username, **self.last_json)
+
+    def feed_user_stream_item(
+        self,
+        item_id: str,
+        is_pull_to_refresh: bool = False,
+    ) -> dict:
+        """
+        Fetch the streamed feed for a user.
+        """
+        data = {
+            "_uuid": self.uuid,
+        }
+        if is_pull_to_refresh:
+            data["is_pull_to_refresh"] = "true"
+        return self.private_request(f"feed/user_stream/{item_id}/", data=data)
+
+    def private_graphql_followers_list(
+        self,
+        user_id: str,
+        rank_token: str,
+        client_doc_id: str = "28479704798344003308647327139",
+        max_id: int = None,
+        priority: str = None,
+        exclude_field_is_favorite: bool = None,
+        exclude_unused_fields: bool = None,
+    ) -> dict:
+        request_data = {
+            "rank_token": rank_token,
+            "enableGroups": True,
+        }
+        variables = {
+            "include_unseen_count": False,
+            "query": "",
+            "include_biography": False,
+            "user_id": str(user_id),
+            "request_data": request_data,
+            "search_surface": "follow_list_page",
+        }
+        if exclude_field_is_favorite is not None:
+            variables["exclude_field_is_favorite"] = exclude_field_is_favorite
+        if max_id is not None:
+            variables["max_id"] = max_id
+        if exclude_unused_fields is not None:
+            variables["exclude_unused_fields"] = exclude_unused_fields
+        return self.private_graphql_query_request(
+            friendly_name="FollowersList",
+            root_field_name="xdt_api__v1__friendships__followers",
+            variables=variables,
+            client_doc_id=client_doc_id,
+            priority=priority,
+        )
+
+    def private_graphql_following_list(
+        self,
+        user_id: str,
+        rank_token: str,
+        client_doc_id: str = "16104639289023609826830352479",
+        max_id: int = None,
+        priority: str = None,
+        exclude_field_is_favorite: bool = None,
+        exclude_unused_fields: bool = None,
+    ) -> dict:
+        request_data = {
+            "search_surface": "follow_list_page",
+            "rank_token": rank_token,
+            "includes_hashtags": True,
+        }
+        variables = {
+            "include_unseen_count": False,
+            "enable_groups": True,
+            "user_id": str(user_id),
+            "request_data": request_data,
+            "include_biography": False,
+            "query": "",
+        }
+        if exclude_field_is_favorite is not None:
+            variables["exclude_field_is_favorite"] = exclude_field_is_favorite
+        if max_id is not None:
+            variables["max_id"] = max_id
+        if exclude_unused_fields is not None:
+            variables["exclude_unused_fields"] = exclude_unused_fields
+        return self.private_graphql_query_request(
+            friendly_name="FollowingList",
+            root_field_name="xdt_api__v1__friendships__following",
+            variables=variables,
+            client_doc_id=client_doc_id,
+            priority=priority,
+        )
+
+    def private_graphql_clips_profile(
+        self,
+        target_user_id: str,
+        client_doc_id: str = "209049231614685382737238866578",
+        priority: str = None,
+        initial_stream_count: int = 6,
+        page_size: int = 12,
+        no_of_medias_in_each_chunk: int = 6,
+    ) -> dict:
+        inner_data = {
+            "target_user_id": str(target_user_id),
+            "should_stream_response": False,
+            "sort_by_views": False,
+            "max_id": None,
+            "include_feed_video": True,
+            "audience": None,
+        }
+        if page_size:
+            inner_data["page_size"] = page_size
+        if no_of_medias_in_each_chunk:
+            inner_data["no_of_medias_in_each_chunk"] = no_of_medias_in_each_chunk
+        variables = {
+            "use_stream": False,
+            "use_defer": False,
+            "enable_video_versions_in_light_media": True,
+            "exclude_caption_user_field": False,
+            "enable_thumbnails_in_light_media": False,
+            "enable_audience_in_light_media": False,
+            "enable_clips_metadata_in_light_media": False,
+            "exclude_main_user_field": False,
+            "enable_likers_in_full_media": False,
+            "data": inner_data,
+            "stream_use_customized_batch": False,
+        }
+        if initial_stream_count:
+            variables["initial_stream_count"] = initial_stream_count
+        return self.private_graphql_query_request(
+            friendly_name="ClipsProfileQuery",
+            root_field_name="xdt_user_clips_graphql",
+            variables=variables,
+            client_doc_id=client_doc_id,
+            priority=priority,
+        )
+
+    def private_graphql_inbox_tray_for_user(
+        self,
+        user_id: str,
+        client_doc_id: str = "2035639076042015234490020607",
+        priority: str = None,
+    ) -> dict:
+        variables = {
+            "user_id": str(user_id),
+            "should_fetch_content_note_stack_video_info": False,
+        }
+        return self.private_graphql_query_request(
+            friendly_name="InboxTrayRequestForUserQuery",
+            root_field_name="xdt_get_inbox_tray_items",
+            variables=variables,
+            client_doc_id=client_doc_id,
+            priority=priority,
+        )
 
     def discover_recommended_accounts_for_category_v1(self, user_id: str) -> dict:
         """

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -97,6 +97,14 @@ class User(TypesBaseModel):
         raise ValidationError("external_url must be a URL or string")
 
 
+class About(TypesBaseModel):
+    username: Optional[str] = ""
+    is_verified: Optional[bool] = False
+    country: Optional[str] = ""
+    date: Optional[str] = ""
+    former_usernames: Optional[str] = ""
+
+
 class Account(TypesBaseModel):
     pk: str
     username: str

--- a/tests/regression/test_comments.py
+++ b/tests/regression/test_comments.py
@@ -36,6 +36,134 @@ class CommentRepliesRegressionTestCase(unittest.TestCase):
         self.assertTrue(all(isinstance(reply, Comment) for reply in replies))
         self.assertEqual(replies[0].replied_to_comment_id, "100")
 
+    def test_media_comments_gql_chunk_posts_doc_id_query(self):
+        client = Client()
+        client._fb_dtsg = "token"
+        with mock.patch.object(
+            client,
+            "graphql_request",
+            return_value={
+                "data": {
+                    "xdt_media_comments": {
+                        "edges": [{"node": {"pk": "101", "text": "hello"}}],
+                        "page_info": {"has_next_page": True, "end_cursor": "cursor-2"},
+                    }
+                }
+            },
+        ) as graphql_request:
+            comments, cursor = client.media_comments_gql_chunk("123", end_cursor="cursor-1")
+
+        self.assertEqual(comments, [{"pk": "101", "text": "hello"}])
+        self.assertEqual(cursor, "cursor-2")
+        data = graphql_request.call_args.kwargs["data"]
+        self.assertEqual(data["doc_id"], "6974885689225067")
+        self.assertIn('"media_id":"123"', data["variables"])
+        self.assertIn('"after":"cursor-1"', data["variables"])
+
+    def test_media_comments_threaded_gql_chunk_posts_parent_comment_id(self):
+        client = Client()
+        client._fb_dtsg = "token"
+        with mock.patch.object(
+            client,
+            "graphql_request",
+            return_value={
+                "data": {
+                    "xdt_threaded_comments": {
+                        "edges": [{"node": {"pk": "201", "text": "reply"}}],
+                        "page_info": {"has_next_page": False, "end_cursor": None},
+                    }
+                }
+            },
+        ) as graphql_request:
+            comments, cursor = client.media_comments_threaded_gql_chunk("123", "100")
+
+        self.assertEqual(comments, [{"pk": "201", "text": "reply"}])
+        self.assertIsNone(cursor)
+        data = graphql_request.call_args.kwargs["data"]
+        self.assertEqual(data["doc_id"], "7171917939589632")
+        self.assertIn('"parent_comment_id":"100"', data["variables"])
+
+    def test_media_comments_v1_chunk_fetches_private_comments_page(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={
+                "comments": [self._reply_payload("101")],
+                "next_min_id": "min-cursor",
+                "next_max_id": "max-cursor",
+            },
+        ) as private_request:
+            comments, min_id, max_id = client.media_comments_v1_chunk("123_456", min_id="prev-min", max_id="prev-max")
+
+        private_request.assert_called_once_with(
+            "media/123_456/comments/",
+            params={
+                "can_support_threading": "true",
+                "permalink_enabled": "false",
+                "min_id": "prev-min",
+                "max_id": "prev-max",
+            },
+        )
+        self.assertEqual([comment.pk for comment in comments], ["101"])
+        self.assertEqual(min_id, "min-cursor")
+        self.assertEqual(max_id, "max-cursor")
+
+    def test_media_stream_comments_v1_chunk_reads_stream_rows(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={
+                "stream_rows": [{"comments": [self._reply_payload("101")]}],
+                "next_min_id": "min-cursor",
+                "next_max_id": "max-cursor",
+            },
+        ) as private_request:
+            comments, min_id, max_id = client.media_stream_comments_v1_chunk("123_456")
+
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "media/123_456/stream_comments/")
+        self.assertEqual([comment.pk for comment in comments], ["101"])
+        self.assertEqual(min_id, "min-cursor")
+        self.assertEqual(max_id, "max-cursor")
+
+    def test_media_comment_infos_joins_media_ids(self):
+        client = Client()
+        expected = {"comment_infos": []}
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.media_comment_infos(["1_2", "3_4"])
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "media/comment_infos/",
+            params={"can_support_carousel_mentions": "false", "media_ids": "1_2,3_4"},
+        )
+
+    def test_comment_likers_gql_chunk_uses_comment_likers_query_hash(self):
+        client = Client()
+        with mock.patch.object(client, "inject_sessionid_to_public", return_value=True):
+            with mock.patch.object(
+                client,
+                "public_graphql_request",
+                return_value={
+                    "comment": {
+                        "edge_liked_by": {
+                            "edges": [{"node": {"id": "1", "username": "alice"}}],
+                            "page_info": {"has_next_page": True, "end_cursor": "cursor-2"},
+                        }
+                    }
+                },
+            ) as public_graphql_request:
+                likers, cursor = client.comment_likers_gql_chunk("100", end_cursor="cursor-1")
+
+        self.assertEqual(likers, [{"id": "1", "username": "alice"}])
+        self.assertEqual(cursor, "cursor-2")
+        public_graphql_request.assert_called_once_with(
+            {"comment_id": "100", "first": 50, "after": "cursor-1"},
+            query_hash="5f0b1f6281e72053cbc07909c8d154ae",
+        )
+
     def test_media_comment_replies_chunk_returns_child_cursor(self):
         client = Client()
         with mock.patch.object(

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -523,3 +523,62 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(media_id, 987654321)
         self.assertEqual(session.calls[0][2]["authorization"], client.authorization)
         self.assertNotEqual(session.calls[0][2]["authorization"], "Bearer IGT:2:raw-session")
+
+    def test_messenger_rupload_headers_merges_common_optional_and_extra_headers(self):
+        client = self.build_client()
+        client.authorization_data = {"ds_user_id": "123", "sessionid": "raw-session"}
+        client.private.headers["Authorization"] = "Bearer token"
+        client.private.headers["IG-U-RUR"] = "rur-token"
+        client.private.headers["X-MID"] = "mid-token"
+
+        headers = client._messenger_rupload_headers({"audio_type": "FILE_ATTACHMENT"})
+
+        self.assertEqual(headers["authorization"], "Bearer token")
+        self.assertEqual(headers["ig-intended-user-id"], "123")
+        self.assertEqual(headers["ig-u-ds-user-id"], "123")
+        self.assertEqual(headers["accept-encoding"], "gzip")
+        self.assertEqual(headers["accept-language"], "en-US")
+        self.assertEqual(headers["priority"], "u=6, i")
+        self.assertEqual(headers["user-agent"], client.user_agent)
+        self.assertEqual(headers["audio_type"], "FILE_ATTACHMENT")
+        self.assertEqual(headers["ig-u-rur"], "rur-token")
+        self.assertEqual(headers["x-mid"], "mid-token")
+
+    def test_video_rupload_delegates_base_headers_to_helper(self):
+        client = self.build_client()
+        session = self.fake_rupload_session(media_id=987654321)
+
+        with (
+            mock.patch("requests.Session", return_value=session),
+            mock.patch.object(
+                client, "_messenger_rupload_headers", return_value={"authorization": "Bearer token"}
+            ) as headers,
+        ):
+            media_id = client._video_rupload(b"video-bytes", "entity-name", "waterfall-id")
+
+        self.assertEqual(media_id, 987654321)
+        headers.assert_called_once_with(
+            {
+                "video_type": "FILE_ATTACHMENT",
+                "segment-start-offset": "0",
+                "segment-type": "3",
+                "ephemeral_media_view_mode": "2",
+                "ig_raven_metadata": "{}",
+                "x_fb_video_waterfall_id": "waterfall-id",
+            }
+        )
+
+    def test_voice_rupload_delegates_base_headers_to_helper(self):
+        client = self.build_client()
+        session = self.fake_rupload_session(media_id=987654321)
+
+        with (
+            mock.patch("requests.Session", return_value=session),
+            mock.patch.object(
+                client, "_messenger_rupload_headers", return_value={"authorization": "Bearer token"}
+            ) as headers,
+        ):
+            media_id = client._voice_rupload(b"voice-bytes", "1234567", -99)
+
+        self.assertEqual(media_id, 987654321)
+        headers.assert_called_once_with({"audio_type": "FILE_ATTACHMENT"})

--- a/tests/regression/test_fbsearch.py
+++ b/tests/regression/test_fbsearch.py
@@ -99,3 +99,101 @@ class FbSearchRegressionTestCase(unittest.TestCase):
             users = client.fbsearch_typehead("ali")
 
         self.assertEqual(users, [])
+
+    def test_web_search_topsearch_sends_expected_params(self):
+        client = self._build_client()
+        expected = {"hashtags": []}
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.web_search_topsearch("alice")
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "web/search/topsearch/",
+            params={
+                "search_surface": "web_top_search",
+                "context": "blended",
+                "include_reel": "true",
+                "query": "alice",
+            },
+        )
+
+    def test_web_search_topsearch_hashtags_extracts_hashtags(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client,
+            "web_search_topsearch",
+            return_value={"hashtags": [{"hashtag": {"id": "1", "name": "python", "media_count": 10}}]},
+        ):
+            hashtags = client.web_search_topsearch_hashtags("python")
+
+        self.assertEqual([hashtag.name for hashtag in hashtags], ["python"])
+
+    def test_fbsearch_item_forwards_optional_cursors(self):
+        client = self._build_client()
+        with mock.patch.object(client, "private_request", return_value={"items": []}) as private_request:
+            result = client.fbsearch_item(
+                "clips_serp_page",
+                "clips_serp_page",
+                "#dance",
+                timezone_offset=10800,
+                count=12,
+                reels_page_index=2,
+                has_more_reels="true",
+                reels_max_id="reels-cursor",
+                next_max_id="next-cursor",
+                rank_token="rank-token",
+                page_index=3,
+                page_token="page-token",
+                paging_token="paging-token",
+            )
+
+        self.assertEqual(result, {"items": []})
+        private_request.assert_called_once_with(
+            "fbsearch/clips_serp_page/",
+            params={
+                "search_surface": "clips_serp_page",
+                "query": "#dance",
+                "timezone_offset": 10800,
+                "count": 12,
+                "reels_page_index": 2,
+                "has_more_reels": "true",
+                "reels_max_id": "reels-cursor",
+                "next_max_id": "next-cursor",
+                "rank_token": "rank-token",
+                "page_index": 3,
+                "page_token": "page-token",
+                "paging_token": "paging-token",
+            },
+        )
+
+    def test_fbsearch_keyword_typeahead_sends_blended_context(self):
+        client = self._build_client()
+        with mock.patch.object(client, "private_request", return_value={"keywords": []}) as private_request:
+            client.fbsearch_keyword_typeahead("ali", timezone_offset=10800, count=5)
+
+        private_request.assert_called_once_with(
+            "fbsearch/keyword_typeahead/",
+            params={
+                "search_surface": "typeahead_search_page",
+                "query": "ali",
+                "context": "blended",
+                "timezone_offset": 10800,
+                "count": 5,
+            },
+        )
+
+    def test_fbsearch_typeahead_stream_sends_blended_context(self):
+        client = self._build_client()
+        with mock.patch.object(client, "private_request", return_value={"stream_rows": []}) as private_request:
+            client.fbsearch_typeahead_stream("ali", timezone_offset=10800, count=5)
+
+        private_request.assert_called_once_with(
+            "fbsearch/typeahead_stream/",
+            params={
+                "search_surface": "typeahead_search_page",
+                "query": "ali",
+                "context": "blended",
+                "timezone_offset": 10800,
+                "count": 5,
+            },
+        )

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -248,3 +248,69 @@ class UserMediasGraphQLRegressionTestCase(unittest.TestCase):
         self.assertEqual(end_cursor, "next-page")
         self.assertEqual([media.pk for media in medias], ["1"])
         self.assertEqual(medias[0].id, "1_2")
+
+    def test_aiograpi_chunk_aliases_delegate_to_paginated_helpers(self):
+        client = Client()
+        with mock.patch.object(client, "user_medias_paginated_gql", return_value=(["gql"], "gql-next")) as gql:
+            self.assertEqual(
+                client.user_medias_chunk_gql("123", sleep=1, end_cursor="cursor", amount=7), (["gql"], "gql-next")
+            )
+        gql.assert_called_once_with("123", amount=7, sleep=1, end_cursor="cursor")
+
+        with mock.patch.object(client, "user_medias_paginated_v1", return_value=(["v1"], "v1-next")) as medias_v1:
+            self.assertEqual(client.user_medias_chunk_v1("123", end_cursor="cursor"), (["v1"], "v1-next"))
+        medias_v1.assert_called_once_with("123", amount=33, end_cursor="cursor")
+
+        with mock.patch.object(client, "user_videos_paginated_v1", return_value=(["video"], "video-next")) as videos_v1:
+            self.assertEqual(client.user_videos_chunk_v1("123", end_cursor="cursor"), (["video"], "video-next"))
+        videos_v1.assert_called_once_with("123", amount=50, end_cursor="cursor")
+
+        with mock.patch.object(client, "user_clips_paginated_v1", return_value=(["clip"], "clip-next")) as clips_v1:
+            self.assertEqual(client.user_clips_chunk_v1("123", end_cursor="cursor"), (["clip"], "clip-next"))
+        clips_v1.assert_called_once_with("123", amount=50, end_cursor="cursor")
+
+        with mock.patch.object(client, "usertag_medias_paginated_v1", return_value=(["tag"], "tag-next")) as tags_v1:
+            self.assertEqual(client.usertag_medias_v1_chunk("123", max_id="cursor"), (["tag"], "tag-next"))
+        tags_v1.assert_called_once_with("123", amount=0, end_cursor="cursor")
+
+    def test_user_medias_chunk_delegates_to_paginated(self):
+        client = Client()
+        with mock.patch.object(client, "user_medias_paginated", return_value=(["media"], "next")) as paginated:
+            result = client.user_medias_chunk("123", end_cursor="cursor")
+
+        self.assertEqual(result, (["media"], "next"))
+        paginated.assert_called_once_with("123", amount=0, end_cursor="cursor")
+
+    def test_media_likers_gql_chunk_posts_doc_id_query(self):
+        client = Client()
+        client._fb_dtsg = "token"
+        with mock.patch.object(
+            client,
+            "graphql_request",
+            return_value={
+                "data": {"xdt_api__v1__likes__media_id__likers": {"users": [{"id": "1", "username": "alice"}]}}
+            },
+        ) as graphql_request:
+            users = client.media_likers_gql_chunk("123")
+
+        self.assertEqual(users, [{"id": "1", "username": "alice"}])
+        data = graphql_request.call_args.kwargs["data"]
+        self.assertEqual(data["doc_id"], "24452425501069647")
+        self.assertIn('"id":"123"', data["variables"])
+
+    def test_media_template_v1_posts_template_media_id(self):
+        client = Client()
+        client.uuid = "uuid"
+        expected = {"template": {"media_id": "123_456"}}
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.media_template_v1("123_456")
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "clips/template/",
+            data={
+                "should_show_friends_media_at_top": "false",
+                "template_clips_media_id": "123_456",
+                "_uuid": "uuid",
+            },
+        )

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -10,3 +10,38 @@ class PasswordEncryptionRegressionTestCase(unittest.TestCase):
         self.assertEqual(parts[1], "4")
         self.assertTrue(int(parts[2]) > 1607612345)
         self.assertTrue(len(parts[3]) == 392)
+
+
+class SignupHelperRegressionTestCase(unittest.TestCase):
+    def test_check_username_posts_uuid_payload(self):
+        client = Client()
+        client.uuid = "uuid"
+        with mock.patch.object(client, "private_request", return_value={"available": True}) as private_request:
+            result = client.check_username("example")
+
+        self.assertEqual(result, {"available": True})
+        private_request.assert_called_once_with(
+            "users/check_username/",
+            data={"username": "example", "_uuid": "uuid"},
+        )
+
+    def test_check_phone_number_posts_signup_payload(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        with mock.patch.object(client, "private_request", return_value={"valid": True}) as private_request:
+            result = client.check_phone_number("+15551234567")
+
+        self.assertEqual(result, {"valid": True})
+        private_request.assert_called_once_with(
+            "accounts/check_phone_number/",
+            data={
+                "phone_id": "phone-id",
+                "login_nonce_map": "{}",
+                "phone_number": "+15551234567",
+                "guid": "uuid",
+                "device_id": "android-id",
+                "prefill_shown": "False",
+            },
+        )

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -481,6 +481,128 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             with self.assertRaises(UserNotFound):
                 client.user_web_profile_info_v1("missing")
 
+    def test_user_info_by_username_a1_requests_full_public_payload(self):
+        client = Client()
+        expected = {"graphql": {"user": {"id": "1"}}}
+        with mock.patch.object(client, "public_a1_request", return_value=expected) as public_a1_request:
+            result = client.user_info_by_username_a1("Example")
+
+        self.assertEqual(result, expected)
+        public_a1_request.assert_called_once_with("/example/", full=True)
+
+    def test_user_info_v2_gql_uses_profile_doc_id(self):
+        client = Client()
+        payload = self.build_web_profile_user(id="25025320")["data"]["user"]
+        payload["pk"] = payload["id"]
+        payload["media_count"] = 0
+        payload["follower_count"] = 0
+        payload["following_count"] = 0
+        payload["profile_pic_url"] = "https://example.com/pic.jpg"
+
+        with mock.patch.object(client, "_inject_sessionid_for_v2_gql") as inject:
+            with mock.patch.object(client, "public_doc_id_graphql_request", return_value={"user": payload}) as gql:
+                user = client.user_info_v2_gql("25025320")
+
+        inject.assert_called_once_with()
+        gql.assert_called_once()
+        self.assertEqual(gql.call_args.args[0], "25980296051578533")
+        self.assertEqual(gql.call_args.args[1]["id"], "25025320")
+        self.assertEqual(user.pk, "25025320")
+
+    def test_user_info_by_username_v2_gql_resolves_username_then_profile(self):
+        client = Client()
+        with mock.patch.object(client, "_inject_sessionid_for_v2_gql"):
+            with mock.patch.object(
+                client,
+                "public_doc_id_graphql_request",
+                return_value={
+                    "xdt_api__v1__fbsearch__non_profiled_serp": {"users": [{"username": "example", "pk": "123"}]}
+                },
+            ) as search:
+                with mock.patch.object(client, "user_info_v2_gql", return_value="user") as profile:
+                    result = client.user_info_by_username_v2_gql("Example")
+
+        self.assertEqual(result, "user")
+        search.assert_called_once_with("26347858941511777", {"hasQuery": True, "query": "example"})
+        profile.assert_called_once_with("123")
+
+    def test_user_about_v1_calls_bloks_action_and_extracts_last_json(self):
+        client = self.build_private_client()
+        client.bloks_versioning_id = "bloks"
+        client.last_json = {"layout": {"bloks_payload": {"data": []}}}
+        expected = object()
+        with mock.patch.object(client, "bloks_action", return_value={}) as bloks_action:
+            with mock.patch("instagrapi.mixins.user.extract_about_v1", return_value=expected) as extract:
+                result = client.user_about_v1("123")
+
+        self.assertIs(result, expected)
+        bloks_action.assert_called_once()
+        self.assertEqual(bloks_action.call_args.args[0], "com.instagram.interactions.about_this_account")
+        self.assertEqual(bloks_action.call_args.args[1]["target_user_id"], "123")
+        extract.assert_called_once_with(client.last_json)
+
+    def test_user_guides_v1_extracts_guides(self):
+        client = Client()
+        with mock.patch.object(client, "private_request", return_value={"guides": [{"summary": {"id": "1"}}]}) as req:
+            with mock.patch("instagrapi.mixins.user.extract_guide_v1", side_effect=lambda item: item["summary"]):
+                guides = client.user_guides_v1("123")
+
+        self.assertEqual(guides, [{"id": "1"}])
+        req.assert_called_once_with("guides/user/123/")
+
+    def test_feed_user_stream_item_posts_uuid_payload(self):
+        client = Client()
+        client.uuid = "uuid"
+        with mock.patch.object(client, "private_request", return_value={"stream_rows": []}) as private_request:
+            client.feed_user_stream_item("123", is_pull_to_refresh=True)
+
+        private_request.assert_called_once_with(
+            "feed/user_stream/123/",
+            data={"_uuid": "uuid", "is_pull_to_refresh": "true"},
+        )
+
+    def test_private_graphql_followers_list_builds_query_wrapper(self):
+        client = Client()
+        with mock.patch.object(client, "private_graphql_query_request", return_value={"data": {}}) as query:
+            client.private_graphql_followers_list("123", "rank", max_id=10, priority="u=3, i")
+
+        query.assert_called_once()
+        self.assertEqual(query.call_args.kwargs["friendly_name"], "FollowersList")
+        self.assertEqual(query.call_args.kwargs["root_field_name"], "xdt_api__v1__friendships__followers")
+        self.assertEqual(query.call_args.kwargs["variables"]["user_id"], "123")
+        self.assertEqual(query.call_args.kwargs["variables"]["max_id"], 10)
+        self.assertEqual(query.call_args.kwargs["priority"], "u=3, i")
+
+    def test_private_graphql_following_list_builds_query_wrapper(self):
+        client = Client()
+        with mock.patch.object(client, "private_graphql_query_request", return_value={"data": {}}) as query:
+            client.private_graphql_following_list("123", "rank")
+
+        self.assertEqual(query.call_args.kwargs["friendly_name"], "FollowingList")
+        self.assertEqual(query.call_args.kwargs["root_field_name"], "xdt_api__v1__friendships__following")
+        self.assertEqual(query.call_args.kwargs["variables"]["user_id"], "123")
+
+    def test_private_graphql_clips_profile_builds_query_wrapper(self):
+        client = Client()
+        with mock.patch.object(client, "private_graphql_query_request", return_value={"data": {}}) as query:
+            client.private_graphql_clips_profile("123", page_size=9, no_of_medias_in_each_chunk=3)
+
+        variables = query.call_args.kwargs["variables"]
+        self.assertEqual(query.call_args.kwargs["friendly_name"], "ClipsProfileQuery")
+        self.assertEqual(variables["data"]["target_user_id"], "123")
+        self.assertEqual(variables["data"]["page_size"], 9)
+        self.assertEqual(variables["data"]["no_of_medias_in_each_chunk"], 3)
+
+    def test_private_graphql_inbox_tray_for_user_builds_query_wrapper(self):
+        client = Client()
+        with mock.patch.object(client, "private_graphql_query_request", return_value={"data": {}}) as query:
+            client.private_graphql_inbox_tray_for_user("123", priority="u=3, i")
+
+        self.assertEqual(query.call_args.kwargs["friendly_name"], "InboxTrayRequestForUserQuery")
+        self.assertEqual(query.call_args.kwargs["root_field_name"], "xdt_get_inbox_tray_items")
+        self.assertEqual(query.call_args.kwargs["variables"]["user_id"], "123")
+        self.assertEqual(query.call_args.kwargs["priority"], "u=3, i")
+
     def test_discover_recommended_accounts_extracts_category_id_from_stream(self):
         client = Client()
         stream_resp = {


### PR DESCRIPTION
## Summary
- Sync the remaining non-Facebook and non-SMS public helper surface from aiograpi into instagrapi.
- Add sync helpers for GraphQL request flows, search wrappers, comment GraphQL/v1 helpers, media chunk aliases/likers/template, user about/guides/feed/private GraphQL helpers, and signup username/phone checks.
- Deduplicate Direct messenger rupload header construction for video and voice attachment uploads.
- Document the newly exposed helpers and cover their request payloads with regression tests.

## Notes
- `send_signup_sms_code` is intentionally deferred from instagrapi for the current SMS scope.
- `clip_share_to_fb_extra_data` remains intentionally deferred from aiograpi for the current Facebook-linked account scope.
- Endpoint parity audit excluding transport-only helpers and the two deferred surfaces: 586/586 public functions with no remaining gaps.

## Verification
- `.venv/bin/python -m pytest -q tests/regression` -> 265 passed, 1 warning, 3 subtests passed
- `.venv/bin/ruff check .` -> passed
- `.venv/bin/ruff format --check .` -> passed
- `.venv/bin/mkdocs build --strict` -> passed with the existing Material for MkDocs advisory
- `.venv/bin/bandit -c pyproject.toml -r instagrapi` -> no issues identified
- `uv build --out-dir /tmp/instagrapi-uv-build` -> built sdist and wheel