### PR TITLE
Add optional curl public transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Support **Python 3.10+**
 pip install instagrapi
 ```
 
+Optional public web TLS impersonation support is available as an extra:
+
+```bash
+pip install "instagrapi[curl]"
+```
+
+Use it only for public web endpoints that are sensitive to browser TLS fingerprints:
+
+```python
+cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
+```
+
 If your project uses [uv](https://docs.astral.sh/uv/), you can add the package with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Use it only for public web endpoints that are sensitive to browser TLS fingerpri
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
+See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
+
 If your project uses [uv](https://docs.astral.sh/uv/), you can add the package with:
 
 ```bash

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -195,6 +195,7 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
 The default remains `public_transport="requests"`. Private mobile API requests still use the regular mobile session.
+See [Public Transport](public-transport.md) for live comparison results and caveats.
 
 ``` python
 cl = Client()

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -59,6 +59,8 @@ print(cl.user_info(cl.user_id))
 | public\_request\_retries\_timeout | Delay between `public_request()` retries
 | session\_retry\_total | Transport-level retry count for `public` and `private` sessions
 | session\_retry\_backoff\_factor | Backoff factor for transport-level retries
+| public\_transport | Public web transport: `requests` by default, or `curl` when `instagrapi[curl]` is installed
+| public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
 
 
 ### Login
@@ -106,7 +108,9 @@ settings = {
    "public_request_retries_timeout": 2,
    "session_retry_total": 3,
    "session_retry_backoff_factor": 2,
-   "session_retry_statuses": [429, 500, 502, 503, 504]
+   "session_retry_statuses": [429, 500, 502, 503, 504],
+   "public_transport": "requests",
+   "public_transport_impersonate": "chrome136"
 }
 
 cl = Client(settings)
@@ -177,6 +181,20 @@ cl.set_retry_config(
     session_retry_total=3,
 )
 ```
