### PR TITLE
Make MoviePy optional for video helpers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -79,6 +79,7 @@ jobs:
             tests/regression/test_user.py::UserMixinRegressionTestCase \
             tests/regression/test_timeline.py::TimelineRegressionTestCase \
             tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase \
+            tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase \
             tests/regression/test_upload.py::UploadRegressionTestCase
 
   build-docs:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Or install it into the active virtual environment:
 uv pip install instagrapi
 ```
 
-Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation,
-`StoryBuilder`, and video/audio composition still need executable `ffmpeg`; Android/Pydroid users should see
-[Pydroid and ffmpeg](docs/usage-guide/pydroid.md).
+Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation, `StoryBuilder`, and video/audio composition still need the optional video extra and executable `ffmpeg`:
+
+```bash
+pip install "instagrapi[video]"
+```
+
+Android users should see [Pydroid and ffmpeg](docs/usage-guide/pydroid.md) and [Termux](docs/usage-guide/termux.md).
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`Highlight`](usage-guide/highlight.md) - Highlights
   * [`Notes`](usage-guide/notes.md) - Notes
   * [`Pydroid and ffmpeg`](usage-guide/pydroid.md) - Android/Pydroid video upload setup
+  * [`Termux`](usage-guide/termux.md) - Termux install notes and optional video helpers
   * [`Public Transport`](usage-guide/public-transport.md) - Optional curl transport for public web requests
   * [`Story`](usage-guide/story.md) - Story
   * [`StoryArchiveDay`](usage-guide/story.md) - Story archive day shell

--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -35,5 +35,4 @@ python examples/upload_story.py photo ./story.jpg --caption "Story"
 python examples/direct_message.py --user-ids 123456789 --text "Hello"
 ```
 
-Video uploads in Android/Pydroid environments should pass `--thumbnail` or configure executable `ffmpeg`.
-See [Pydroid and ffmpeg](pydroid.md).
+Video uploads in Android environments should pass `--thumbnail` or install the optional video extra and configure executable `ffmpeg`. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).

--- a/docs/usage-guide/fundamentals.md
+++ b/docs/usage-guide/fundamentals.md
@@ -34,6 +34,7 @@ use an internal fallback chain and choose the best currently working path for th
   * [`Highlight`](highlight.md) - Highlights
   * [`Notes`](notes.md) - Direct Notes
   * [`Pydroid and ffmpeg`](pydroid.md) - Android/Pydroid video upload setup
+  * [`Termux`](termux.md) - Termux install notes and optional video helpers
   * [`Story`](story.md) - Story
   * [`StoryArchiveDay`](story.md) - Story archive day shell
   * [`StoryLink`](story.md) - Story link sticker

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -326,7 +326,7 @@ Upload medias to your feed. Common arguments:
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
 
-For video uploads in Android/Pydroid environments, pass `thumbnail=...` to avoid automatic thumbnail generation or configure executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md).
+For video uploads in Android environments, pass `thumbnail=...` to avoid automatic thumbnail generation, or install the optional video extra and configure executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
 
 
 In `extra_data`, you can pass additional media settings, for example:

