### PR TITLE
Add sorted follower retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ cl.delete_note(note.id)
 * Works with users, media, comments, locations, hashtags, collections, notes, direct messages, and insights
 * Supports story building with mentions, hashtags, link stickers, and media stickers
 * Includes helpers for current location search and notes flows
+* Supports mobile follower sorting with `date_followed_latest` and `date_followed_earliest`
 * App-side discovery surfaces: `chaining`, `fetch_suggestion_details`, `discover_recommended_accounts_for_category_v1`, `user_stream_*`, `user_web_profile_info_v1`
 * v2 search SERPs: `fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`
 * Alternative media-info path (`media_info_v2`) for ad-tagged / sponsored media that the canonical endpoint refuses

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -6,7 +6,7 @@ View a list of a user's medias, following and followers
 
 | Method                                        | Return                | Description                                                  |
 |-----------------------------------------------|-----------------------|--------------------------------------------------------------|
-| user_followers(user_id: str, amount: int = 0) | Dict\[int, UserShort] | Get dict of followers users (amount=0 - fetch all followers) |
+| user_followers(user_id: str, amount: int = 0, order: str = None) | Dict\[int, UserShort] | Get dict of followers users (amount=0 - fetch all followers). Use `order="date_followed_latest"` or `order="date_followed_earliest"` for mobile follower sorting |
 | user_following(user_id: str, amount: int = 0) | Dict\[int, UserShort] | Get dict of following users (amount=0 - fetch all)           |
 | search_followers(user_id: str, query: str)    | List[UserShort]       | Search by followers                                          |
 | search_following(user_id: str, query: str)    | List[UserShort]       | Search by following                                          |
@@ -66,8 +66,8 @@ Low level methods:
 |-------------------------------------------------------------------------------------|-----------------------------|----------------------------------------------------------------------------|
 | user_followers_gql_chunk(user_id: str, max_amount: int = 0, end_cursor: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Public Graphql API and end_cursor      |
 | user_followers_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's followers information by Public Graphql API                     |
-| user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "")        | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor) |
-| user_followers_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's followers information by Private Mobile API                     |
+| user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "", order: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor). Supports `date_followed_latest` and `date_followed_earliest` |
+| user_followers_v1(user_id: str, amount: int = 0, order: str = None)                 | List[UserShort]             | Get user's followers information by Private Mobile API. Supports `date_followed_latest` and `date_followed_earliest` |
 | user_following_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's following users information by Private Mobile API               |
 | user_follow_requests_chunk(max_amount: int = 0, max_id: str = "")                   | Tuple[List[UserShort], str] | Get pending incoming follow requests by Private Mobile API and max_id      |
 | user_following_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
@@ -131,6 +131,13 @@ dict_keys([5563084402, 43848984510, 1498977320, ...])
  'external_url': HttpUrl('https://example.org/', scheme='https', host='example.org', tld='com', host_type='domain', path='/'),
  'is_business': False}
 
