### PR TITLE
Fix Reel Facebook crosspost payload

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -321,7 +321,7 @@ Upload medias to your feed. Common arguments:
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
-| clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None, attempt_id: str = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
+| clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
 | clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload Reels Clip as reel with music metadata
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
@@ -353,7 +353,8 @@ contains availability flags, not the full Account Center destination state, and 
 `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. For those accounts, pass
 `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually
 with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination,
-instagrapi raises `ClientError` before uploading video bytes.
+instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated
+automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
 
 ### Example:
 

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -321,7 +321,7 @@ Upload medias to your feed. Common arguments:
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
-| clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
+| clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None, attempt_id: str = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
 | clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload Reels Clip as reel with music metadata
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
@@ -345,11 +345,15 @@ configure, so keep upload-side error handling for backend eligibility decisions.
 `trial_params={"graduation_strategy": "manual"}` by default and disables feed preview for the upload.
 
 Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer
-use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields. Use
-`clip_upload(..., share_to_facebook=True)` to fetch `clip_share_to_fb_config()` and build the configure payload before
-video bytes are uploaded. If the account is not linked or Instagram does not return a Reel Facebook destination,
-instagrapi raises `ClientError` before upload. Advanced callers can pass `fb_destination_id` and `fb_destination_type`,
-or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`.
+use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as
+`share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
+
+`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response
+contains availability flags, not the full Account Center destination state, and some linked accounts can still return
+`share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. For those accounts, pass
+`fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually
+with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination,
+instagrapi raises `ClientError` before uploading video bytes.
 
 ### Example:
 
@@ -370,11 +374,13 @@ or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`.
 ...     "/app/reel.mp4",
 ...     "Cross-posting this Reel to Facebook",
 ...     share_to_facebook=True,
+...     fb_destination_id="FACEBOOK_DESTINATION_ID",
+...     fb_destination_type="USER",
 ... )
 
 >>> fb_extra = cl.clip_share_to_fb_extra_data(
 ...     destination_id="FACEBOOK_DESTINATION_ID",
-...     destination_type="DESTINATION_TYPE_FROM_APP_CONFIG",
+...     destination_type="USER",
 ... )
 >>> reel = cl.clip_upload(
 ...     "/app/reel.mp4",

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -192,6 +192,7 @@ class UploadClipMixin:
         destination_audience_type: Optional[str] = None,
         xpost_surface: str = "IG_REELS_COMPOSER",
         validation_check_bypass: Optional[bool] = None,
+        attempt_id: Optional[str] = None,
     ) -> Dict[str, object]:
         """
         Build configure fields for sharing a Reel to Facebook.
@@ -203,18 +204,22 @@ class UploadClipMixin:
         Parameters
         ----------
         config: Dict[str, object], optional
-            Response from ``clip_share_to_fb_config()``. When omitted, this
-            method fetches it.
+            Facebook cross-posting config. The lightweight
+            ``clip_share_to_fb_config()`` response contains availability flags;
+            app/draft configs can also contain destination fields.
         destination_id: str, optional
             Facebook destination id. Overrides config values.
         destination_type: str, optional
-            Facebook destination type/posting type. Overrides config values.
+            Facebook destination type/posting type, ``USER`` or ``PAGE``.
+            Overrides config values.
         destination_audience_type: str, optional
             Facebook Reels audience type, e.g. ``PUBLIC``.
         xpost_surface: str, optional
             Cross-posting surface reported by the Instagram app.
         validation_check_bypass: bool, optional
             Whether to bypass app-side FB validation. Overrides config values.
+        attempt_id: str, optional
+            Cross-post configure attempt id. Generated when omitted.
 
         Returns
         -------
@@ -222,8 +227,6 @@ class UploadClipMixin:
             Extra configure data for ``clip_upload(..., extra_data=...)``.
         """
         fb_config = (config if config is not None else self.clip_share_to_fb_config()) or {}
-        if fb_config.get("share_to_fb_unavailable"):
-            raise ClientError("Facebook Reel sharing is unavailable for this account")
         if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
             raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
 
