### PR TITLE
Upgrade optional video helpers to MoviePy 2

### DIFF
--- a/.github/actions/install-dependencies/action.sh
+++ b/.github/actions/install-dependencies/action.sh
@@ -21,6 +21,8 @@ retry_pip_install 3 --upgrade pip
 if [[ "${INSTALL_TEST}" == "true"  ]]; then
   echo "Installing project with test extras"
   retry_pip_install 3 ".[test]"
+  echo "Installing MoviePy 2.2.1 without dependency downgrades"
+  retry_pip_install 3 --no-deps "moviepy==2.2.1"
 elif [[ "${INSTALL_PACKAGE}" == "true"  ]]; then
   echo "Installing project package"
   retry_pip_install 3 .

--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ Or install it into the active virtual environment:
 uv pip install instagrapi
 ```
 
-Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation, `StoryBuilder`, and video/audio composition still need the optional video extra and executable `ffmpeg`:
+Video uploads can use a built-in MP4 metadata parser when you provide `thumbnail=...`. Automatic thumbnail generation, `StoryBuilder`, and video/audio composition still need the optional video dependencies, MoviePy `2.2.1`, and executable `ffmpeg`:
 
 ```bash
 pip install "instagrapi[video]"
+pip install --no-deps "moviepy==2.2.1"
 ```
+
+MoviePy `2.2.1` currently declares `Pillow<12`, but instagrapi keeps `Pillow>=12.2.0` for security fixes; the `--no-deps` install keeps the safe Pillow version. If your project imports MoviePy directly, migrate any MoviePy `1.x` code from `moviepy.editor`, `set_*`, `resize`, and `subclip` APIs to the MoviePy `2.x` API before upgrading.
 
 Android users should see [Pydroid and ffmpeg](docs/usage-guide/pydroid.md) and [Termux](docs/usage-guide/termux.md).
 

--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -35,4 +35,4 @@ python examples/upload_story.py photo ./story.jpg --caption "Story"
 python examples/direct_message.py --user-ids 123456789 --text "Hello"
 ```
 
-Video uploads in Android environments should pass `--thumbnail` or install the optional video extra and configure executable `ffmpeg`. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
+Video uploads in Android environments should pass `--thumbnail` or install the optional video dependencies, MoviePy `2.2.1`, and executable `ffmpeg`. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -326,7 +326,7 @@ Upload medias to your feed. Common arguments:
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
 
-For video uploads in Android environments, pass `thumbnail=...` to avoid automatic thumbnail generation, or install the optional video extra and configure executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
+For video uploads in Android environments, pass `thumbnail=...` to avoid automatic thumbnail generation, or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
 
 
 In `extra_data`, you can pass additional media settings, for example:

--- a/docs/usage-guide/pydroid.md
+++ b/docs/usage-guide/pydroid.md
@@ -21,9 +21,10 @@ MoviePy/ffmpeg is still required when `instagrapi` has to render or extract medi
 
 ```bash
 pip install "instagrapi[video]"
+pip install --no-deps "moviepy==2.2.1"
 ```
 
-The extra is intentionally not part of the default install, because it pulls in MoviePy and NumPy and can be hard to build on Android.
+The extra is intentionally not part of the default install, because it pulls in NumPy and ffmpeg-related packages that can be hard to build on Android. MoviePy `2.2.1` currently declares `Pillow<12`, but instagrapi keeps `Pillow>=12.2.0` for security fixes; the `--no-deps` install keeps the safe Pillow version. MoviePy `1.x` is no longer supported by instagrapi's video helpers.
 
 * automatic thumbnail generation when `thumbnail` is not provided
 * `StoryBuilder`
@@ -43,7 +44,7 @@ RuntimeError: No ffmpeg exe could be found. Install ffmpeg on your system, or se
 Current `instagrapi` upload helpers raise a clearer error for this thumbnail path:
 
 ```text
-Could not generate video thumbnail. Pass thumbnail=... or install MoviePy with pip install "instagrapi[video]" and configure ffmpeg / set IMAGEIO_FFMPEG_EXE.
+Could not generate video thumbnail. Pass thumbnail=... or install MoviePy 2.2.1. Install video dependencies with pip install "instagrapi[video]" and then install MoviePy with pip install --no-deps "moviepy==2.2.1". Make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE.
 ```
 
 ## Fix
