### PR TITLE
Add runnable examples cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ user_id = cl.user_id_from_username(ACCOUNT_USERNAME)
 medias = cl.user_medias(user_id, 20)
 ```
 
+## Runnable Examples
+
+Practical scripts live in [examples/README.md](examples/README.md). They cover session login, public lookups, media
+downloads, feed uploads, Reels and Trial Reels, story uploads, Direct messages, proxies, challenge handling, and optional
+curl-backed public transport.
+
 ## Session Persistence
 
 ``` python

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,6 +39,7 @@ cl.login(USERNAME, PASSWORD)
 
 ## What's Next?
 
+* [Runnable examples](usage-guide/examples.md)
 * [Fundamentals](usage-guide/fundamentals.md)
 * [Interactions](usage-guide/interactions.md)
 * [Best Practices](usage-guide/best-practices.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,6 +109,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
 
 * [Getting Started](getting-started.md)
 * [Usage Guide](usage-guide/fundamentals.md)
+* [Runnable Examples](usage-guide/examples.md)
 * [Interactions](usage-guide/interactions.md)
   * [`Media`](usage-guide/media.md) - Publication (also called post): Photo, Video, Album, IGTV and Reels
   * [`Resource`](usage-guide/media.md) - Part of Media (for albums)

--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -1,0 +1,39 @@
+# Examples
+
+Runnable examples live in the repository:
+
+* [examples/README.md](https://github.com/subzeroid/instagrapi/blob/master/examples/README.md)
+* [examples directory](https://github.com/subzeroid/instagrapi/tree/master/examples)
+
+The examples read credentials and runtime options from environment variables instead of hard-coding secrets:
+
+```bash
+export IG_USERNAME="your_username"
+export IG_PASSWORD="your_password"
+export IG_SESSION_FILE="./ig_settings.json"
+```
+
+Common scripts:
+
+| Script | Purpose |
+| --- | --- |
+| `public_lookup.py` | Public profile lookup with optional `public_transport="curl"`. |
+| `download_user_media.py` | Login, list recent media for a username, and download photos/videos/albums. |
+| `upload_media.py` | Upload a feed photo, feed video, Reel, or Trial Reel. |
+| `upload_story.py` | Upload a photo or video story, optionally with a link sticker. |
+| `direct_message.py` | Send a Direct text message to user IDs or thread IDs. |
+| `handle_exception.py` | Centralized exception handling for challenges, relogin, and rate limits. |
+
+Examples:
+
+```bash
+python examples/public_lookup.py instagram
+IG_PUBLIC_TRANSPORT=curl python examples/public_lookup.py instagram
+python examples/download_user_media.py instagram --amount 5 --folder ./downloads
+python examples/upload_media.py reel ./reel.mp4 --thumbnail ./thumb.jpg --caption "Reel"
+python examples/upload_story.py photo ./story.jpg --caption "Story"
+python examples/direct_message.py --user-ids 123456789 --text "Hello"
+```
+
+Video uploads in Android/Pydroid environments should pass `--thumbnail` or configure executable `ffmpeg`.
+See [Pydroid and ffmpeg](pydroid.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,85 @@
+# instagrapi Examples
+
+These scripts are small runnable starting points for common `instagrapi` tasks.
+They keep credentials out of source code and use environment variables so they can be copied into applications without
+hard-coded secrets.
+
+## Setup
+
+Install the package and export credentials:
+
+```bash
+python -m pip install -U instagrapi
+
+export IG_USERNAME="your_username"
+export IG_PASSWORD="your_password"
+export IG_SESSION_FILE="./ig_settings.json"
+```
+
+Optional settings:
+
+```bash
+export IG_PROXY="http://user:pass@host:port"
+export IG_PUBLIC_TRANSPORT="curl"
+export IG_PUBLIC_TRANSPORT_IMPERSONATE="chrome136"
+```
+
+`IG_SESSION_FILE` is reused between runs. Keep that file private; it contains session data.
+
+## Scripts
+
+| Script | Purpose |
+| --- | --- |
+| `_common.py` | Shared login, proxy, session, and environment helpers used by the examples. |
+| `session_login.py` | Minimal session persistence and `sessionid` login sample. |
+| `public_lookup.py` | Public profile lookup with optional `public_transport="curl"`. |
+| `download_user_media.py` | Login, list recent media for a username, and download photos/videos/albums. |
+| `upload_media.py` | Upload a feed photo, feed video, Reel, or Trial Reel. |
+| `upload_story.py` | Upload a photo or video story, optionally with a link sticker. |
+| `direct_message.py` | Send a Direct text message to user IDs or thread IDs. |
+| `handle_exception.py` | Centralized exception handling pattern for challenges, relogin, and rate limits. |
+| `challenge_resolvers.py` | Email/SMS challenge resolver hooks. |
+| `next_proxy.py` | Example proxy rotation scaffold. |
+| `download_all_medias.py` | Larger download script for account media. |
+
+## Public lookup
+
+```bash
+python examples/public_lookup.py instagram
+IG_PUBLIC_TRANSPORT=curl python examples/public_lookup.py instagram
+```
+
+## Download media
+
+```bash
+python examples/download_user_media.py instagram --amount 5 --folder ./downloads
+```
+
+## Upload media
+
+```bash
+python examples/upload_media.py photo ./photo.jpg --caption "Hello from instagrapi"
+python examples/upload_media.py video ./video.mp4 --thumbnail ./thumb.jpg --caption "Feed video"
+python examples/upload_media.py reel ./reel.mp4 --thumbnail ./thumb.jpg --caption "Reel"
+python examples/upload_media.py trial-reel ./reel.mp4 --thumbnail ./thumb.jpg --caption "Trial Reel"
+```
+
+For Android/Pydroid environments, pass `--thumbnail` for videos and Reels or configure executable `ffmpeg`.
+
+## Upload story
+
+```bash
+python examples/upload_story.py photo ./story.jpg --caption "Story"
+python examples/upload_story.py video ./story.mp4 --thumbnail ./thumb.jpg --link https://github.com/subzeroid/instagrapi
+```
+
+Story assets should usually be 9:16, for example 720x1280.
+
+## Direct message
+
+```bash
+python examples/direct_message.py --user-ids 123456789 --text "Hello"
+python examples/direct_message.py --thread-ids 340282366841710301949128122292511813703 --text "Hello thread"
+```
+
+Use exactly one target type: `--user-ids` or `--thread-ids`.

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+from instagrapi import Client
+
+DEFAULT_SESSION_FILE = "ig_settings.json"
+
+
+def env(name: str, default: str | None = None) -> str | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def require_env(name: str) -> str:
+    value = env(name)
+    if value is None:
+        raise SystemExit(f"Set {name} environment variable before running this example.")
+    return value
+
+
+def env_int(name: str, default: int) -> int:
+    value = env(name)
+    if value is None:
+        return default
+    return int(value)
+
+
+def parse_ids(values: Iterable[str] | str | None) -> list[int]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = values.split(",")
+    return [int(value.strip()) for value in values if value.strip()]
+
+
+def make_client(login: bool = True) -> Client:
+    kwargs = {}
+    public_transport = env("IG_PUBLIC_TRANSPORT")
+    if public_transport:
+        kwargs["public_transport"] = public_transport
+    public_transport_impersonate = env("IG_PUBLIC_TRANSPORT_IMPERSONATE")
+    if public_transport_impersonate:
+        kwargs["public_transport_impersonate"] = public_transport_impersonate
+
+    cl = Client(**kwargs)
+    proxy = env("IG_PROXY")
+    if proxy:
+        cl.set_proxy(proxy)
+
+    if not login:
+        return cl
+
+    username = require_env("IG_USERNAME")
+    password = require_env("IG_PASSWORD")
+    session_file = Path(env("IG_SESSION_FILE", DEFAULT_SESSION_FILE)).expanduser()
+
+    if session_file.exists():
+        cl.load_settings(session_file)
+
+    cl.login(username, password, verification_code=env("IG_VERIFICATION_CODE", ""))
+    cl.dump_settings(session_file)
+    return cl

--- a/examples/direct_message.py
+++ b/examples/direct_message.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+
+from _common import env, make_client, parse_ids
+
+
+def send_direct(text: str, user_ids: list[int], thread_ids: list[int]):
+    if bool(user_ids) == bool(thread_ids):
+        raise SystemExit("Pass exactly one of --user-ids or --thread-ids.")
+
+    cl = make_client()
+    return cl.direct_send(text, user_ids=user_ids, thread_ids=thread_ids)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send a Direct text message.")
+    parser.add_argument("--text", default=env("IG_DIRECT_TEXT", "Hello from instagrapi"))
+    parser.add_argument("--user-ids", default=env("IG_DIRECT_USER_IDS"))
+    parser.add_argument("--thread-ids", default=env("IG_DIRECT_THREAD_IDS"))
+    args = parser.parse_args()
+
+    message = send_direct(
+        args.text,
+        user_ids=parse_ids(args.user_ids),
+        thread_ids=parse_ids(args.thread_ids),
+    )
+    print(f"Sent direct message {message.id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/download_user_media.py
+++ b/examples/download_user_media.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _common import env_int, make_client
+
+
+def download_media(username: str, amount: int, folder: Path) -> list[Path]:
+    cl = make_client()
+    folder.mkdir(parents=True, exist_ok=True)
+
+    user_id = cl.user_id_from_username(username)
+    downloaded: list[Path] = []
+    for media in cl.user_medias(user_id, amount=amount):
+        if media.media_type == 1:
+            downloaded.append(cl.photo_download(media.pk, folder=folder))
+        elif media.media_type == 2:
+            downloaded.append(cl.video_download(media.pk, folder=folder))
+        elif media.media_type == 8:
+            downloaded.extend(cl.album_download(media.pk, folder=folder))
+    return downloaded
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download recent media for an Instagram username.")
+    parser.add_argument("username")
+    parser.add_argument("--amount", type=int, default=env_int("IG_AMOUNT", 10))
+    parser.add_argument("--folder", type=Path, default=Path("downloads"))
+    args = parser.parse_args()
+
+    for path in download_media(args.username, args.amount, args.folder):
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/public_lookup.py
+++ b/examples/public_lookup.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+from json import dumps
+
+from _common import make_client
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch public Instagram profile information.")
+    parser.add_argument("username", nargs="?", default="instagram")
+    args = parser.parse_args()
+
+    cl = make_client(login=False)
+    user = cl.user_info_by_username_gql(args.username)
+    print(
+        dumps(
+            {
+                "pk": user.pk,
+                "username": user.username,
+                "full_name": user.full_name,
+                "media_count": user.media_count,
+                "follower_count": user.follower_count,
+                "following_count": user.following_count,
+                "is_private": user.is_private,
+                "is_verified": user.is_verified,
+            },
+            indent=2,
+            default=str,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/upload_media.py
+++ b/examples/upload_media.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _common import env, make_client
+
+
+def upload_media(kind: str, path: Path, caption: str, thumbnail: Path | None = None):
+    cl = make_client()
+
+    if kind == "photo":
+        return cl.photo_upload(path, caption)
+    if kind == "video":
+        return cl.video_upload(path, caption, thumbnail=thumbnail)
+    if kind == "reel":
+        return cl.clip_upload(path, caption, thumbnail=thumbnail)
+    if kind == "trial-reel":
+        if not cl.clip_trial_eligible():
+            raise SystemExit("This account does not currently report Trial Reels eligibility.")
+        return cl.clip_upload(path, caption, thumbnail=thumbnail, trial=True)
+
+    raise ValueError(f"Unsupported media kind: {kind}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Upload a feed photo, feed video, Reel, or Trial Reel.")
+    parser.add_argument("kind", choices=["photo", "video", "reel", "trial-reel"])
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--caption", default=env("IG_CAPTION", "Uploaded with instagrapi"))
+    parser.add_argument("--thumbnail", type=Path, default=None)
+    args = parser.parse_args()
+
+    media = upload_media(args.kind, args.path, args.caption, args.thumbnail)
+    print(f"Uploaded {media.pk} https://www.instagram.com/p/{media.code}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/upload_story.py
+++ b/examples/upload_story.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _common import env, make_client
+
+from instagrapi.types import StoryLink
+
+
+def upload_story(kind: str, path: Path, caption: str, thumbnail: Path | None = None, link: str | None = None):
+    cl = make_client()
+    links = [StoryLink(webUri=link)] if link else []
+
+    if kind == "photo":
+        return cl.photo_upload_to_story(path, caption=caption, links=links)
+    if kind == "video":
+        return cl.video_upload_to_story(path, caption=caption, thumbnail=thumbnail, links=links)
+
+    raise ValueError(f"Unsupported story kind: {kind}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Upload a photo or video story.")
+    parser.add_argument("kind", choices=["photo", "video"])
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--caption", default=env("IG_CAPTION", ""))
+    parser.add_argument("--thumbnail", type=Path, default=None)
+    parser.add_argument("--link", default=env("IG_STORY_LINK"))
+    args = parser.parse_args()
+
+    story = upload_story(args.kind, args.path, args.caption, args.thumbnail, args.link)
+    print(f"Uploaded story {story.pk}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Overview: index.md
   - Getting Started: getting-started.md
   - Usage Guide:
+    - Examples: usage-guide/examples.md
     - Fundamentals: usage-guide/fundamentals.md
     - Interactions: usage-guide/interactions.md
     - TOTP: usage-guide/totp.md

--- a/tests/regression/test_examples.py
+++ b/tests/regression/test_examples.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import py_compile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = ROOT / "examples"
+
+EXPECTED_EXAMPLE_SCRIPTS = [
+    "_common.py",
+    "public_lookup.py",
+    "download_user_media.py",
+    "upload_media.py",
+    "upload_story.py",
+    "direct_message.py",
+]
+
+
+def test_examples_readme_links_practical_scripts():
+    readme = EXAMPLES / "README.md"
+    assert readme.exists()
+
+    content = readme.read_text()
+    for filename in EXPECTED_EXAMPLE_SCRIPTS:
+        assert (EXAMPLES / filename).exists()
+        assert filename in content
+
+
+def test_practical_examples_compile():
+    for filename in EXPECTED_EXAMPLE_SCRIPTS:
+        py_compile.compile(str(EXAMPLES / filename), doraise=True)


### PR DESCRIPTION
## Summary
- add runnable example scripts for public lookup, media downloads, uploads, stories, and Direct messages
- add shared example login/session/proxy helper and examples README
- link examples from README and MkDocs usage guide

## Test Plan
- .venv/bin/python -m pytest tests/regression -q
- .venv/bin/python -m ruff check examples/*.py tests/regression/test_examples.py
- .venv/bin/python -m mkdocs build --strict