### PR TITLE
Link example scripts in docs

### DIFF
--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -17,12 +17,12 @@ Common scripts:
 
 | Script | Purpose |
 | --- | --- |
-| `public_lookup.py` | Public profile lookup with optional `public_transport="curl"`. |
-| `download_user_media.py` | Login, list recent media for a username, and download photos/videos/albums. |
-| `upload_media.py` | Upload a feed photo, feed video, Reel, or Trial Reel. |
-| `upload_story.py` | Upload a photo or video story, optionally with a link sticker. |
-| `direct_message.py` | Send a Direct text message to user IDs or thread IDs. |
-| `handle_exception.py` | Centralized exception handling for challenges, relogin, and rate limits. |
+| [`public_lookup.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/public_lookup.py) | Public profile lookup with optional `public_transport="curl"`. |
+| [`download_user_media.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/download_user_media.py) | Login, list recent media for a username, and download photos/videos/albums. |
+| [`upload_media.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
+| [`upload_story.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
+| [`direct_message.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
+| [`handle_exception.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/handle_exception.py) | Centralized exception handling for challenges, relogin, and rate limits. |
 
 Examples:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,17 +30,17 @@ export IG_PUBLIC_TRANSPORT_IMPERSONATE="chrome136"
 
 | Script | Purpose |
 | --- | --- |
-| `_common.py` | Shared login, proxy, session, and environment helpers used by the examples. |
-| `session_login.py` | Minimal session persistence and `sessionid` login sample. |
-| `public_lookup.py` | Public profile lookup with optional `public_transport="curl"`. |
-| `download_user_media.py` | Login, list recent media for a username, and download photos/videos/albums. |
-| `upload_media.py` | Upload a feed photo, feed video, Reel, or Trial Reel. |
-| `upload_story.py` | Upload a photo or video story, optionally with a link sticker. |
-| `direct_message.py` | Send a Direct text message to user IDs or thread IDs. |
-| `handle_exception.py` | Centralized exception handling pattern for challenges, relogin, and rate limits. |
-| `challenge_resolvers.py` | Email/SMS challenge resolver hooks. |
-| `next_proxy.py` | Example proxy rotation scaffold. |
-| `download_all_medias.py` | Larger download script for account media. |
+| [`_common.py`](_common.py) | Shared login, proxy, session, and environment helpers used by the examples. |
+| [`session_login.py`](session_login.py) | Minimal session persistence and `sessionid` login sample. |
+| [`public_lookup.py`](public_lookup.py) | Public profile lookup with optional `public_transport="curl"`. |
+| [`download_user_media.py`](download_user_media.py) | Login, list recent media for a username, and download photos/videos/albums. |
+| [`upload_media.py`](upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
+| [`upload_story.py`](upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
+| [`direct_message.py`](direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
+| [`handle_exception.py`](handle_exception.py) | Centralized exception handling pattern for challenges, relogin, and rate limits. |
+| [`challenge_resolvers.py`](challenge_resolvers.py) | Email/SMS challenge resolver hooks. |
+| [`next_proxy.py`](next_proxy.py) | Example proxy rotation scaffold. |
+| [`download_all_medias.py`](download_all_medias.py) | Larger download script for account media. |
 
 ## Public lookup
 

--- a/tests/regression/test_examples.py
+++ b/tests/regression/test_examples.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES = ROOT / "examples"
+DOCS_EXAMPLES = ROOT / "docs" / "usage-guide" / "examples.md"
+GITHUB_EXAMPLES_URL = "https://github.com/subzeroid/instagrapi/blob/master/examples"
 
 EXPECTED_EXAMPLE_SCRIPTS = [
     "_common.py",
@@ -15,6 +17,15 @@ EXPECTED_EXAMPLE_SCRIPTS = [
     "direct_message.py",
 ]
 
+DOCS_EXAMPLE_SCRIPTS = [
+    "public_lookup.py",
+    "download_user_media.py",
+    "upload_media.py",
+    "upload_story.py",
+    "direct_message.py",
+    "handle_exception.py",
+]
+
 
 def test_examples_readme_links_practical_scripts():
     readme = EXAMPLES / "README.md"
@@ -23,7 +34,14 @@ def test_examples_readme_links_practical_scripts():
     content = readme.read_text()
     for filename in EXPECTED_EXAMPLE_SCRIPTS:
         assert (EXAMPLES / filename).exists()
-        assert filename in content
+        assert f"[`{filename}`]({filename})" in content
+
+
+def test_docs_examples_links_to_github_scripts():
+    content = DOCS_EXAMPLES.read_text()
+    for filename in DOCS_EXAMPLE_SCRIPTS:
+        assert (EXAMPLES / filename).exists()
+        assert f"[`{filename}`]({GITHUB_EXAMPLES_URL}/{filename})" in content
 
 
 def test_practical_examples_compile():


### PR DESCRIPTION
## Summary
- make example script names clickable in the docs examples table
- make examples/README script names link to local files
- strengthen regression coverage so examples must be linked, not just mentioned

## Test Plan
- .venv/bin/python -m pytest tests/regression/test_examples.py -q
- .venv/bin/python -m ruff check tests/regression/test_examples.py
- .venv/bin/python -m mkdocs build --strict