@@ -55,7 +56,7 @@ The most reliable Pydroid setup is to pre-process the video outside Pydroid and 
 
 Then call the upload method with `thumbnail=Path("thumb.jpg")`.
 
-If you need automatic thumbnail generation or StoryBuilder inside Pydroid, install the optional video extra, install an ffmpeg binary that the Pydroid app can execute, and set `IMAGEIO_FFMPEG_EXE` before running the upload:
+If you need automatic thumbnail generation or StoryBuilder inside Pydroid, install the optional video dependencies and MoviePy, install an ffmpeg binary that the Pydroid app can execute, and set `IMAGEIO_FFMPEG_EXE` before running the upload:
 
 ```python
 import os

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -86,7 +86,7 @@ Notes:
 * `links`, `hashtags`, `locations`, `stickers`, `medias`, and `polls` are all part of the story sticker payload.
 * Link stickers are supported through `StoryLink`; this is no longer the old Instagram "swipe up" flow.
 * For story uploads, use a 9:16 asset or build one with `StoryBuilder`.
-* Android users should pass `thumbnail=...` for video stories or install the optional video extra and configure ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
+* Android users should pass `thumbnail=...` for video stories or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
 * Anonymous public story fetch is not guaranteed. If the public/web story path fails, reliable story retrieval usually requires an authenticated session.
 
 
@@ -117,11 +117,14 @@ cl.video_upload_to_story(
 
 ## Build Story to Upload
 
-If you want to format your story correctly (correct resolution, user mentions, etc) use StoryBuilder. StoryBuilder renders media with MoviePy and ffmpeg, so install the optional video extra first:
+If you want to format your story correctly (correct resolution, user mentions, etc) use StoryBuilder. StoryBuilder renders media with MoviePy and ffmpeg, so install the optional video dependencies first:
 
 ```bash
 pip install "instagrapi[video]"
+pip install --no-deps "moviepy==2.2.1"
 ```
+
+MoviePy `2.2.1` currently declares `Pillow<12`, but instagrapi keeps `Pillow>=12.2.0` for security fixes; the `--no-deps` install keeps the safe Pillow version. Older MoviePy `1.x` imports such as `moviepy.editor` and clip methods such as `set_duration`, `set_position`, `resize`, and `subclip` are not supported by instagrapi's video helpers.
 
 | Method                                                | Return     | Description                              |
 | ----------------------------------------------------- | ---------- | ---------------------------------------- |

--- a/docs/usage-guide/termux.md
+++ b/docs/usage-guide/termux.md
@@ -36,7 +36,10 @@ Install the optional video extra only if you need automatic thumbnail generation
 ```bash
 pkg install ffmpeg
 python -m pip install "instagrapi[video]"
+python -m pip install --no-deps "moviepy==2.2.1"
 ```
+
+MoviePy `2.2.1` currently declares `Pillow<12`, but instagrapi keeps `Pillow>=12.2.0` for security fixes; the `--no-deps` install keeps the safe Pillow version. MoviePy `1.x` is no longer supported by instagrapi's optional video helpers.
 
 If MoviePy cannot find ffmpeg, point ImageIO at the Termux binary before running the script:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,7 +64,7 @@ python examples/upload_media.py reel ./reel.mp4 --thumbnail ./thumb.jpg --captio
 python examples/upload_media.py trial-reel ./reel.mp4 --thumbnail ./thumb.jpg --caption "Trial Reel"
 ```
 
-For Android/Pydroid environments, pass `--thumbnail` for videos and Reels or configure executable `ffmpeg`.
+For Android environments, pass `--thumbnail` for videos and Reels or install `instagrapi[video]`, install MoviePy with `pip install --no-deps "moviepy==2.2.1"`, and configure executable `ffmpeg`.
 
 ## Upload story
 

--- a/instagrapi/image_util.py
+++ b/instagrapi/image_util.py
@@ -16,10 +16,9 @@ except ImportError:
 
 import requests
 
-VIDEO_EXTRA_MESSAGE = (
-    'prepare_video() requires MoviePy and ffmpeg. Install it with pip install "instagrapi[video]" '
-    "and make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE."
-)
+from instagrapi.utils.video import MOVIEPY_2_FFMPEG_MESSAGE
+
+VIDEO_EXTRA_MESSAGE = f"prepare_video() requires MoviePy 2.2.1 and ffmpeg. {MOVIEPY_2_FFMPEG_MESSAGE}"
 
 
 def calc_resize(max_size, curr_size, min_size=(0, 0)):