@@ -232,11 +235,12 @@ class UploadClipMixin:
             or fb_config.get("share_to_fb_destination_id")
             or fb_config.get("reels_destination_id")
             or fb_config.get("destination_id")
+            or fb_config.get("account_id")
         )
         destination_type = (
             destination_type
             or fb_config.get("share_to_fb_destination_type")
-            or fb_config.get("reels_cross_app_share_type")
+            or fb_config.get("destination_type")
             or fb_config.get("posting_type")
         )
         destination_audience_type = (
@@ -246,8 +250,18 @@ class UploadClipMixin:
             or fb_config.get("audience_type")
         )
         if validation_check_bypass is None:
-            validation_check_bypass = fb_config.get("reels_cross_app_share_fb_validation_check_bypass")
+            validation_check_bypass = fb_config.get(
+                "reels_cross_app_share_fb_validation_check_bypass",
+                fb_config.get("cross_app_share_fb_validation_check_bypass"),
+            )
 
+        has_destination = bool(destination_id and destination_type)
+        if fb_config.get("share_to_fb_unavailable") and not has_destination:
+            raise ClientError(
+                "Facebook Reel sharing is unavailable from the Reel preflight response. "
+                "If the Instagram app can still cross-post manually, pass destination_id "
+                "and destination_type explicitly."
+            )
         if not destination_id:
             raise ClientError(
                 "Facebook Reel sharing configuration has no destination. "
@@ -255,9 +269,15 @@ class UploadClipMixin:
             )
         if not destination_type:
             raise ClientError(
-                "Facebook Reel sharing configuration has no destination type. "
-                "Pass destination_type from a linked-account app capture."
+                "Facebook Reel sharing configuration has no destination type. Pass destination_type as USER or PAGE."
             )
+        destination_type = str(destination_type).upper()
+        if destination_type not in {"USER", "PAGE"}:
+            raise ClientError(
+                "Facebook Reel sharing destination type must be USER or PAGE. "
+                "Do not pass reels_cross_app_share_type here."
+            )
+        attempt_id = attempt_id or str(uuid4())
 
         data = {
             "share_to_facebook": "1",
@@ -266,6 +286,8 @@ class UploadClipMixin:
             "share_to_fb_destination_id": destination_id,
             "share_to_fb_destination_type": destination_type,
             "xpost_surface": xpost_surface,
+            "no_token_crosspost": "1",
+            "attempt_id": attempt_id,
         }
         if destination_audience_type:
             data["share_to_fb_destination_audience_type"] = destination_audience_type
@@ -325,7 +347,8 @@ class UploadClipMixin:
         fb_destination_id: str, optional
             Facebook destination id used when share_to_facebook is True.
         fb_destination_type: str, optional
-            Facebook destination type used when share_to_facebook is True.
+            Facebook destination type used when share_to_facebook is True,
+            ``USER`` or ``PAGE``.
         fb_destination_audience_type: str, optional
             Facebook Reels audience type, e.g. ``PUBLIC``.
         fb_xpost_surface: str, optional

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -286,7 +286,7 @@ class UploadClipMixin:
             "share_to_fb_destination_id": destination_id,
             "share_to_fb_destination_type": destination_type,
             "xpost_surface": xpost_surface,
-            "no_token_crosspost": "1",
+            "no_token_crosspost": "1",  # nosec B105
             "attempt_id": attempt_id,
         }
         if destination_audience_type:

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -376,4 +376,7 @@ class ClientFacebookReelCrosspostLiveTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(extra_data["is_reel_shared_to_fb"])
         self.assertTrue(extra_data["share_to_fb_destination_id"])
         self.assertTrue(extra_data["share_to_fb_destination_type"])
+        self.assertIn(extra_data["share_to_fb_destination_type"], {"USER", "PAGE"})
         self.assertEqual(extra_data["xpost_surface"], "IG_REELS_COMPOSER")
+        self.assertEqual(extra_data["no_token_crosspost"], "1")
+        self.assertTrue(extra_data["attempt_id"])

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -85,12 +85,13 @@ class UploadRegressionTestCase(unittest.TestCase):
             "is_account_linked": True,
             "reels_share_to_facebook": True,
             "reels_destination_id": "fb-destination-id",
