### PR TITLE
Add public transport link to docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`Highlight`](usage-guide/highlight.md) - Highlights
   * [`Notes`](usage-guide/notes.md) - Notes
   * [`Pydroid and ffmpeg`](usage-guide/pydroid.md) - Android/Pydroid video upload setup
+  * [`Public Transport`](usage-guide/public-transport.md) - Optional curl transport for public web requests
   * [`Story`](usage-guide/story.md) - Story
   * [`StoryArchiveDay`](usage-guide/story.md) - Story archive day shell
   * [`StoryLink`](usage-guide/story.md) - Link sticker


### PR DESCRIPTION
## Summary
- add Public Transport to the docs homepage usage-guide list
- make the published curl transport guide discoverable from the docs index

## Tests
- `mkdocs build --strict`
- `git diff --check`