@@ -175,8 +174,7 @@ def prepare_video(
     :return:
     """
     try:
-        from moviepy.video.fx.all import crop, resize
-        from moviepy.video.io.VideoFileClip import VideoFileClip
+        from moviepy import VideoFileClip
     except ImportError as exc:
         raise RuntimeError(VIDEO_EXTRA_MESSAGE) from exc
     except Exception as exc:
@@ -214,7 +212,7 @@ def prepare_video(
         raise ValueError("Duration is too short")
 
     if vidclip.duration > max_duration * 1.0:
-        vidclip = vidclip.subclip(0, max_duration)
+        vidclip = vidclip.subclipped(0, max_duration)
         vid_is_modified = True
 
     if thumbnail_frame_ts > vidclip.duration:
@@ -223,13 +221,13 @@ def prepare_video(
     if aspect_ratios:
         crop_box = calc_crop(aspect_ratios, vidclip.size)
         if crop_box:
-            vidclip = crop(vidclip, x1=crop_box[0], y1=crop_box[1], x2=crop_box[2], y2=crop_box[3])
+            vidclip = vidclip.cropped(x1=crop_box[0], y1=crop_box[1], x2=crop_box[2], y2=crop_box[3])
             vid_is_modified = True
 
     if max_size or min_size:
         new_size = calc_resize(max_size, vidclip.size, min_size=min_size)
         if new_size:
-            vidclip = resize(vidclip, newsize=new_size)
+            vidclip = vidclip.resized(new_size=new_size)
             vid_is_modified = True
 
     temp_vid_output_file = tempfile.NamedTemporaryFile(prefix="ipae_", suffix=".mp4", delete=False)
@@ -240,8 +238,7 @@ def prepare_video(
             codec="libx264",
             audio=True,
             audio_codec="aac",
-            verbose=False,
-            progress_bar=progress_bar,
+            logger="bar" if progress_bar else None,
             preset=preset,
             remove_temp=True,
         )

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -11,7 +11,7 @@ from instagrapi import config
 from instagrapi.exceptions import ClientError, ClipConfigureError, ClipNotUpload
 from instagrapi.types import Location, Media, Track, Usertag
 from instagrapi.utils.timing import date_time_original
-from instagrapi.utils.video import analyze_video_for_upload
+from instagrapi.utils.video import MOVIEPY_2_INSTALL_MESSAGE, analyze_video_for_upload
 
 try:
     from PIL import Image
@@ -570,23 +570,22 @@ class UploadClipMixin:
         except IndexError:
             highlight_start_time = 0
         try:
-            import moviepy.editor as mp
-        except ImportError:
-            try:
-                import moviepy as mp
-            except ImportError:
-                raise RuntimeError('Install video helpers with pip install "instagrapi[video]" and retry')
+            from moviepy import AudioFileClip, VideoFileClip
+        except ImportError as exc:
+            raise RuntimeError(
+                f"clip_upload_as_reel_with_music() requires MoviePy 2.2.1. {MOVIEPY_2_INSTALL_MESSAGE}"
+            ) from exc
         video = None
         audio_clip = None
         try:
             # get all media to create the reel
-            video = mp.VideoFileClip(str(path))
-            audio_clip = mp.AudioFileClip(str(tmpaudio))
+            video = VideoFileClip(str(path))
+            audio_clip = AudioFileClip(str(tmpaudio))
             # set the start time of the audio and create the actual media
             start = highlight_start_time / 1000
             end = highlight_start_time / 1000 + video.duration
-            audio_clip = audio_clip.subclip(start, end)
-            video = video.set_audio(audio_clip)
+            audio_clip = audio_clip.subclipped(start, end)
+            video = video.with_audio(audio_clip)
             video_duration = video.duration
             # save the media in tmp folder
             tmpvideo = Path(_make_tmp_path(".mp4"))

--- a/instagrapi/story.py
+++ b/instagrapi/story.py
@@ -5,11 +5,9 @@ from typing import List
 from urllib.parse import urlparse
 
 from .types import StoryBuild, StoryMention, StorySticker
+from .utils.video import MOVIEPY_2_FFMPEG_MESSAGE
 
-STORY_BUILDER_VIDEO_EXTRA_MESSAGE = (
-    'StoryBuilder requires MoviePy and ffmpeg. Install it with pip install "instagrapi[video]" '
-    "and make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE."
-)
+STORY_BUILDER_VIDEO_EXTRA_MESSAGE = f"StoryBuilder requires MoviePy 2.2.1 and ffmpeg. {MOVIEPY_2_FFMPEG_MESSAGE}"
 STORY_BUILDER_PILLOW_MESSAGE = "StoryBuilder photo rendering requires Pillow. Install Pillow and retry."
 
 
@@ -20,26 +18,14 @@ def _ffmpeg_unavailable(exc: Exception) -> bool:
 
 def _import_moviepy_for_story():
     try:
-        from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
-    except ImportError:
-        try:
-            from moviepy.editor import (
-                CompositeVideoClip,
-                ImageClip,
-                TextClip,
-                VideoFileClip,
-            )
-        except ImportError as exc:
-            raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
-        except Exception as exc:
-            if _ffmpeg_unavailable(exc):
-                raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
-            raise
+        from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip, vfx
+    except ImportError as exc:
+        raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
     except Exception as exc:
         if _ffmpeg_unavailable(exc):
             raise RuntimeError(STORY_BUILDER_VIDEO_EXTRA_MESSAGE) from exc
         raise
-    return CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+    return CompositeVideoClip, ImageClip, TextClip, VideoFileClip, vfx
 
 
 def _import_pillow_for_story():
@@ -131,7 +117,7 @@ class StoryBuilder:
         StoryBuild
             An object of StoryBuild
         """
-        CompositeVideoClip, ImageClip, TextClip, _ = _import_moviepy_for_story()
+        CompositeVideoClip, ImageClip, TextClip, _, vfx = _import_moviepy_for_story()
         clips = []
         stickers = []
         # Background
@@ -144,7 +130,7 @@ class StoryBuilder:
         clip_top = (self.height - clip.size[1]) / 2
         if clip_top > 90:
             clip_top -= 50
-        media_clip = clip.set_position((clip_left, clip_top))
+        media_clip = clip.with_position((clip_left, clip_top))
         clips.append(media_clip)
         mention = self.mentions[0] if self.mentions else None
         # Text clip
@@ -155,11 +141,10 @@ class StoryBuilder:
                 caption = f"@{mention.user.username}"
         if caption:
             text_clip = TextClip(
-                caption,
+                text=caption,
                 color=color,
                 font=font,
-                kerning=-1,
-                fontsize=fontsize,
+                font_size=fontsize,
                 method="label",
             )
             text_clip_left = (self.width - 600) / 2
@@ -167,22 +152,29 @@ class StoryBuilder:
             offset = (text_clip_top + text_clip.size[1]) - self.height
             if offset > 0:
                 text_clip_top -= offset + 90
-            text_clip = text_clip.resize(width=600).set_position((text_clip_left, text_clip_top)).fadein(3)
+            text_clip = (
+                text_clip.resized(width=600)
+                .with_position((text_clip_left, text_clip_top))
+                .with_effects([vfx.FadeIn(3)])
+            )
             clips.append(text_clip)
         if link:
             url = urlparse(link)
             link_clip = TextClip(
-                url.netloc,
+                text=url.netloc,
                 color="blue",
                 bg_color="white",
                 font=font,
-                kerning=-1,
-                fontsize=32,
+                font_size=32,
                 method="label",
             )
             link_clip_left = (self.width - 400) / 2
             link_clip_top = clip.size[1] / 2
-            link_clip = link_clip.resize(width=400).set_position((link_clip_left, link_clip_top)).fadein(3)
+            link_clip = (
+                link_clip.resized(width=400)
+                .with_position((link_clip_left, link_clip_top))
+                .with_effects([vfx.FadeIn(3)])
+            )
             link_sticker = StorySticker(
                 # x=160.0, y=641.0, z=0, width=400.0, height=88.0,
                 x=round(link_clip_left / self.width, 7),  # e.g. 0.49953705
@@ -214,7 +206,7 @@ class StoryBuilder:
             if duration > int(clip.duration) or not duration:
                 duration = int(clip.duration)
         destination = _make_tmp_path(".mp4")
-        cvc = CompositeVideoClip(clips, size=(self.width, self.height)).set_fps(24).set_duration(duration)
+        cvc = CompositeVideoClip(clips, size=(self.width, self.height)).with_fps(24).with_duration(duration)
         cvc.write_videofile(destination, codec="libx264", audio=True, audio_codec="aac")
         paths = []
         if duration > 15:
@@ -223,7 +215,7 @@ class StoryBuilder:
                 start = i * 15
                 rest = duration - start
                 end = start + (rest if rest < 15 else 15)
-                sub = cvc.subclip(start, end)
+                sub = cvc.subclipped(start, end)
                 sub.write_videofile(path, codec="libx264", audio=True, audio_codec="aac")
                 paths.append(path)
         return StoryBuild(mentions=mentions, path=destination, paths=paths, stickers=stickers)
@@ -255,7 +247,7 @@ class StoryBuilder:
         StoryBuild
             An object of StoryBuild
         """
-        _, _, _, VideoFileClip = _import_moviepy_for_story()
+        _, _, _, VideoFileClip, _ = _import_moviepy_for_story()
         clip = VideoFileClip(str(self.path), has_mask=True)
         build = self.build_main(clip, max_duration, font, fontsize, color, link)
         clip.close()
@@ -289,7 +281,7 @@ class StoryBuilder:
             An object of StoryBuild
         """
 
-        _, ImageClip, _, _ = _import_moviepy_for_story()
+        _, ImageClip, _, _, _ = _import_moviepy_for_story()
         Image = _import_pillow_for_story()
         with Image.open(self.path) as im:
             image_width, image_height = im.size
@@ -297,5 +289,5 @@ class StoryBuilder:
         width_reduction_percent = self.width / float(image_width)
         height_in_ratio = int((float(image_height) * float(width_reduction_percent)))
 
-        clip = ImageClip(str(self.path)).resize(width=self.width, height=height_in_ratio)
+        clip = ImageClip(str(self.path)).resized(width=self.width, height=height_in_ratio)
         return self.build_main(clip, max_duration or 15, font, fontsize, color, link)

--- a/instagrapi/utils/video.py
+++ b/instagrapi/utils/video.py
@@ -3,14 +3,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
+MOVIEPY_2_INSTALL_MESSAGE = (
+    'Install video dependencies with pip install "instagrapi[video]" and then install MoviePy with '
+    'pip install --no-deps "moviepy==2.2.1".'
+)
+MOVIEPY_2_FFMPEG_MESSAGE = f"{MOVIEPY_2_INSTALL_MESSAGE} Make sure ffmpeg is executable or set IMAGEIO_FFMPEG_EXE."
+
 THUMBNAIL_FFMPEG_MESSAGE = (
-    'Could not generate video thumbnail. Pass thumbnail=... or install MoviePy with pip install "instagrapi[video]" '
-    "and configure ffmpeg / set IMAGEIO_FFMPEG_EXE."
+    f"Could not generate video thumbnail. Pass thumbnail=... or install MoviePy 2.2.1. {MOVIEPY_2_FFMPEG_MESSAGE}"
 )
 METADATA_FFMPEG_MESSAGE = (
     "Could not read video metadata with the MP4 parser and MoviePy/ffmpeg is unavailable. "
-    'Use a standard MP4 file, or install MoviePy with pip install "instagrapi[video]" and configure ffmpeg / '
-    "set IMAGEIO_FFMPEG_EXE."
+    f"Use a standard MP4 file, or install MoviePy 2.2.1. {MOVIEPY_2_FFMPEG_MESSAGE}"
 )
 
 
@@ -182,16 +186,9 @@ def _ffmpeg_unavailable(exc: Exception) -> bool:
 
 def _import_moviepy(error_message: str):
     try:
-        import moviepy.editor as mp
-    except ImportError:
-        try:
-            import moviepy as mp
-        except ImportError as exc:
-            raise RuntimeError(error_message) from exc
-        except Exception as exc:
-            if _ffmpeg_unavailable(exc):
-                raise RuntimeError(error_message) from exc
-            raise
+        import moviepy as mp
+    except ImportError as exc:
+        raise RuntimeError(error_message) from exc
     except Exception as exc:
         if _ffmpeg_unavailable(exc):
             raise RuntimeError(error_message) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,20 @@ curl = [
     "curl-adapter>=1.2.1",
 ]
 video = [
-    "moviepy==1.0.3",
+    # MoviePy 2.2.1 still declares pillow<12, while instagrapi requires Pillow 12.2.0
+    # for security fixes. Install MoviePy itself with --no-deps after this extra.
+    "decorator>=4.0.2,<6.0",
+    "imageio>=2.5,<3.0",
+    "imageio-ffmpeg>=0.2.0",
+    "numpy>=1.25.0",
+    "proglog<=1.0.0",
+    "python-dotenv>=0.10",
 ]
 test = [
     "bandit==1.9.4",
+    "decorator>=4.0.2,<6.0",
+    "imageio>=2.5,<3.0",
+    "imageio-ffmpeg>=0.2.0",
     "mike==2.2.0",
     # mike implicitly imports pkg_resources from setuptools — see
     # https://github.com/jimporter/mike/issues/148
@@ -81,9 +91,12 @@ test = [
     "markdown-include==0.8.1",
     "mkdocs-material==9.7.6",
     "mkdocstrings[python]==1.0.4",
+    "numpy>=1.25.0",
     "pre-commit==4.6.0",
+    "proglog<=1.0.0",
     "pytest-xdist==3.8.0",
     "pytest==9.0.3",
+    "python-dotenv>=0.10",
     "ruff==0.15.13",
 ]
 

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -653,7 +653,7 @@ class UploadRegressionTestCase(unittest.TestCase):
             def __init__(self, path):
                 self.path = path
 
-            def subclip(self, start, end):
+            def subclipped(self, start, end):
                 return self
 
             def close(self):
@@ -664,7 +664,7 @@ class UploadRegressionTestCase(unittest.TestCase):
                 self.path = path
                 self.duration = 2.5
 
-            def set_audio(self, audio_clip):
+            def with_audio(self, audio_clip):
                 self.audio_clip = audio_clip
                 return self
 
@@ -674,7 +674,7 @@ class UploadRegressionTestCase(unittest.TestCase):
             def close(self):
                 return None
 
-        fake_mp = types.ModuleType("moviepy.editor")
+        fake_mp = types.ModuleType("moviepy")
         fake_mp.VideoFileClip = FakeVideoClip
         fake_mp.AudioFileClip = FakeAudioClip
 
@@ -686,7 +686,6 @@ class UploadRegressionTestCase(unittest.TestCase):
                 "sys.modules",
                 {
                     "moviepy": fake_mp,
-                    "moviepy.editor": fake_mp,
                 },
             ):
                 with mock.patch("tempfile.mktemp", side_effect=[str(audio_path), str(video_path)]):
@@ -722,7 +721,7 @@ class UploadRegressionTestCase(unittest.TestCase):
             def __init__(self, path):
                 self.path = path
 
-            def subclip(self, start, end):
+            def subclipped(self, start, end):
                 return self
 
             def close(self):
@@ -733,7 +732,7 @@ class UploadRegressionTestCase(unittest.TestCase):
                 self.path = path
                 self.duration = 2.5
 
-            def set_audio(self, audio_clip):
+            def with_audio(self, audio_clip):
                 self.audio_clip = audio_clip
                 return self
 
@@ -743,7 +742,7 @@ class UploadRegressionTestCase(unittest.TestCase):
             def close(self):
                 return None
 
-        fake_mp = types.ModuleType("moviepy.editor")
+        fake_mp = types.ModuleType("moviepy")
         fake_mp.VideoFileClip = FakeVideoClip
         fake_mp.AudioFileClip = FakeAudioClip
 
@@ -755,7 +754,6 @@ class UploadRegressionTestCase(unittest.TestCase):
                 "sys.modules",
                 {
                     "moviepy": fake_mp,
-                    "moviepy.editor": fake_mp,
                 },
             ):
                 with mock.patch("tempfile.mktemp", side_effect=[str(audio_path), str(video_path)]):
@@ -792,7 +790,7 @@ class UploadRegressionTestCase(unittest.TestCase):
             def __init__(self, path):
                 self.path = path
 
-            def subclip(self, start, end):
+            def subclipped(self, start, end):
                 return self
 
             def close(self):
@@ -803,7 +801,7 @@ class UploadRegressionTestCase(unittest.TestCase):
                 self.path = path
                 self.duration = 2.5
 
-            def set_audio(self, audio_clip):
+            def with_audio(self, audio_clip):
                 self.audio_clip = audio_clip
                 return self
 
@@ -813,7 +811,7 @@ class UploadRegressionTestCase(unittest.TestCase):
             def close(self):
                 return None
 
-        fake_mp = types.ModuleType("moviepy.editor")
+        fake_mp = types.ModuleType("moviepy")
         fake_mp.VideoFileClip = FakeVideoClip
         fake_mp.AudioFileClip = FakeAudioClip
 
@@ -825,7 +823,6 @@ class UploadRegressionTestCase(unittest.TestCase):
                 "sys.modules",
                 {
                     "moviepy": fake_mp,
-                    "moviepy.editor": fake_mp,
                 },
             ):
                 with mock.patch("tempfile.mktemp", side_effect=[str(audio_path), str(video_path)]):