-            "reels_cross_app_share_type": "2",
+            "posting_type": "USER",
+            "reels_cross_app_share_type": "CROSSPOST",
             "reels_cross_app_share_fb_validation_check_bypass": True,
             "status": "ok",
         }
 
-        result = client.clip_share_to_fb_extra_data(config=config)
+        result = client.clip_share_to_fb_extra_data(config=config, attempt_id="attempt-id")
 
         self.assertEqual(
             result,
@@ -99,11 +100,62 @@ class UploadRegressionTestCase(unittest.TestCase):
                 "is_reel_shared_to_fb": True,
                 "share_to_facebook_reels": True,
                 "share_to_fb_destination_id": "fb-destination-id",
-                "share_to_fb_destination_type": "2",
+                "share_to_fb_destination_type": "USER",
                 "cross_app_share_fb_validation_check_bypass": True,
                 "xpost_surface": "IG_REELS_COMPOSER",
+                "no_token_crosspost": "1",
+                "attempt_id": "attempt-id",
             },
         )
+
+    def test_clip_share_to_fb_extra_data_allows_explicit_destination_when_preflight_is_unavailable(self):
+        client = self.build_client()
+
+        result = client.clip_share_to_fb_extra_data(
+            config={
+                "share_to_fb_unavailable": True,
+                "status": "ok",
+            },
+            destination_id="fb-destination-id",
+            destination_type="USER",
+            attempt_id="attempt-id",
+        )
+
+        self.assertEqual(result["share_to_fb_destination_id"], "fb-destination-id")
+        self.assertEqual(result["share_to_fb_destination_type"], "USER")
+        self.assertEqual(result["attempt_id"], "attempt-id")
+
+    def test_clip_share_to_fb_extra_data_allows_config_destination_when_preflight_is_unavailable(self):
+        client = self.build_client()
+
+        result = client.clip_share_to_fb_extra_data(
+            config={
+                "share_to_fb_unavailable": True,
+                "reels_destination_id": "fb-destination-id",
+                "posting_type": "PAGE",
+                "status": "ok",
+            },
+            attempt_id="attempt-id",
+        )
+
+        self.assertEqual(result["share_to_fb_destination_id"], "fb-destination-id")
+        self.assertEqual(result["share_to_fb_destination_type"], "PAGE")
+
+    def test_clip_share_to_fb_extra_data_does_not_use_cross_app_share_type_as_destination_type(self):
+        client = self.build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            client.clip_share_to_fb_extra_data(
+                config={
+                    "enabled": True,
+                    "is_account_linked": True,
+                    "reels_destination_id": "fb-destination-id",
+                    "reels_cross_app_share_type": "CROSSPOST",
+                    "status": "ok",
+                }
+            )
+
+        self.assertIn("destination type", str(ctx.exception))
 
     def test_clip_share_to_fb_extra_data_raises_without_destination(self):
         client = self.build_client()
@@ -541,9 +593,11 @@ class UploadRegressionTestCase(unittest.TestCase):
             "is_reel_shared_to_fb": True,
             "share_to_facebook_reels": True,
             "share_to_fb_destination_id": "fb-destination-id",
-            "share_to_fb_destination_type": "2",
+            "share_to_fb_destination_type": "USER",
             "cross_app_share_fb_validation_check_bypass": False,
             "xpost_surface": "IG_REELS_COMPOSER",
+            "no_token_crosspost": "1",
+            "attempt_id": "attempt-id",
         }
 
         with mock.patch.object(client, "clip_share_to_fb_extra_data", return_value=fb_extra) as share_to_fb_extra:


### PR DESCRIPTION
## Summary
- align Reel Facebook crosspost configure fields with the current Android app payload
- stop treating reels_cross_app_share_type as share_to_fb_destination_type; require USER or PAGE instead
- allow explicit/config-provided destinations to bypass false-negative share_to_fb_unavailable preflight responses
- document explicit fb_destination_id/fb_destination_type usage

## Tests
- python -m pytest tests/regression/test_upload.py -q
- python -m ruff check --output-format=github instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py docs/usage-guide/media.md
- targeted live preflight test reached Instagram and skipped because no linked Facebook Reel destination was available for the live account

Closes #2491