### PR TITLE
Fix Termux pydantic install resolution

### DIFF
--- a/docs/usage-guide/termux.md
+++ b/docs/usage-guide/termux.md
@@ -8,10 +8,12 @@ Termux can run many `instagrapi` flows, but Android does not use the same binary
 pkg update
 pkg install python python-pillow
 python -m pip install -U pip setuptools wheel
-python -m pip install instagrapi
+python -m pip install --extra-index-url https://termux-user-repository.github.io/pypi/ instagrapi
 ```
 
 `python-pillow` is recommended because photo uploads use Pillow through `instagrapi.image_util`. Installing it with `pkg` avoids a slow or fragile Pillow source build in pip.
+
+The Termux User Repository PyPI index provides Android wheels for native packages that PyPI may only publish as desktop Linux wheels. On Android, `instagrapi` uses `pydantic==2.12.5`, which depends on `pydantic-core==2.41.5`; that version has Android wheels for Python 3.13 in the Termux index. Newer `pydantic-core` releases may otherwise try to build with Rust and fail on-device.
 
 ## Video Uploads
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ keywords = [
 dependencies = [
     "requests==2.34.2",
     "PySocks==1.7.1",
-    "pydantic==2.13.4",
+    "pydantic==2.12.5; sys_platform == 'android'",
+    "pydantic>=2.12.5,<2.14; sys_platform != 'android'",
     "Pillow==12.2.0",
     "pycryptodomex==3.23.0",
 ]

--- a/tests/regression/test_packaging.py
+++ b/tests/regression/test_packaging.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_pydantic_dependency_allows_termux_android_wheel_version():
+    pyproject = Path("pyproject.toml").read_text()
+    required_dependencies = pyproject.split("[project.optional-dependencies]", 1)[0]
+
+    assert "\"pydantic==2.12.5; sys_platform == 'android'\"" in required_dependencies
+    assert "\"pydantic>=2.12.5,<2.14; sys_platform != 'android'\"" in required_dependencies
+    assert '"pydantic==2.13.4"' not in required_dependencies
+
+
+def test_termux_guide_documents_android_pydantic_core_wheel_index():
+    termux_guide = Path("docs/usage-guide/termux.md").read_text()
+
+    assert "https://termux-user-repository.github.io/pypi/" in termux_guide
+    assert "pydantic==2.12.5" in termux_guide


### PR DESCRIPTION
## Summary
- use an Android-specific pydantic pin so Termux resolves to pydantic-core 2.41.5, which has Android wheels in the Termux User Repository PyPI
- keep non-Android installs on the current pydantic range through 2.13.x
- update the Termux install guide and add packaging regression coverage

## Verification
- PYTHONPATH=. /Users/colinfrl/work/sub/instagrapi/.venv/bin/pytest tests/regression/test_packaging.py
- /Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff check tests/regression/test_packaging.py
- /Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m build --wheel --outdir /tmp/instagrapi-termux-pydantic-dist
- unzip METADATA check: pydantic==2.12.5 for sys_platform == android; pydantic>=2.12.5,<2.14 otherwise
- /Users/colinfrl/work/sub/instagrapi/.venv/bin/mkdocs build --strict
- verified TUR publishes pydantic_core-2.41.5 cp313 Android arm64 wheel