@@ -858,14 +855,13 @@ class UploadRegressionTestCase(unittest.TestCase):
             def close(self):
                 closed["value"] = True
 
-        fake_mp = types.ModuleType("moviepy.editor")
+        fake_mp = types.ModuleType("moviepy")
         fake_mp.VideoFileClip = FakeVideoClip
 
         with mock.patch.dict(
             "sys.modules",
             {
                 "moviepy": fake_mp,
-                "moviepy.editor": fake_mp,
             },
         ):
             result = clip_mixin.analyze_video(Path("input.mp4"), thumbnail=Path("thumb.jpg"))
@@ -889,14 +885,13 @@ class UploadRegressionTestCase(unittest.TestCase):
             def close(self):
                 closed["value"] = True
 
-        fake_mp = types.ModuleType("moviepy.editor")
+        fake_mp = types.ModuleType("moviepy")
         fake_mp.VideoFileClip = FakeVideoClip
 
         with mock.patch.dict(
             "sys.modules",
             {
                 "moviepy": fake_mp,
-                "moviepy.editor": fake_mp,
             },
         ):
             with self.assertRaises(RuntimeError):
@@ -920,14 +915,13 @@ class UploadRegressionTestCase(unittest.TestCase):
             def close(self):
                 closed["value"] = True
 
