### PR TITLE
Add private GraphQL follow list ordering

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -76,8 +76,8 @@ Low level methods:
 | user_info_by_username_a1(username: str)                                             | dict                        | Raw public A1 username payload                                             |
 | user_info_v2_gql(user_id: str)                                                      | User                        | Profile lookup through current doc_id GraphQL                              |
 | user_info_by_username_v2_gql(username: str)                                         | User                        | Resolve username through doc_id search, then fetch profile                 |
-| private_graphql_followers_list(user_id: str, rank_token: str, ...)                  | dict                        | Raw private mobile GraphQL followers list                                  |
-| private_graphql_following_list(user_id: str, rank_token: str, ...)                  | dict                        | Raw private mobile GraphQL following list                                  |
+| private_graphql_followers_list(user_id: str, rank_token: str, ..., order: str = None) | dict                      | Raw private mobile GraphQL followers list. Supports `date_followed_latest` and `date_followed_earliest` |
+| private_graphql_following_list(user_id: str, rank_token: str, ..., order: str = None) | dict                      | Raw private mobile GraphQL following list. Supports mobile `order` when accepted by Instagram |
 | private_graphql_clips_profile(target_user_id: str, ...)                             | dict                        | Raw private mobile GraphQL profile Reels stream                            |
 | private_graphql_inbox_tray_for_user(user_id: str, ...)                              | dict                        | Raw private mobile GraphQL inbox tray query                                |
 
@@ -138,6 +138,12 @@ Sorted followers:
 ``` python
 latest_followers = cl.user_followers(cl.user_id, amount=50, order="date_followed_latest")
 earliest_followers = cl.user_followers_v1(cl.user_id, amount=50, order="date_followed_earliest")
+```
+
+Raw private GraphQL helpers expose the same mobile `order` variable for callers that need the `FollowersList`/`FollowingList` payload directly:
+
+``` python
+payload = cl.private_graphql_followers_list(cl.user_id, cl.rank_token, order="date_followed_latest")
 ```
 
 Example: We go around the list of our followers and unfollow from them:

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1881,9 +1881,10 @@ class UserMixin:
         self,
         user_id: str,
         rank_token: str,
-        client_doc_id: str = "28479704798344003308647327139",
+        client_doc_id: str = "28479704797510738576165798526",
         max_id: int = None,
         priority: str = None,
+        order: str = None,
         exclude_field_is_favorite: bool = None,
         exclude_unused_fields: bool = None,
     ) -> dict:
@@ -1892,17 +1893,25 @@ class UserMixin:
             "enableGroups": True,
         }
         variables = {
-            "include_unseen_count": False,
-            "query": "",
-            "include_biography": False,
             "user_id": str(user_id),
+            "skip_suggested_users": True,
+            "skip_more_groups_available": True,
+            "skip_friendship_followers_fields": True,
             "request_data": request_data,
+            "skip_page_size": True,
+            "skip_pending_admins": True,
+            "skip_has_more": True,
             "search_surface": "follow_list_page",
+            "query": "",
+            "skip_big_list": True,
+            "include_unseen_count": True,
         }
         if exclude_field_is_favorite is not None:
             variables["exclude_field_is_favorite"] = exclude_field_is_favorite
         if max_id is not None:
             variables["max_id"] = max_id
+        if order is not None:
+            variables["order"] = order
         if exclude_unused_fields is not None:
             variables["exclude_unused_fields"] = exclude_unused_fields
         return self.private_graphql_query_request(
@@ -1911,15 +1920,17 @@ class UserMixin:
             variables=variables,
             client_doc_id=client_doc_id,
             priority=priority,
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
         )
 
     def private_graphql_following_list(
         self,
         user_id: str,
         rank_token: str,
-        client_doc_id: str = "16104639289023609826830352479",
+        client_doc_id: str = "161046392817718486717479294775",
         max_id: int = None,
         priority: str = None,
+        order: str = None,
         exclude_field_is_favorite: bool = None,
         exclude_unused_fields: bool = None,
     ) -> dict:
@@ -1929,17 +1940,31 @@ class UserMixin:
             "includes_hashtags": True,
         }
         variables = {
-            "include_unseen_count": False,
-            "enable_groups": True,
             "user_id": str(user_id),
+            "skip_use_clickable_see_more": True,
+            "skip_preview_hashtags": True,
+            "skip_should_limit_list_of_followers": True,
+            "skip_pending_admins": True,
+            "skip_more_groups_available": True,
+            "skip_friendship_followers_fields": False,
             "request_data": request_data,
-            "include_biography": False,
+            "skip_page_size": True,
+            "skip_friend_requests": True,
+            "skip_big_list": True,
             "query": "",
+            "include_profile_update_info": True,
+            "skip_suggested_users": True,
+            "include_unseen_count": True,
+            "skip_has_more": True,
+            "enable_groups": True,
+            "skip_hashtag_count": True,
         }
         if exclude_field_is_favorite is not None:
             variables["exclude_field_is_favorite"] = exclude_field_is_favorite
         if max_id is not None:
             variables["max_id"] = max_id
