### PR TITLE
Fix timeline feed pagination telemetry

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -499,10 +499,14 @@ Reels:
 Timeline helpers:
 
 ```python
+>>> first_page = cl.get_timeline_feed("cold_start_fetch")
+>>> second_page = cl.get_timeline_feed(max_id=first_page["next_max_id"])
 >>> cl.reels(amount=10)
 >>> cl.explore_reels(amount=10)
 >>> cl.friends_reels(amount=10)
 ```
+
+`get_timeline_feed()` remembers media ids from the previous response and sends `seen_posts` plus minimal `feed_view_info` when `max_id` is used. For stateless pagination, pass `seen_posts=...` and `feed_view_info=...` explicitly.
 
 ```python
 >>> clips = cl.user_clips_v1(25025320, amount=2)

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Union
+from typing import Any, Dict, Iterable, List, Union
 from uuid import uuid4
 
 import requests
@@ -188,7 +188,82 @@ class PostLoginFlowMixin:
         check_flow.append(self.get_timeline_feed(["cold_start_fetch"]))
         return all(check_flow)
 
-    def get_timeline_feed(self, reason: TIMELINE_FEED_REASON = "pull_to_refresh", max_id: str = None) -> Dict:
+    @staticmethod
+    def _timeline_media_id(media: Dict) -> str:
+        media_id = media.get("id") or media.get("media_id")
+        if media_id:
+            return str(media_id)
+
+        pk = media.get("pk")
+        user = media.get("user") or {}
+        user_pk = user.get("pk") or media.get("user_id") or media.get("owner_id")
+        if pk and user_pk:
+            return f"{pk}_{user_pk}"
+        if pk:
+            return str(pk)
+        return ""
+
+    def _timeline_seen_posts_from_response(self, response: Dict) -> List[str]:
+        media_ids = []
+        for item in response.get("feed_items") or []:
+            if not isinstance(item, dict):
+                continue
+            media = item.get("media_or_ad") or item.get("media")
+            if not isinstance(media, dict):
+                continue
+            media_id = self._timeline_media_id(media)
+            if media_id:
+                media_ids.append(media_id)
+        return media_ids
+
+    def _remember_timeline_seen_posts(self, response: Dict) -> None:
+        remembered = list(getattr(self, "_timeline_seen_posts", []))
+        known = set(remembered)
+        for media_id in self._timeline_seen_posts_from_response(response):
+            if media_id in known:
+                continue
+            remembered.append(media_id)
+            known.add(media_id)
+        self._timeline_seen_posts = remembered[-200:]
+
+    @staticmethod
+    def _join_timeline_seen_posts(seen_posts: Union[str, Iterable[str], None]) -> str:
+        if not seen_posts:
+            return ""
+        if isinstance(seen_posts, str):
+            return seen_posts
+        return ",".join(str(media_id) for media_id in seen_posts if media_id)
+
+    @staticmethod
+    def _timeline_feed_view_info(media_ids: Iterable[str]) -> List[Dict]:
+        latest_timestamp = int(time.time() * 1000)
+        return [
+            {
+                "media_id": str(media_id),
+                "version": 24,
+                "media_pct": 1.0,
+                "time_info": {"10": 1, "25": 1, "50": 1, "75": 1},
+                "latest_timestamp": latest_timestamp,
+            }
+            for media_id in media_ids
+        ]
+
+    def _timeline_feed_view_info_json(self, feed_view_info: Union[str, List[Dict], None], seen_posts: str) -> str:
+        if feed_view_info is not None:
+            if isinstance(feed_view_info, str):
+                return feed_view_info
+            return json.dumps(feed_view_info)
+        if not seen_posts:
+            return "[]"
+        return json.dumps(self._timeline_feed_view_info(seen_posts.split(",")))
+
+    def get_timeline_feed(
+        self,
+        reason: TIMELINE_FEED_REASON = "pull_to_refresh",
+        max_id: str = None,
+        seen_posts: Union[str, Iterable[str], None] = None,
+        feed_view_info: Union[str, List[Dict[str, Any]], None] = None,
+    ) -> Dict:
         """
         Get your timeline feed
 
@@ -198,6 +273,12 @@ class PostLoginFlowMixin:
             Reason to refresh the feed (cold_start_fetch, paginating, pull_to_refresh); Default "pull_to_refresh"
         max_id: str, optional
             Cursor for the next feed chunk (next cursor can be found in response["next_max_id"])
+        seen_posts: str or iterable, optional
+            Media ids already rendered by the caller. When omitted during pagination,
+            ids from previous get_timeline_feed() responses are reused.
+        feed_view_info: str or list, optional
+            JSON-serializable view telemetry. When omitted during pagination, a
+            minimal view telemetry payload is generated from seen_posts.
 
         Returns
         -------
@@ -236,11 +317,21 @@ class PostLoginFlowMixin:
         if max_id:
             data["max_id"] = max_id
             data["reason"] = "pagination"
+            if seen_posts is None:
+                seen_posts = getattr(self, "_timeline_seen_posts", [])
+
+        seen_posts_value = self._join_timeline_seen_posts(seen_posts)
+        if seen_posts_value:
+            data["seen_posts"] = seen_posts_value
+        data["feed_view_info"] = self._timeline_feed_view_info_json(feed_view_info, seen_posts_value)
+
         # if "push_disabled" in options:
         #     data["push_disabled"] = "true"
         # if "recovered_from_crash" in options:
         #     data["recovered_from_crash"] = "1"
-        return self.private_request("feed/timeline/", json.dumps(data), with_signature=False, headers=headers)
+        result = self.private_request("feed/timeline/", json.dumps(data), with_signature=False, headers=headers)
+        self._remember_timeline_seen_posts(result)
+        return result
 
     def get_reels_tray_feed(self, reason: REELS_TRAY_REASON = "pull_to_refresh") -> Dict:
         """

--- a/tests/live/test_timeline.py
+++ b/tests/live/test_timeline.py
@@ -3,6 +3,16 @@ from tests.helpers import *
 
 
 class ClientTimelineLiveTestCase(_helpers.ClientPrivateTestCase):
+    @staticmethod
+    def _feed_media_ids(result):
+        media_ids = []
+        for item in result.get("feed_items") or []:
+            media = item.get("media_or_ad") or item.get("media") or {}
+            media_id = media.get("id")
+            if media_id:
+                media_ids.append(str(media_id))
+        return media_ids
+
     def test_friends_reels_live_endpoint(self):
         result = self.cl.private_request(
             "clips/discover/social/",
@@ -20,3 +30,31 @@ class ClientTimelineLiveTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(medias, list)
         for media in medias:
             self.assertIsInstance(media, Media)
+
+    def test_get_timeline_feed_live_paginates_with_seen_posts(self):
+        calls = []
+        private_request = self.cl.private_request
+
+        def recording_private_request(endpoint, data=None, *args, **kwargs):
+            if endpoint == "feed/timeline/":
+                calls.append(data)
+            return private_request(endpoint, data, *args, **kwargs)
+
+        self.cl.private_request = recording_private_request
+        try:
+            first_page = self.cl.get_timeline_feed("cold_start_fetch")
+            next_max_id = first_page.get("next_max_id")
+            if not next_max_id:
+                self.skipTest("Timeline feed did not return next_max_id")
+            seen_posts = self._feed_media_ids(first_page) or ["0_0"]
+            second_page = self.cl.get_timeline_feed(max_id=next_max_id, seen_posts=seen_posts)
+        finally:
+            self.cl.private_request = private_request
+
+        self.assertEqual(second_page.get("status"), "ok")
+        self.assertGreaterEqual(len(calls), 2)
+        second_payload = json.loads(calls[1])
+        self.assertEqual(second_payload["reason"], "pagination")
+        self.assertEqual(second_payload["max_id"], next_max_id)
+        self.assertEqual(second_payload["seen_posts"], ",".join(seen_posts))
+        self.assertNotEqual(second_payload["feed_view_info"], "[]")

--- a/tests/regression/test_timeline.py
+++ b/tests/regression/test_timeline.py
@@ -93,3 +93,31 @@ class TimelineRegressionTestCase(unittest.TestCase):
         self.assertEqual(private_request.args[0], "clips/discover/social/")
         self.assertEqual(private_request.kwargs["data"], " ")
         self.assertEqual(private_request.kwargs["params"]["max_id"], "")
+
+    def test_get_timeline_feed_sends_seen_posts_when_paginating(self):
+        client = Client()
+        client.private_request = Mock(
+            side_effect=[
+                {
+                    "feed_items": [
+                        {"media_or_ad": {"id": "111_1"}},
+                        {"media_or_ad": {"pk": "222", "user": {"pk": "1"}}},
+                    ],
+                    "next_max_id": "next-page",
+                },
+                {"feed_items": []},
+            ]
+        )
+
+        client.get_timeline_feed("cold_start_fetch")
+        client.get_timeline_feed("pull_to_refresh", max_id="next-page")
+
+        first_data = json.loads(client.private_request.call_args_list[0].args[1])
+        second_data = json.loads(client.private_request.call_args_list[1].args[1])
+        self.assertEqual(first_data["feed_view_info"], "[]")
+        self.assertNotIn("seen_posts", first_data)
+        self.assertEqual(second_data["reason"], "pagination")
+        self.assertEqual(second_data["max_id"], "next-page")
+        self.assertEqual(second_data["seen_posts"], "111_1,222_1")
+        feed_view_info = json.loads(second_data["feed_view_info"])
+        self.assertEqual([item["media_id"] for item in feed_view_info], ["111_1", "222_1"])


### PR DESCRIPTION
## Summary
- remember timeline feed media ids from previous `get_timeline_feed()` responses
- send `seen_posts` and generated `feed_view_info` when paginating with `max_id`
- allow explicit `seen_posts` / `feed_view_info` for stateless callers
- document the timeline pagination pattern and add regression + live coverage

Fixes #1789

## Verification
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mkdocs build --strict`
- `.venv/bin/bandit -c pyproject.toml -r instagrapi`
- authenticated live: `python -m pytest -q -rs tests/live/test_timeline.py::ClientTimelineLiveTestCase::test_get_timeline_feed_live_paginates_with_seen_posts -s`