--- a/docs/usage-guide/pydroid.md
+++ b/docs/usage-guide/pydroid.md
@@ -17,7 +17,13 @@ cl.igtv_upload(Path("video.mp4"), "title", "caption", thumbnail=Path("thumb.jpg"
 cl.video_upload_to_story(Path("story.mp4"), thumbnail=Path("thumb.jpg"))
 ```
 
-MoviePy/ffmpeg is still required when `instagrapi` has to render or extract media:
+MoviePy/ffmpeg is still required when `instagrapi` has to render or extract media. Install the optional video extra for these flows:
+
+```bash
+pip install "instagrapi[video]"
+```
+
+The extra is intentionally not part of the default install, because it pulls in MoviePy and NumPy and can be hard to build on Android.
 
 * automatic thumbnail generation when `thumbnail` is not provided
 * `StoryBuilder`
@@ -37,7 +43,7 @@ RuntimeError: No ffmpeg exe could be found. Install ffmpeg on your system, or se
 Current `instagrapi` upload helpers raise a clearer error for this thumbnail path:
 
 ```text
-Could not generate video thumbnail. Pass thumbnail=... or install ffmpeg / set IMAGEIO_FFMPEG_EXE.
+Could not generate video thumbnail. Pass thumbnail=... or install MoviePy with pip install "instagrapi[video]" and configure ffmpeg / set IMAGEIO_FFMPEG_EXE.
 ```
 
 ## Fix
@@ -49,7 +55,7 @@ The most reliable Pydroid setup is to pre-process the video outside Pydroid and 
 
 Then call the upload method with `thumbnail=Path("thumb.jpg")`.
 
-If you need automatic thumbnail generation or StoryBuilder inside Pydroid, install an ffmpeg binary that the Pydroid app can execute and set `IMAGEIO_FFMPEG_EXE` before running the upload:
+If you need automatic thumbnail generation or StoryBuilder inside Pydroid, install the optional video extra, install an ffmpeg binary that the Pydroid app can execute, and set `IMAGEIO_FFMPEG_EXE` before running the upload:
 
 ```python
 import os

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -86,7 +86,7 @@ Notes:
 * `links`, `hashtags`, `locations`, `stickers`, `medias`, and `polls` are all part of the story sticker payload.
 * Link stickers are supported through `StoryLink`; this is no longer the old Instagram "swipe up" flow.
 * For story uploads, use a 9:16 asset or build one with `StoryBuilder`.
-* Android/Pydroid users should pass `thumbnail=...` for video stories or configure ffmpeg. See [Pydroid and ffmpeg](pydroid.md).
+* Android users should pass `thumbnail=...` for video stories or install the optional video extra and configure ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
 * Anonymous public story fetch is not guaranteed. If the public/web story path fails, reliable story retrieval usually requires an authenticated session.
 
 
@@ -117,7 +117,11 @@ cl.video_upload_to_story(
 
 ## Build Story to Upload
 
-If you want to format your story correctly (correct resolution, user mentions, etc) use StoryBuilder:
+If you want to format your story correctly (correct resolution, user mentions, etc) use StoryBuilder. StoryBuilder renders media with MoviePy and ffmpeg, so install the optional video extra first:
+
+```bash
+pip install "instagrapi[video]"
+```
 
 | Method                                                | Return     | Description                              |
 | ----------------------------------------------------- | ---------- | ---------------------------------------- |

--- a/docs/usage-guide/termux.md
+++ b/docs/usage-guide/termux.md
@@ -1,0 +1,47 @@
+# Termux
+
+Termux can run many `instagrapi` flows, but Android does not use the same binary wheel ecosystem as desktop Linux. Keep the default install small and add media tooling only when the script really needs it.
+
+## Install
+
+```bash
+pkg update
+pkg install python python-pillow
+python -m pip install -U pip setuptools wheel
+python -m pip install instagrapi
+```
+
+`python-pillow` is recommended because photo uploads use Pillow through `instagrapi.image_util`. Installing it with `pkg` avoids a slow or fragile Pillow source build in pip.
+
+## Video Uploads
+
+For standard MP4 uploads, pass your own thumbnail and `instagrapi` can read width, height, and duration with its built-in MP4 parser:
+
+```python
+from pathlib import Path
+
+media = cl.clip_upload(
+    Path("reel.mp4"),
+    "Uploaded from Termux",
+    thumbnail=Path("reel-thumb.jpg"),
+)
+```
+
+This path does not need MoviePy, NumPy, or ffmpeg.
+
+## Optional Video Helpers
+
+Install the optional video extra only if you need automatic thumbnail generation, `StoryBuilder`, `prepare_video()`, or audio/video composition helpers:
+
+```bash
+pkg install ffmpeg
+python -m pip install "instagrapi[video]"
+```
+
+If MoviePy cannot find ffmpeg, point ImageIO at the Termux binary before running the script:
+
+```bash
+export IMAGEIO_FFMPEG_EXE="$(command -v ffmpeg)"
+```
+
+If `pip install "instagrapi[video]"` tries to build NumPy and fails, avoid the optional video helpers on-device: prepare the MP4 and thumbnail elsewhere, then use upload methods with `thumbnail=...`.

--- a/instagrapi/image_util.py
+++ b/instagrapi/image_util.py
@@ -16,6 +16,11 @@ except ImportError:
 
 import requests
 
+VIDEO_EXTRA_MESSAGE = (
+    'prepare_video() requires MoviePy and ffmpeg. Install it with pip install "instagrapi[video]" '
+    "and make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE."
+)
+
 
 def calc_resize(max_size, curr_size, min_size=(0, 0)):
     """
@@ -169,8 +174,16 @@ def prepare_video(
          choose ultrafast when you are in a hurry and file size does not matter.
     :return:
     """
-    from moviepy.video.fx.all import crop, resize
-    from moviepy.video.io.VideoFileClip import VideoFileClip
+    try:
+        from moviepy.video.fx.all import crop, resize
+        from moviepy.video.io.VideoFileClip import VideoFileClip
+    except ImportError as exc:
+        raise RuntimeError(VIDEO_EXTRA_MESSAGE) from exc
+    except Exception as exc:
+        message = str(exc).lower()
+        if "ffmpeg" in message or "imageio_ffmpeg_exe" in message or "no ffmpeg exe" in message:
+            raise RuntimeError(VIDEO_EXTRA_MESSAGE) from exc
+        raise
 
     min_size = kwargs.pop("min_size", (612, 320))
     progress_bar = True if kwargs.pop("progress_bar", None) else False

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -575,7 +575,7 @@ class UploadClipMixin:
             try:
                 import moviepy as mp
             except ImportError:
-                raise Exception("Please install moviepy>=1.0.3 and retry")
+                raise RuntimeError('Install video helpers with pip install "instagrapi[video]" and retry')
         video = None
         audio_clip = None
         try:

--- a/instagrapi/story.py
+++ b/instagrapi/story.py
@@ -6,23 +6,48 @@ from urllib.parse import urlparse
 
 from .types import StoryBuild, StoryMention, StorySticker
 
-try:
-    from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
-except ImportError:
-    try:
-        from moviepy.editor import (
-            CompositeVideoClip,
-            ImageClip,
-            TextClip,
-            VideoFileClip,
-        )
-    except ImportError:
-        raise Exception("Please install moviepy>=1.0.3 and retry")
+STORY_BUILDER_VIDEO_EXTRA_MESSAGE = (
+    'StoryBuilder requires MoviePy and ffmpeg. Install it with pip install "instagrapi[video]" '
+    "and make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE."
+)
+STORY_BUILDER_PILLOW_MESSAGE = "StoryBuilder photo rendering requires Pillow. Install Pillow and retry."
 
-try:
-    from PIL import Image
-except ImportError:
-    raise Exception("You don't have PIL installed. Please install PIL or Pillow>=8.1.1")
+
+def _ffmpeg_unavailable(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "ffmpeg" in message or "imageio_ffmpeg_exe" in message or "no ffmpeg exe" in message
+
+
+def _import_moviepy_for_story():
+    try:
+        from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+    except ImportError:
+        try:
+            from moviepy.editor import (
+                CompositeVideoClip,
+                ImageClip,
+                TextClip,
+                VideoFileClip,
+            )
+        except ImportError as exc:
+            raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
+        except Exception as exc:
+            if _ffmpeg_unavailable(exc):
+                raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
+            raise
+    except Exception as exc:
+        if _ffmpeg_unavailable(exc):
+            raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
+        raise
+    return CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+
+
+def _import_pillow_for_story():
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise RuntimeError(STORY_BUILDER_PILLOW_MESSAGE) from exc
+    return Image
 
 
 def _make_tmp_path(suffix: str) -> str:
@@ -106,6 +131,7 @@ class StoryBuilder:
         StoryBuild
             An object of StoryBuild
         """
+        CompositeVideoClip, ImageClip, TextClip, _ = _import_moviepy_for_story()
         clips = []
         stickers = []
         # Background
@@ -229,6 +255,7 @@ class StoryBuilder:
         StoryBuild
             An object of StoryBuild
         """
+        _, _, _, VideoFileClip = _import_moviepy_for_story()
         clip = VideoFileClip(str(self.path), has_mask=True)
         build = self.build_main(clip, max_duration, font, fontsize, color, link)
         clip.close()
@@ -262,6 +289,8 @@ class StoryBuilder:
             An object of StoryBuild
         """
 
+        _, ImageClip, _, _ = _import_moviepy_for_story()
+        Image = _import_pillow_for_story()
         with Image.open(self.path) as im:
             image_width, image_height = im.size
 

--- a/instagrapi/utils/video.py
+++ b/instagrapi/utils/video.py
@@ -4,11 +4,13 @@ from pathlib import Path
 from typing import Callable, Optional
 
 THUMBNAIL_FFMPEG_MESSAGE = (
-    "Could not generate video thumbnail. Pass thumbnail=... or install ffmpeg / set IMAGEIO_FFMPEG_EXE."
+    'Could not generate video thumbnail. Pass thumbnail=... or install MoviePy with pip install "instagrapi[video]" '
+    "and configure ffmpeg / set IMAGEIO_FFMPEG_EXE."
 )
 METADATA_FFMPEG_MESSAGE = (
     "Could not read video metadata with the MP4 parser and MoviePy/ffmpeg is unavailable. "
-    "Use a standard MP4 file, or install ffmpeg / set IMAGEIO_FFMPEG_EXE."
+    'Use a standard MP4 file, or install MoviePy with pip install "instagrapi[video]" and configure ffmpeg / '
+    "set IMAGEIO_FFMPEG_EXE."
 )
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - Public Transport: usage-guide/public-transport.md
     - Search: usage-guide/search.md
     - Story: usage-guide/story.md
+    - Termux: usage-guide/termux.md
     - Track: usage-guide/track.md
     - User: usage-guide/user.md
     - Account: usage-guide/account.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "requests==2.34.2",
     "PySocks==1.7.1",
     "pydantic==2.13.4",
-    "moviepy==1.0.3",
+    "Pillow==12.2.0",
     "pycryptodomex==3.23.0",
 ]
 
@@ -69,8 +69,10 @@ Guides = "https://instagrapi.com/guides/"
 curl = [
     "curl-adapter>=1.2.1",
 ]
+video = [
+    "moviepy==1.0.3",
+]
 test = [
-    "Pillow==12.2.0",
     "bandit==1.9.4",
     "mike==2.2.0",
     # mike implicitly imports pkg_resources from setuptools — see

--- a/tests/regression/test_video_metadata.py
+++ b/tests/regression/test_video_metadata.py
@@ -1,5 +1,7 @@
 import builtins
+import importlib
 import struct
+import sys
 
 from tests.helpers import *
 
@@ -116,3 +118,40 @@ class VideoMetadataRegressionTestCase(unittest.TestCase):
         message = str(ctx.exception)
         self.assertIn("Pass thumbnail=...", message)
         self.assertIn("IMAGEIO_FFMPEG_EXE", message)
+
+    def test_core_install_does_not_require_moviepy(self):
+        pyproject = Path("pyproject.toml").read_text()
+        required_dependencies = pyproject.split("[project.optional-dependencies]", 1)[0]
+        optional_dependencies = pyproject.split("[project.optional-dependencies]", 1)[1]
+
+        self.assertNotIn("moviepy", required_dependencies)
+        self.assertIn("video = [", optional_dependencies)
+        self.assertIn('"moviepy==1.0.3"', optional_dependencies)
+
+    def test_story_builder_import_does_not_require_moviepy(self):
+        sys.modules.pop("instagrapi.story", None)
+        with self.block_moviepy_imports(ImportError("no moviepy")):
+            try:
+                story = importlib.import_module("instagrapi.story")
+            except Exception as exc:
+                self.fail(f"StoryBuilder import should not require MoviePy: {exc}")
+
+        self.assertEqual(story.StoryBuilder(Path("photo.jpg")).path, Path("photo.jpg"))
+
+    def test_story_builder_render_reports_video_extra_without_moviepy(self):
+        sys.modules.pop("instagrapi.story", None)
+        with self.block_moviepy_imports(ImportError("no moviepy")):
+            story = importlib.import_module("instagrapi.story")
+            with self.assertRaises(RuntimeError) as ctx:
+                story.StoryBuilder(Path("video.mp4")).video()
+
+        self.assertIn("instagrapi[video]", str(ctx.exception))
+
+    def test_prepare_video_reports_video_extra_without_moviepy(self):
+        from instagrapi.image_util import prepare_video
+
+        with self.block_moviepy_imports(ImportError("no moviepy")):
+            with self.assertRaises(RuntimeError) as ctx:
+                prepare_video("video.mp4")
+
+        self.assertIn("instagrapi[video]", str(ctx.exception))


### PR DESCRIPTION
## Summary
- move MoviePy out of required dependencies into the `video` extra so Termux/default installs do not pull NumPy
- keep video upload analysis working without MoviePy when `thumbnail=...` is provided, and make StoryBuilder/prepare_video fail with actionable `instagrapi[video]` guidance
- add Termux docs plus README/Pydroid/story docs updates
- add regression and CI smoke coverage for optional MoviePy behavior

Fixes #2501.

## Verification
- `.venv/bin/python -m pytest tests/regression/test_video_metadata.py tests/regression/test_public_transport.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- workflow smoke command from `.github/workflows/python-package.yml` with `test_video_metadata` included
- `.venv/bin/python -m ruff check --output-format=github .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m bandit -c pyproject.toml -r instagrapi`
- `.venv/bin/python -m mkdocs build --strict`
- clean venv `pip install .` then import `instagrapi` and `instagrapi.story`; `moviepy` was not installed