### PR TITLE
Add client TLS verification setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
 
+TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
+
 If your project uses [uv](https://docs.astral.sh/uv/), you can add the package with:
 
 ```bash

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -33,7 +33,7 @@
 
 `instagrapi` provides the following `Interactions` that can be used to control and get the information about your `Instagram` account:
 
-* `Client(settings: dict = {}, proxy: str = "")` - Init `instagrapi` client
+* `Client(settings: dict = {}, proxy: str = "", tls_verify: Union[bool, str] = True)` - Init `instagrapi` client
 
 ``` python
 cl.login("instagrapi", "42")
@@ -61,6 +61,7 @@ print(cl.user_info(cl.user_id))
 | session\_retry\_backoff\_factor | Backoff factor for transport-level retries
 | public\_transport | Public web transport: `requests` by default, or `curl` when `instagrapi[curl]` is installed
 | public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
+| tls\_verify | TLS certificate verification: `True` by default, `False` for temporary trusted MITM debugging, or a CA bundle path
 
 
 ### Login
@@ -110,7 +111,8 @@ settings = {
    "session_retry_backoff_factor": 2,
    "session_retry_statuses": [429, 500, 502, 503, 504],
    "public_transport": "requests",
-   "public_transport_impersonate": "chrome136"
+   "public_transport_impersonate": "chrome136",
+   "tls_verify": True
 }
 
 cl = Client(settings)
@@ -163,6 +165,7 @@ cl.get_timeline_feed()  # check session
 | set_locale(locale: str = "en_US")        | bool | Set locale (advice: use the locale of your proxy)
 | set_timezone_offset(seconds: int)        | bool | Set timezone offset in seconds
 | set_retry_config(...)                    | bool | Configure request timeout plus public/manual and session/transport retry settings
+| set_tls_verify(tls_verify: bool \| str)  | bool | Update TLS certificate verification for existing public, private and GraphQL sessions
 
 Example:
 
@@ -196,6 +199,24 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 The default remains `public_transport="requests"`. Private mobile API requests still use the regular mobile session.
 See [Public Transport](public-transport.md) for live comparison results and caveats.
+
+### TLS verification and debugging proxies
+
+By default `instagrapi` verifies TLS certificates on all client sessions. Keep this enabled for production, residential proxies, and normal CONNECT-tunnel proxies.
+
+If you use a trusted local debugging proxy that intercepts TLS, prefer installing its CA certificate and pointing the client at that bundle:
+
+```python
+cl = Client(tls_verify="/path/to/proxy-ca.pem")
+```
+
+For short local captures you can disable verification explicitly:
+
+```python
+cl = Client(tls_verify=False)
+```
+
+Do not disable TLS verification on untrusted networks or shared proxies because session cookies and passwords can be intercepted.
 
 ``` python
 cl = Client()

--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -106,6 +106,7 @@ class Client(
         override_app_version: bool = False,
         **kwargs,
     ):
+        self.tls_verify = kwargs.pop("tls_verify", True)
         self.request_timeout = kwargs.pop("request_timeout", 1)
         self.public_request_retries_count = kwargs.pop("public_request_retries_count", 3)
         self.public_request_retries_timeout = kwargs.pop("public_request_retries_timeout", 2)

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -443,6 +443,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         locale = self.settings.get("locale", self.locale)
         country = self.settings.get("country", self.country)
         country_code = self.settings.get("country_code", self.country_code)
+        self.set_tls_verify(self.settings.get("tls_verify", self.tls_verify))
         self.set_retry_config(
             request_timeout=self.settings.get("request_timeout", self.request_timeout),
             public_request_retries_count=self.settings.get(
@@ -741,6 +742,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "session_retry_statuses": self.session_retry_statuses,
             "public_transport": self.public_transport,
             "public_transport_impersonate": self.public_transport_impersonate,
+            "tls_verify": self.tls_verify,
         }
 
     def set_settings(self, settings: Dict) -> bool:
@@ -794,6 +796,16 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         """
         with open(path, "w") as fp:
             json.dump(self.get_settings(), fp, indent=4)
+        return True
+
+    def set_tls_verify(self, tls_verify: Union[bool, str]) -> bool:
+        self.tls_verify = tls_verify
+        for name in ("public", "private", "graphql"):
+            session = getattr(self, name, None)
+            if session is not None:
+                session.verify = tls_verify
+        if self.settings is not None:
+            self.settings["tls_verify"] = tls_verify
         return True
 
     def set_retry_config(

--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -142,7 +142,7 @@ class ChallengeResolveMixin:
         ajax_seed = "#PWD_INSTAGRAM_BROWSER:0:%s:" % str(int(time.time()))
         instagram_ajax = hashlib.sha256(ajax_seed.encode()).hexdigest()[:12]
         session = requests.Session()
-        session.verify = False  # fix SSLError/HTTPSConnectionPool
+        session.verify = self.tls_verify
         session.proxies = self.private.proxies
         session.headers.update(
             {

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -916,6 +916,7 @@ class DirectMixin:
         url = f"https://rupload.facebook.com/messenger_video/{entity_name}"
 
         sess = requests.Session()
+        sess.verify = self.tls_verify
         if getattr(self, "proxy", None):
             sess.proxies = {"http": self.proxy, "https": self.proxy}
 
@@ -1066,6 +1067,7 @@ class DirectMixin:
         url = f"https://rupload.facebook.com/messenger_audio/{entity}"
 
         sess = requests.Session()
+        sess.verify = self.tls_verify
         if getattr(self, "proxy", None):
             sess.proxies = {"http": self.proxy, "https": self.proxy}
 

--- a/instagrapi/mixins/graphql.py
+++ b/instagrapi/mixins/graphql.py
@@ -76,7 +76,7 @@ class PrivateGraphQLRequestMixin:
 
     def __init__(self, *args, **kwargs):
         self.graphql = requests.Session()
-        self.graphql.verify = False
+        self.graphql.verify = getattr(self, "tls_verify", True)
         self.graphql.headers.update(
             {
                 "Connection": "Keep-Alive",

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -94,7 +94,7 @@ class PrivateRequestMixin:
     def __init__(self, *args, **kwargs):
         session = requests.Session()
         self.private = session
-        self.private.verify = False  # fix SSLError/HTTPSConnectionPool
+        self.private.verify = getattr(self, "tls_verify", True)
         self.email = kwargs.pop("email", None)
         self.phone_number = kwargs.pop("phone_number", None)
         self.request_timeout = kwargs.pop("request_timeout", getattr(self, "request_timeout", self.request_timeout))

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -58,7 +58,7 @@ class PublicRequestMixin:
     def __init__(self, *args, **kwargs):
         session = requests.Session()
         self.public = session
-        self.public.verify = False  # fix SSLError/HTTPSConnectionPool
+        self.public.verify = getattr(self, "tls_verify", True)
         self.public_transport = self._normalize_public_transport(
             kwargs.pop("public_transport", getattr(self, "public_transport", self.public_transport))
         )

--- a/tests/regression/test_tls_verify.py
+++ b/tests/regression/test_tls_verify.py
@@ -1,0 +1,74 @@
+from unittest import mock
+
+from instagrapi import Client
+
+
+class _FakeResponse:
+    status_code = 200
+    text = ""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self):
+        self.verify = None
+        self.proxies = {}
+        self.get_calls = []
+        self.post_calls = []
+
+    def get(self, *args, **kwargs):
+        self.get_calls.append((args, kwargs))
+        return _FakeResponse({"offset": 0})
+
+    def post(self, *args, **kwargs):
+        self.post_calls.append((args, kwargs))
+        return _FakeResponse({"media_id": 123})
+
+
+def _assert_client_tls_verify(client, expected):
+    assert client.tls_verify == expected
+    assert client.public.verify == expected
+    assert client.private.verify == expected
+    assert client.graphql.verify == expected
+
+
+def test_default_client_tls_verify_is_enabled():
+    _assert_client_tls_verify(Client(), True)
+
+
+def test_client_tls_verify_can_be_disabled_for_debugging_proxy():
+    _assert_client_tls_verify(Client(tls_verify=False), False)
+
+
+def test_client_tls_verify_accepts_ca_bundle_path_and_roundtrips_settings():
+    ca_bundle = "/tmp/instagram-proxy-ca.pem"
+    client = Client(tls_verify=ca_bundle)
+
+    settings = client.get_settings()
+    assert settings["tls_verify"] == ca_bundle
+
+    restored = Client(settings=settings)
+    _assert_client_tls_verify(restored, ca_bundle)
+
+
+def test_set_tls_verify_updates_existing_sessions():
+    client = Client()
+
+    assert client.set_tls_verify(False) is True
+    _assert_client_tls_verify(client, False)
+
+
+def test_direct_rupload_fresh_sessions_use_client_tls_verify():
+    client = Client(tls_verify="/tmp/direct-ca.pem")
+    fake_session = _FakeSession()
+
+    with mock.patch("requests.Session", return_value=fake_session):
+        media_id = client._video_rupload(b"video-bytes", "entity-name", "waterfall-id")
+
+    assert media_id == 123
+    assert fake_session.verify == "/tmp/direct-ca.pem"


### PR DESCRIPTION
## Summary
- add Client(tls_verify=...) and set_tls_verify(...)
- propagate TLS verification to public, private, GraphQL, challenge, and Direct rupload sessions
- document CA bundle / temporary debug disable usage

## Tests
- .venv/bin/pytest tests/regression/test_tls_verify.py tests/regression/test_public_transport.py tests/regression/test_challenge.py tests/regression/test_direct.py -q
- .venv/bin/ruff check instagrapi tests/regression/test_tls_verify.py
- .venv/bin/mkdocs build --strict