+
+For public web endpoints that are sensitive to browser TLS fingerprints, install the optional curl transport:
+
+```bash
+pip install "instagrapi[curl]"
+```
+
+Then opt in explicitly:
+
+```python
+cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
+```
+
+The default remains `public_transport="requests"`. Private mobile API requests still use the regular mobile session.
 
 ``` python
 cl = Client()

--- a/docs/usage-guide/public-transport.md
+++ b/docs/usage-guide/public-transport.md
@@ -1,0 +1,68 @@
+# Public Transport
+
+`instagrapi` uses two network surfaces:
+
+* private mobile API requests, used for authenticated mobile flows;
+* public web requests, used by helpers such as public profile and public media lookups.
+
+The default public web transport is `requests`. It has the smallest dependency footprint and keeps the existing
+transport-level retry behavior.
+
+For public web endpoints that are sensitive to browser TLS fingerprints, you can install the optional curl transport:
+
+```bash
+pip install "instagrapi[curl]"
+```
+
+Then opt in explicitly:
+
+```python
+from instagrapi import Client
+
+cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
+```
+
+Private mobile API requests still use the regular mobile session. The curl transport only changes the public web
+session.
+
+## Live Comparison
+
+This is a point-in-time live comparison from May 15, 2026. Instagram public web behavior changes frequently, so treat
+these numbers as a practical signal, not a guarantee.
+
+Method:
+
+* branch: curl public transport PR branch;
+* environment: fresh remote Linux clone with `instagrapi[curl]` installed;
+* Python: 3.12;
+* rounds: 4;
+* public request retry loop: disabled with `public_request_retries_count = 1`;
+* curl impersonation: `chrome136`;
+* identical inputs for both transports.
+
+| Public web helper | `requests` | `curl` |
+| --- | ---: | ---: |
+| `user_info_by_username_gql("instagram")` | 0/4 ok, p50 12.05s | 3/4 ok, p50 1.42s |
+| `user_info_by_username_gql("1fexd")` | 0/4 ok, p50 12.05s | 2/4 ok, p50 0.20s |
+| `media_pk_from_url("https://www.instagram.com/p/C_BM2yAN4Rm/")` | 4/4 ok, p50 0.00s | 4/4 ok, p50 0.00s |
+| `media_info_gql("3441088131388376166")` | 0/4 ok, p50 2.49s | 0/4 ok, p50 2.45s |
+| Total | 4/16 ok, p50 7.28s | 9/16 ok, p50 0.23s |
+
+Observed failures:
+
+* `requests` repeatedly hit `429` on `users/web_profile_info`;
+* `curl` avoided those `429` responses in early rounds, then hit `401` on the same public endpoint;
+* both transports hit `404` on the tested public media info path.
+
+## Recommendation
+
+Use the default `requests` transport unless you specifically need public web endpoints that are being rate limited or
+blocked by TLS fingerprint checks.
+
+Use `public_transport="curl"` when:
+
+* public profile web lookups return repeated `429` responses with the default transport;
+* you can install the optional native dependencies pulled by `instagrapi[curl]`;
+* you understand that public web access is still opportunistic and can return `401`, `403`, `404`, or `429`.
+
+Prefer authenticated private API helpers for production workflows when an equivalent private/mobile path exists.

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -456,6 +456,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 "session_retry_backoff_factor", self.session_retry_backoff_factor
             ),
             session_retry_statuses=self.settings.get("session_retry_statuses", self.session_retry_statuses),
+            public_transport=self.settings.get("public_transport"),
+            public_transport_impersonate=self.settings.get("public_transport_impersonate"),
         )
 
         self.set_timezone_offset(timezone_offset)
@@ -737,6 +739,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "session_retry_total": self.session_retry_total,
             "session_retry_backoff_factor": self.session_retry_backoff_factor,
             "session_retry_statuses": self.session_retry_statuses,
+            "public_transport": self.public_transport,
+            "public_transport_impersonate": self.public_transport_impersonate,
         }
 
     def set_settings(self, settings: Dict) -> bool:
@@ -800,6 +804,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         session_retry_total: int = None,
         session_retry_backoff_factor: Union[int, float] = None,
         session_retry_statuses: list = None,
+        public_transport: str = None,
+        public_transport_impersonate: str = None,
     ) -> bool:
         if request_timeout is not None:
             self.request_timeout = request_timeout
@@ -813,6 +819,15 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             self.session_retry_backoff_factor = session_retry_backoff_factor
         if session_retry_statuses is not None:
             self.session_retry_statuses = list(session_retry_statuses)
+        if public_transport is not None:
+            self.public_transport = self._normalize_public_transport(public_transport)
+        if public_transport_impersonate is not None:
+            self.public_transport_impersonate = public_transport_impersonate
+        if public_transport is not None or public_transport_impersonate is not None:
+            self.public_user_agent = self._default_public_user_agent(
+                self.public_transport, self.public_transport_impersonate
+            )
+            self.public.headers["User-Agent"] = self.public_user_agent
 
         self._configure_public_session_retry()
         self._configure_private_session_retry()
@@ -826,6 +841,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                     "session_retry_total": self.session_retry_total,
                     "session_retry_backoff_factor": self.session_retry_backoff_factor,
                     "session_retry_statuses": self.session_retry_statuses,
+                    "public_transport": self.public_transport,
+                    "public_transport_impersonate": self.public_transport_impersonate,
                 }
             )
         return True

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -3,9 +3,6 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
-from curl_adapter import CurlCffiAdapter
-from curl_cffi import BrowserType, BrowserTypeLiteral
-
 try:
     from simplejson.errors import JSONDecodeError
 except ImportError:
@@ -46,20 +43,36 @@ class PublicRequestMixin:
     session_retry_backoff_factor = 2
     session_retry_statuses = [429, 500, 502, 503, 504]
     last_response_ts = 0
-    public_browser_type: BrowserTypeLiteral = "chrome146"
-    user_agents: dict[BrowserTypeLiteral, str] = {
-        "chrome146": f"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+    public_transport = "requests"
+    public_transport_impersonate = "chrome136"
+    public_user_agent = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 "
+        "(KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
+    )
+    public_curl_user_agents = {
+        "chrome136": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
     }
-    public_user_agent = user_agents[public_browser_type]
     public_accept_language = "en-US"
 
     def __init__(self, *args, **kwargs):
         session = requests.Session()
         self.public = session
         self.public.verify = False  # fix SSLError/HTTPSConnectionPool
-        self.public_browser_type = kwargs.pop("browser_type", getattr(self, "browser_type", self.public_browser_type))
-        self.public_user_agent = kwargs.pop("public_user_agent", getattr(self, "public_user_agent", self.public_user_agent))
-        self.public_accept_language = kwargs.pop("public_accept_language", getattr(self, "public_accept_language", self.public_accept_language))
+        self.public_transport = self._normalize_public_transport(
+            kwargs.pop("public_transport", getattr(self, "public_transport", self.public_transport))
+        )
+        self.public_transport_impersonate = kwargs.pop(
+            "public_transport_impersonate",
+            getattr(self, "public_transport_impersonate", self.public_transport_impersonate),
+        )
+        self.public_user_agent = kwargs.pop(
+            "public_user_agent",
+            self._default_public_user_agent(self.public_transport, self.public_transport_impersonate),
+        )
+        self.public_accept_language = kwargs.pop(
+            "public_accept_language", getattr(self, "public_accept_language", self.public_accept_language)
+        )
         self.public.headers.update(
             {
                 "Connection": "Keep-Alive",
@@ -107,6 +120,19 @@ class PublicRequestMixin:
         self._configure_public_session_retry()
         super().__init__(*args, **kwargs)
 
+    @classmethod
+    def _normalize_public_transport(cls, public_transport: str) -> str:
+        public_transport = public_transport or "requests"
+        if public_transport not in {"requests", "curl"}:
+            raise ValueError("public_transport must be 'requests' or 'curl'")
+        return public_transport
+
+    @classmethod
+    def _default_public_user_agent(cls, public_transport: str, impersonate: str) -> str:
+        if public_transport == "curl":
+            return cls.public_curl_user_agents.get(impersonate, cls.public_curl_user_agents["chrome136"])
+        return cls.public_user_agent
+
     def _build_public_session_retry_strategy(self):
         try:
             return Retry(
@@ -124,8 +150,16 @@ class PublicRequestMixin:
             )
 
     def _configure_public_session_retry(self):
-        # adapter = HTTPAdapter(max_retries=self._build_public_session_retry_strategy())
-        adapter = CurlCffiAdapter(impersonate_browser_type=self.public_browser_type)
+        if self.public_transport == "curl":
+            try:
+                from curl_adapter import CurlCffiAdapter
+            except ImportError as exc:
+                raise RuntimeError(
+                    "curl public transport requires the optional curl extra: pip install instagrapi[curl]"
+                ) from exc
+            adapter = CurlCffiAdapter(impersonate_browser_type=self.public_transport_impersonate)
+        else:
+            adapter = HTTPAdapter(max_retries=self._build_public_session_retry_strategy())
         self.public.mount("https://", adapter)
         self.public.mount("http://", adapter)
 

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -3,6 +3,9 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
+from curl_adapter import CurlCffiAdapter
+from curl_cffi import BrowserType, BrowserTypeLiteral
+
 try:
     from simplejson.errors import JSONDecodeError
 except ImportError:
@@ -43,21 +46,27 @@ class PublicRequestMixin:
     session_retry_backoff_factor = 2
     session_retry_statuses = [429, 500, 502, 503, 504]
     last_response_ts = 0
+    public_browser_type: BrowserTypeLiteral = "chrome146"
+    user_agents: dict[BrowserTypeLiteral, str] = {
+        "chrome146": f"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+    }
+    public_user_agent = user_agents[public_browser_type]
+    public_accept_language = "en-US"
 
     def __init__(self, *args, **kwargs):
         session = requests.Session()
         self.public = session
         self.public.verify = False  # fix SSLError/HTTPSConnectionPool
+        self.public_browser_type = kwargs.pop("browser_type", getattr(self, "browser_type", self.public_browser_type))
+        self.public_user_agent = kwargs.pop("public_user_agent", getattr(self, "public_user_agent", self.public_user_agent))
+        self.public_accept_language = kwargs.pop("public_accept_language", getattr(self, "public_accept_language", self.public_accept_language))
         self.public.headers.update(
             {
                 "Connection": "Keep-Alive",
                 "Accept": "*/*",
                 "Accept-Encoding": "gzip,deflate",
-                "Accept-Language": "en-US",
-                "User-Agent": (
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 "
-                    "(KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
-                ),
+                "Accept-Language": self.public_accept_language,
+                "User-Agent": self.public_user_agent,
             }
         )
         self.request_timeout = kwargs.pop("request_timeout", getattr(self, "request_timeout", self.request_timeout))
@@ -115,7 +124,8 @@ class PublicRequestMixin:
             )
 
     def _configure_public_session_retry(self):
-        adapter = HTTPAdapter(max_retries=self._build_public_session_retry_strategy())
+        # adapter = HTTPAdapter(max_retries=self._build_public_session_retry_strategy())
+        adapter = CurlCffiAdapter(impersonate_browser_type=self.public_browser_type)
         self.public.mount("https://", adapter)
         self.public.mount("http://", adapter)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
     - Media: usage-guide/media.md
     - Notes: usage-guide/notes.md
     - Pydroid and ffmpeg: usage-guide/pydroid.md
+    - Public Transport: usage-guide/public-transport.md
     - Search: usage-guide/search.md
     - Story: usage-guide/story.md
     - Track: usage-guide/track.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
     "pydantic==2.13.4",
     "moviepy==1.0.3",
     "pycryptodomex==3.23.0",
-    "curl-adapter>=1.2.1",
 ]
 
 [project.urls]
@@ -67,6 +66,9 @@ Issues = "https://github.com/subzeroid/instagrapi/issues"
 Guides = "https://instagrapi.com/guides/"
 
 [project.optional-dependencies]
+curl = [
+    "curl-adapter>=1.2.1",
+]
 test = [
     "Pillow==12.2.0",
     "bandit==1.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "pydantic==2.13.4",
     "moviepy==1.0.3",
     "pycryptodomex==3.23.0",
+    "curl-adapter>=1.2.1",
 ]
 
 [project.urls]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,7 +24,7 @@ from tests.live.test_media import (
     ClientMediaTestCase,
 )
 from tests.live.test_notes import ClientNoteLiveTestCase
-from tests.live.test_public import ClientPublicTestCase
+from tests.live.test_public import ClientPublicTestCase, PublicTransportLiveTestCase
 from tests.live.test_share import ClientShareTestCase
 from tests.live.test_signup import SignUpTestCase
 from tests.live.test_story import ClientStoryTestCase

--- a/tests/live/test_public.py
+++ b/tests/live/test_public.py
@@ -2,6 +2,21 @@ from tests import helpers as _helpers
 from tests.helpers import *
 
 
+class PublicTransportLiveTestCase(unittest.TestCase):
+    def test_curl_public_transport_user_info_by_username_gql(self):
+        try:
+            import curl_adapter  # noqa: F401
+        except ImportError:
+            self.skipTest("instagrapi[curl] is required for curl public transport live tests")
+
+        cl = Client(public_transport="curl", request_timeout=0, public_request_retries_count=2)
+        user = cl.user_info_by_username_gql("instagram")
+
+        self.assertIsInstance(user, User)
+        self.assertEqual(user.pk, "25025320")
+        self.assertEqual(user.username, "instagram")
+
+
 class ClientPublicTestCase(_helpers.ClientPrivateTestCase):
     cl = None
 

--- a/tests/regression/test_public_transport.py
+++ b/tests/regression/test_public_transport.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+from instagrapi import Client
+
+
+def test_default_public_transport_does_not_require_curl_adapter():
+    assert Client().public_transport == "requests"
+
+
+def test_public_user_agent_override_is_preserved():
+    client = Client(public_user_agent="custom-public-agent")
+
+    assert client.public.headers["User-Agent"] == "custom-public-agent"
+
+
+def test_curl_adapter_is_optional_extra():
+    pyproject = Path("pyproject.toml").read_text()
+    required_dependencies = pyproject.split("[project.optional-dependencies]", 1)[0]
+    optional_dependencies = pyproject.split("[project.optional-dependencies]", 1)[1]
+
+    assert "curl-adapter" not in required_dependencies
+    assert "curl = [" in optional_dependencies
+    assert '"curl-adapter>=1.2.1"' in optional_dependencies
+
+
+def test_curl_public_transport_uses_optional_adapter():
+    adapter = mock.Mock()
+    adapter_cls = mock.Mock(return_value=adapter)
+    with mock.patch.dict(sys.modules, {"curl_adapter": mock.Mock(CurlCffiAdapter=adapter_cls)}):
+        client = Client(public_transport="curl", public_transport_impersonate="chrome136")
+
+    assert client.public_transport == "curl"
+    assert client.public_transport_impersonate == "chrome136"
+    adapter_cls.assert_any_call(impersonate_browser_type="chrome136")
+    assert client.public.adapters["https://"] is adapter
+    assert client.public.adapters["http://"] is adapter
+
+
+def test_curl_public_transport_missing_extra_has_clear_error():
+    with mock.patch.dict(sys.modules, {"curl_adapter": None}):
+        try:
+            Client(public_transport="curl")
+        except RuntimeError as exc:
+            assert "pip install instagrapi[curl]" in str(exc)
+        else:
+            raise AssertionError("Expected RuntimeError when curl extra is not installed")
+
+
+def test_public_transport_settings_roundtrip():
+    adapter_cls = mock.Mock(return_value=mock.Mock())
+    with mock.patch.dict(sys.modules, {"curl_adapter": mock.Mock(CurlCffiAdapter=adapter_cls)}):
+        client = Client(public_transport="curl", public_transport_impersonate="chrome136")
+        settings = client.get_settings()
+
+        assert settings["public_transport"] == "curl"
+        assert settings["public_transport_impersonate"] == "chrome136"
+
+        restored = Client(settings=settings)
+
+    assert restored.public_transport == "curl"
+    assert restored.public_transport_impersonate == "chrome136"


### PR DESCRIPTION
## Summary
- builds on #2489 and keeps the original curl-impersonate PoC as an opt-in public transport
- moves curl-adapter into the optional `instagrapi[curl]` extra so default installs keep using requests
- persists `public_transport` / `public_transport_impersonate` in settings and documents README + usage guide
- adds regression coverage and a curl public transport live smoke test

## Tests
- RED before implementation: `PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/regression/test_public_transport.py` failed during collection with `ModuleNotFoundError: No module named 'curl_adapter'`
- `PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/regression/test_public_transport.py tests/regression/test_public.py tests/regression/test_user.py tests/regression/test_auth_story.py` -> 86 passed
- `PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/regression` -> 272 passed, 1 warning, 3 subtests passed
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/ruff check .` -> passed
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/ruff format --check .` -> passed
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/mkdocs build --strict` -> passed
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/bandit -c pyproject.toml -r instagrapi` -> no issues
- clean local optional-extra smoke: `uv venv /tmp/instagrapi-curl-venv --python 3.12 && uv pip install --python /tmp/instagrapi-curl-venv/bin/python -e '.[curl]' pytest==9.0.3 && PYTHONPATH=. /tmp/instagrapi-curl-venv/bin/python -m pytest -q -rs tests/live/test_public.py::PublicTransportLiveTestCase::test_curl_public_transport_user_info_by_username_gql -s` -> 1 passed
- live on remote test host from fresh clone of this branch with `.[curl]`: `tests/live/test_public.py::PublicTransportLiveTestCase::test_curl_public_transport_user_info_by_username_gql` -> 1 passed