+```
+
+Sorted followers:
+
+``` python
+latest_followers = cl.user_followers(cl.user_id, amount=50, order="date_followed_latest")
+earliest_followers = cl.user_followers_v1(cl.user_id, amount=50, order="date_followed_earliest")
 ```
 
 Example: We go around the list of our followers and unfollow from them:

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -28,6 +28,7 @@ from instagrapi.utils.serialization import dumps, json_value
 
 MAX_USER_COUNT = 200
 INFO_FROM_MODULES = ("self_profile", "feed_timeline", "reel_feed_timeline")
+FOLLOWERS_ORDERS = ("date_followed_latest", "date_followed_earliest")
 USER_WEB_PROFILE_DOC_ID = "26762473490008061"
 
 logger = logging.getLogger(__name__)
@@ -36,8 +37,10 @@ try:
     from typing import Literal
 
     INFO_FROM_MODULE = Literal[INFO_FROM_MODULES]
+    FOLLOWERS_ORDER = Literal[FOLLOWERS_ORDERS]
 except Exception:
     INFO_FROM_MODULE = str
+    FOLLOWERS_ORDER = str
 
 
 class UserMixin:
@@ -891,7 +894,11 @@ class UserMixin:
         return users
 
     def user_followers_v1_chunk(
-        self, user_id: str, max_amount: int = 0, max_id: str = ""
+        self,
+        user_id: str,
+        max_amount: int = 0,
+        max_id: str = "",
+        order: FOLLOWERS_ORDER = None,
     ) -> Tuple[List[UserShort], str]:
         """
         Get user's followers information by Private Mobile API and max_id (cursor)
@@ -904,6 +911,8 @@ class UserMixin:
             Maximum number of media to return, default is 0 - Inf
         max_id: str, optional
             Max ID, default value is empty String
+        order: str, optional
+            Followers sort order: date_followed_latest or date_followed_earliest
 
         Returns
         -------
@@ -920,6 +929,8 @@ class UserMixin:
                 "query": "",
                 "enable_groups": "true",
             }
+            if order:
+                params["order"] = order
             if max_id:
                 params["max_id"] = max_id
             result = self.private_request(
@@ -937,7 +948,12 @@ class UserMixin:
                 break
         return users, max_id
 
-    def user_followers_v1(self, user_id: str, amount: int = 0) -> List[UserShort]:
+    def user_followers_v1(
+        self,
+        user_id: str,
+        amount: int = 0,
+        order: FOLLOWERS_ORDER = None,
+    ) -> List[UserShort]:
         """
         Get user's followers information by Private Mobile API
 
@@ -947,18 +963,26 @@ class UserMixin:
             User id of an instagram account
         amount: int, optional
             Maximum number of media to return, default is 0 - Inf
+        order: str, optional
+            Followers sort order: date_followed_latest or date_followed_earliest
 
         Returns
         -------
         List[UserShort]
             List of objects of User type
         """
-        users, _ = self.user_followers_v1_chunk(str(user_id), amount)
+        users, _ = self.user_followers_v1_chunk(str(user_id), amount, order=order)
         if amount:
             users = users[:amount]
         return users
 
-    def user_followers(self, user_id: str, use_cache: bool = True, amount: int = 0) -> Dict[str, UserShort]:
+    def user_followers(
+        self,
+        user_id: str,
+        use_cache: bool = True,
+        amount: int = 0,
+        order: FOLLOWERS_ORDER = None,
+    ) -> Dict[str, UserShort]:
         """
         Get user's followers
 
@@ -970,6 +994,9 @@ class UserMixin:
             Whether or not to use information from cache, default value is True
         amount: int, optional
             Maximum number of media to return, default is 0 - Inf
+        order: str, optional
+            Followers sort order: date_followed_latest or date_followed_earliest.
+            Sorted requests use the private mobile endpoint and bypass cache.
 
         Returns
         -------
@@ -977,6 +1004,9 @@ class UserMixin:
             Dict of user_id and User object
         """
         user_id = str(user_id)
+        if order:
+            users = self.user_followers_v1(user_id, amount, order=order)
+            return {user.pk: user for user in users}
         users = self._users_followers.get(user_id, {})
         if not use_cache or not users or (amount and len(users) < amount):
             try:

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -9,6 +9,12 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(len(followers) == 10)
         self.assertIsInstance(list(followers.values())[0], UserShort)
 
+    def test_user_followers_sorted_v1(self):
+        user_id = self.user_id_from_username("instagram")
+        followers = self.cl.user_followers_v1(user_id, amount=5, order="date_followed_latest")
+        self.assertTrue(len(followers) == 5)
+        self.assertIsInstance(followers[0], UserShort)
+
 
 class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
     def test_user_short_gql(self):

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -225,6 +225,41 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         params = private_request.call_args.kwargs["params"]
         self.assertEqual(params["max_id"], "cursor")
 
+    def test_user_followers_v1_chunk_sends_order_when_provided(self):
+        client = self.build_private_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"users": [], "next_max_id": None},
+        ) as private_request:
+            client.user_followers_v1_chunk("123", order="date_followed_latest")
+
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(params["order"], "date_followed_latest")
+
+    def test_user_followers_with_order_uses_private_api_without_cache(self):
+        client = self.build_private_client()
+        cached_user = UserShort(pk="old", username="cached")
+        sorted_user = UserShort(pk="new", username="sorted")
+        client._users_followers = {"123": {cached_user.pk: cached_user}}
+
+        with mock.patch.object(
+            client,
+            "user_followers_v1",
+            return_value=[sorted_user],
+        ) as user_followers_v1:
+            with mock.patch.object(
+                client,
+                "user_followers_gql",
+                side_effect=AssertionError("sorted followers should use private API"),
+            ):
+                followers = client.user_followers("123", order="date_followed_latest")
+
+        user_followers_v1.assert_called_once_with("123", 0, order="date_followed_latest")
+        self.assertEqual(list(followers), ["new"])
+        self.assertEqual(list(client._users_followers["123"]), ["old"])
+
     def test_user_following_v1_chunk_omits_empty_max_id_on_first_page(self):
         client = self.build_private_client()
 


### PR DESCRIPTION
## Summary

- add `order` support to private follower retrieval via `user_followers_v1_chunk`, `user_followers_v1`, and `user_followers`
- support the current mobile sort values `date_followed_latest` and `date_followed_earliest`
- keep sorted high-level calls on the private mobile endpoint and out of the existing followers cache
- document sorted follower usage and add regression/live coverage

Closes #2512.

## Tests

- `uv run --extra test python -m pytest tests/regression/test_user.py`
- `uv run --extra test ruff check instagrapi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`
- `PYTHONPATH=/tmp/instagrapi-followers-sorting-2512 ~/instagrapi/.venv/bin/python -m pytest tests/live/test_user.py::ClientUserTestCase::test_user_followers_sorted_v1 -s` on the live test host
