### PR TITLE
Harden signup challenge path validation

### DIFF
--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -1,6 +1,7 @@
 import random
 import secrets
 import time
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 from instagrapi.exceptions import (
@@ -21,6 +22,26 @@ class SignUpMixin:
     waterfall_id = str(uuid4())
     adid = str(uuid4())
     wait_seconds = 5
+
+    @staticmethod
+    def _safe_challenge_api_path(api_path: str, field_name: str = "api_path") -> str:
+        if not isinstance(api_path, str) or not api_path:
+            raise ClientError(f"Malformed challenge data from Instagram (missing {field_name}).")
+        parts = urlsplit(api_path)
+        has_control_chars = any(ord(char) < 32 or ord(char) == 127 for char in api_path)
+        if (
+            parts.scheme
+            or parts.netloc
+            or not api_path.startswith("/")
+            or api_path.startswith("//")
+            or "\\" in api_path
+            or has_control_chars
+        ):
+            raise ClientError(f"Unsafe challenge path from Instagram: {field_name}")
+        return api_path
+
+    def _challenge_url(self, api_path: str, prefix: str = "", field_name: str = "api_path") -> str:
+        return f"https://i.instagram.com{prefix}{self._safe_challenge_api_path(api_path, field_name)}"
 
     def signup(
         self,
@@ -202,7 +223,7 @@ class SignUpMixin:
 
     def challenge_api(self, data):
         resp = self.private.get(
-            "https://i.instagram.com/api/v1%s" % data["api_path"],
+            self._challenge_url(data.get("api_path"), prefix="/api/v1"),
             params={
                 "guid": self.uuid,
                 "device_id": self.android_device_id,
@@ -222,7 +243,7 @@ class SignUpMixin:
             )
             raise ClientError("Malformed captcha challenge data from Instagram (missing site_key or api_path).")
 
-        challenge_post_url = "https://i.instagram.com%s" % api_path
+        challenge_post_url = self._challenge_url(api_path)
         captcha_details_for_solver = {
             "site_key": site_key,
             "challenge_type": challenge_type,
@@ -256,7 +277,7 @@ class SignUpMixin:
     def challenge_submit_phone_number(self, data, phone_number):
         api_path = data.get("navigation", {}).get("forward")
         resp = self.private.post(
-            "https://i.instagram.com%s" % api_path,
+            self._challenge_url(api_path, field_name="navigation.forward"),
             data={
                 "phone_number": phone_number,
                 "challenge_context": data["challenge_context"],
@@ -267,7 +288,7 @@ class SignUpMixin:
     def challenge_verify_sms_captcha(self, data, security_code):
         api_path = data.get("navigation", {}).get("forward")
         resp = self.private.post(
-            "https://i.instagram.com%s" % api_path,
+            self._challenge_url(api_path, field_name="navigation.forward"),
             data={
                 "security_code": security_code,
                 "challenge_context": data["challenge_context"],

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -45,3 +45,68 @@ class SignupHelperRegressionTestCase(unittest.TestCase):
                 "prefill_shown": "False",
             },
         )
+
+    def test_challenge_api_rejects_external_api_path(self):
+        client = Client()
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.private.get = mock.Mock()
+
+        for api_path in ("@attacker.example/steal", "//attacker.example/steal"):
+            with self.subTest(api_path=api_path):
+                with self.assertRaises(ClientError):
+                    client.challenge_api(
+                        {
+                            "api_path": api_path,
+                            "challenge_context": "{}",
+                        }
+                    )
+
+        client.private.get.assert_not_called()
+
+    def test_challenge_captcha_rejects_external_api_path_before_solver(self):
+        client = Client()
+        client.captcha_resolve = mock.Mock(side_effect=AssertionError("solver should not be called"))
+        client.private.post = mock.Mock()
+
+        with self.assertRaises(ClientError):
+            client.challenge_captcha(
+                {
+                    "api_path": "@attacker.example/steal",
+                    "fields": {"sitekey": "site-key"},
+                    "challengeType": "RecaptchaChallengeForm",
+                }
+            )
+
+        client.captcha_resolve.assert_not_called()
+        client.private.post.assert_not_called()
+
+    def test_challenge_submit_phone_number_rejects_external_forward_path(self):
+        client = Client()
+        client.private.post = mock.Mock(json=mock.Mock(return_value={"status": "ok"}))
+
+        with self.assertRaises(ClientError):
+            client.challenge_submit_phone_number(
+                {
+                    "navigation": {"forward": "@attacker.example/steal"},
+                    "challenge_context": "{}",
+                },
+                "+15551234567",
+            )
+
+        client.private.post.assert_not_called()
+
+    def test_challenge_verify_sms_captcha_rejects_external_forward_path(self):
+        client = Client()
+        client.private.post = mock.Mock(json=mock.Mock(return_value={"status": "ok"}))
+
+        with self.assertRaises(ClientError):
+            client.challenge_verify_sms_captcha(
+                {
+                    "navigation": {"forward": "@attacker.example/steal"},
+                    "challenge_context": "{}",
+                },
+                "123456",
+            )
+
+        client.private.post.assert_not_called()


### PR DESCRIPTION
## Summary
- validate signup challenge paths before building request URLs
- reject malformed or non-relative challenge paths before network requests or captcha solving
- add regression coverage for challenge API, captcha, and SMS challenge forward paths

## Tests
- `PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/pytest tests/regression/test_signup.py -k challenge`
- `PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/pytest tests/regression/test_signup.py tests/regression/test_challenge.py`
- `PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/pytest tests/regression`
- `PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/ruff check .`