+        if order is not None:
+            variables["order"] = order
         if exclude_unused_fields is not None:
             variables["exclude_unused_fields"] = exclude_unused_fields
         return self.private_graphql_query_request(
@@ -1948,6 +1973,7 @@ class UserMixin:
             variables=variables,
             client_doc_id=client_doc_id,
             priority=priority,
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
         )
 
     def private_graphql_clips_profile(

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -15,6 +15,34 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(len(followers) == 5)
         self.assertIsInstance(followers[0], UserShort)
 
+    def test_private_graphql_followers_list_sorted(self):
+        user_id = self.user_id_from_username("instagram")
+        result = None
+        for _ in range(3):
+            try:
+                result = self.cl.private_graphql_followers_list(
+                    user_id,
+                    self.cl.rank_token,
+                    order="date_followed_latest",
+                )
+                break
+            except ClientGraphqlError:
+                time.sleep(2)
+        if result is None:
+            result = self.cl.private_graphql_followers_list(
+                user_id,
+                self.cl.rank_token,
+                order="date_followed_latest",
+            )
+
+        data = result.get("data") or {}
+        followers = next(
+            (value for key, value in data.items() if "xdt_api__v1__friendships__followers" in key),
+            None,
+        )
+        self.assertIsInstance(followers, dict)
+        self.assertGreater(len(followers.get("users", [])), 0)
+
 
 class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
     def test_user_short_gql(self):

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -599,23 +599,41 @@ class UserMixinRegressionTestCase(unittest.TestCase):
     def test_private_graphql_followers_list_builds_query_wrapper(self):
         client = Client()
         with mock.patch.object(client, "private_graphql_query_request", return_value={"data": {}}) as query:
-            client.private_graphql_followers_list("123", "rank", max_id=10, priority="u=3, i")
+            client.private_graphql_followers_list(
+                "123",
+                "rank",
+                max_id=10,
+                priority="u=3, i",
+                order="date_followed_latest",
+            )
 
         query.assert_called_once()
         self.assertEqual(query.call_args.kwargs["friendly_name"], "FollowersList")
         self.assertEqual(query.call_args.kwargs["root_field_name"], "xdt_api__v1__friendships__followers")
+        self.assertEqual(query.call_args.kwargs["client_doc_id"], "28479704797510738576165798526")
         self.assertEqual(query.call_args.kwargs["variables"]["user_id"], "123")
         self.assertEqual(query.call_args.kwargs["variables"]["max_id"], 10)
+        self.assertEqual(query.call_args.kwargs["variables"]["order"], "date_followed_latest")
+        self.assertTrue(query.call_args.kwargs["variables"]["skip_suggested_users"])
+        self.assertTrue(query.call_args.kwargs["variables"]["skip_page_size"])
+        self.assertTrue(query.call_args.kwargs["variables"]["skip_pending_admins"])
         self.assertEqual(query.call_args.kwargs["priority"], "u=3, i")
+        self.assertEqual(query.call_args.kwargs["extra_headers"]["X-FB-RMD"], "state=URL_ELIGIBLE")
 
     def test_private_graphql_following_list_builds_query_wrapper(self):
         client = Client()
         with mock.patch.object(client, "private_graphql_query_request", return_value={"data": {}}) as query:
-            client.private_graphql_following_list("123", "rank")
+            client.private_graphql_following_list("123", "rank", order="date_followed_earliest")
 
         self.assertEqual(query.call_args.kwargs["friendly_name"], "FollowingList")
         self.assertEqual(query.call_args.kwargs["root_field_name"], "xdt_api__v1__friendships__following")
+        self.assertEqual(query.call_args.kwargs["client_doc_id"], "161046392817718486717479294775")
         self.assertEqual(query.call_args.kwargs["variables"]["user_id"], "123")
+        self.assertEqual(query.call_args.kwargs["variables"]["order"], "date_followed_earliest")
+        self.assertTrue(query.call_args.kwargs["variables"]["skip_use_clickable_see_more"])
+        self.assertTrue(query.call_args.kwargs["variables"]["skip_page_size"])
+        self.assertTrue(query.call_args.kwargs["variables"]["skip_friend_requests"])
+        self.assertEqual(query.call_args.kwargs["extra_headers"]["X-FB-RMD"], "state=URL_ELIGIBLE")
 
     def test_private_graphql_clips_profile_builds_query_wrapper(self):
         client = Client()


### PR DESCRIPTION
## Summary
- update raw private `FollowersList` and `FollowingList` GraphQL builders to the current mobile request shape
- add optional `order` forwarding for private GraphQL follow-list payloads
- document raw GraphQL ordering and add regression/live coverage

Closes #2514.

## Tests
- `.venv/bin/pytest tests/regression/test_user.py -k 'private_graphql_followers_list or private_graphql_following_list'`\n- `.venv/bin/pytest tests/regression/test_user.py`\n- `.venv/bin/pytest tests/regression`\n- `.venv/bin/ruff check .`\n- `pytest -sv tests/live/test_user.py::ClientUserTestCase::test_private_graphql_followers_list_sorted` on isolated live-test host: 1 passed, 1 TLS warning from the test environment