-        fake_mp = types.ModuleType("moviepy.editor")
+        fake_mp = types.ModuleType("moviepy")
         fake_mp.VideoFileClip = FakeVideoClip
 
         with mock.patch.dict(
             "sys.modules",
             {
                 "moviepy": fake_mp,
-                "moviepy.editor": fake_mp,
             },
         ):
             with self.assertRaises(RuntimeError):

--- a/tests/regression/test_video_metadata.py
+++ b/tests/regression/test_video_metadata.py
@@ -213,7 +213,7 @@ class VideoMetadataRegressionTestCase(unittest.TestCase):
             image = tmpdir / "photo.jpg"
             Image.new("RGB", (720, 1280), "white").save(image)
 
-            build = StoryBuilder(image, caption="MoviePy 2").photo(max_duration=1, link="https://example.com")
+            build = StoryBuilder(image).photo(max_duration=1)
             try:
                 output = Path(build.path)
                 self.assertTrue(output.exists())

--- a/tests/regression/test_video_metadata.py
+++ b/tests/regression/test_video_metadata.py
@@ -1,6 +1,11 @@
 import builtins
+import contextlib
 import importlib
+import importlib.metadata
+import os
+import shutil
 import struct
+import subprocess
 import sys
 
 from tests.helpers import *
@@ -34,6 +39,39 @@ def _sample_mp4(width: int = 720, height: int = 1280, duration: float = 3.5) -> 
     trak = _box("trak", tkhd + mdia)
     moov = _box("moov", mvhd + trak)
     return ftyp + moov + _box("mdat", b"\x00" * 4)
+
+
+def _ffmpeg_exe() -> str:
+    try:
+        import imageio_ffmpeg
+
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            return ffmpeg
+    raise unittest.SkipTest("ffmpeg is required for MoviePy video generation coverage")
+
+
+def _write_real_mp4(folder: Path, name: str = "source.mp4", duration: float = 4.0) -> Path:
+    path = folder / name
+    subprocess.run(
+        [
+            _ffmpeg_exe(),
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=black:s=640x360:d={duration}",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    return path
 
 
 class VideoMetadataRegressionTestCase(unittest.TestCase):
@@ -126,7 +164,8 @@ class VideoMetadataRegressionTestCase(unittest.TestCase):
 
         self.assertNotIn("moviepy", required_dependencies)
         self.assertIn("video = [", optional_dependencies)
-        self.assertIn('"moviepy==1.0.3"', optional_dependencies)
+        self.assertIn('"imageio-ffmpeg>=0.2.0"', optional_dependencies)
+        self.assertNotIn('"moviepy==1.0.3"', optional_dependencies)
 
     def test_story_builder_import_does_not_require_moviepy(self):
         sys.modules.pop("instagrapi.story", None)
@@ -145,7 +184,10 @@ class VideoMetadataRegressionTestCase(unittest.TestCase):
             with self.assertRaises(RuntimeError) as ctx:
                 story.StoryBuilder(Path("video.mp4")).video()
 
-        self.assertIn("instagrapi[video]", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("instagrapi[video]", message)
+        self.assertIn("moviepy==2.2.1", message)
+        self.assertIn("--no-deps", message)
 
     def test_prepare_video_reports_video_extra_without_moviepy(self):
         from instagrapi.image_util import prepare_video
@@ -154,4 +196,49 @@ class VideoMetadataRegressionTestCase(unittest.TestCase):
             with self.assertRaises(RuntimeError) as ctx:
                 prepare_video("video.mp4")
 
-        self.assertIn("instagrapi[video]", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("instagrapi[video]", message)
+        self.assertIn("moviepy==2.2.1", message)
+        self.assertIn("--no-deps", message)
+
+    def test_story_builder_photo_generates_video_with_moviepy_2(self):
+        from PIL import Image
+
+        from instagrapi.story import StoryBuilder
+        from instagrapi.utils.video import read_video_metadata
+
+        self.assertEqual(importlib.metadata.version("moviepy"), "2.2.1")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            image = tmpdir / "photo.jpg"
+            Image.new("RGB", (720, 1280), "white").save(image)
+
+            build = StoryBuilder(image, caption="MoviePy 2").photo(max_duration=1, link="https://example.com")
+            try:
+                output = Path(build.path)
+                self.assertTrue(output.exists())
+                self.assertGreater(output.stat().st_size, 0)
+                metadata = read_video_metadata(output)
+                self.assertEqual((metadata.width, metadata.height), (720, 1280))
+                self.assertAlmostEqual(metadata.duration, 1.0, delta=0.25)
+            finally:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(build.path)
+
+    def test_prepare_video_generates_thumbnail_with_moviepy_2(self):
+        from instagrapi.image_util import prepare_video
+
+        self.assertEqual(importlib.metadata.version("moviepy"), "2.2.1")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_real_mp4(Path(tmpdir))
+            video_data, size, duration, thumbnail_data = prepare_video(
+                str(path),
+                max_size=None,
+                aspect_ratios=None,
+                skip_reencoding=True,
+            )
+
+        self.assertGreater(len(video_data), 0)
+        self.assertEqual(size, [640, 360])
+        self.assertAlmostEqual(duration, 4.0, delta=0.25)
+        self.assertGreater(len(thumbnail_data), 0)


### PR DESCRIPTION
## Summary
- migrate StoryBuilder, prepare_video(), thumbnail generation, and Reel music composition to the MoviePy 2 API
- keep Pillow 12.2.0 as the security floor and install MoviePy 2.2.1 with --no-deps in CI because upstream MoviePy 2.2.1 declares Pillow<12
- add real MoviePy 2.2.1 video generation coverage for StoryBuilder.photo() and prepare_video()
- document MoviePy 1.x migration notes and Android/Pydroid/Termux install commands

Fixes #2507

## Tests
- .venv/bin/python -m pytest tests/regression/test_video_metadata.py tests/regression/test_upload.py -q
- .venv/bin/python -m pytest tests/regression -q
- clean core install: pip install .; verified Pillow 12.2.0 and no moviepy import
- clean test/video install: pip install .[test]; pip install --no-deps moviepy==2.2.1; pytest tests/regression/test_video_metadata.py -q
- .venv/bin/python -m ruff check --output-format=github .
- .venv/bin/python -m ruff format --check .
- .venv/bin/python -m bandit -c pyproject.toml -r instagrapi
- .venv/bin/python -m mkdocs build --strict