### PR TITLE
Skip non-track music search results

### DIFF
--- a/instagrapi/mixins/fbsearch.py
+++ b/instagrapi/mixins/fbsearch.py
@@ -61,7 +61,7 @@ class FbSearchMixin:
             "browse_session_id": self.generate_uuid(),
         }
         result = self.private_request("music/audio_global_search/", params=params)
-        return [extract_track(item["track"]) for item in result["items"]]
+        return [extract_track(item["track"]) for item in result["items"] if item.get("track")]
 
     def search_hashtags(self, query: str) -> List[Hashtag]:
         params = {

--- a/tests/regression/test_fbsearch.py
+++ b/tests/regression/test_fbsearch.py
@@ -128,6 +128,43 @@ class FbSearchRegressionTestCase(unittest.TestCase):
 
         self.assertEqual([hashtag.name for hashtag in hashtags], ["python"])
 
+    def test_search_music_skips_non_track_items(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={
+                "items": [
+                    {"artist": {"pk": "123", "username": "hanszimmer"}, "track": None},
+                    {"playlist": {"id": "456", "title": "Hans Zimmer Essentials"}},
+                    {
+                        "track": {
+                            "id": "789",
+                            "title": "Time",
+                            "subtitle": "Hans Zimmer",
+                            "display_artist": "Hans Zimmer",
+                            "audio_cluster_id": 111,
+                            "cover_artwork_uri": None,
+                            "cover_artwork_thumbnail_uri": None,
+                            "highlight_start_times_in_ms": [0],
+                            "is_explicit": False,
+                            "dash_manifest": "",
+                            "has_lyrics": False,
+                            "audio_asset_id": 222,
+                            "duration_in_ms": 123000,
+                            "allows_saving": True,
+                        }
+                    },
+                ]
+            },
+        ) as private_request:
+            tracks = client.search_music("Hans Zimmer")
+
+        self.assertEqual([track.title for track in tracks], ["Time"])
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "music/audio_global_search/")
+        self.assertIn("params", private_request.call_args.kwargs)
+
     def test_fbsearch_item_forwards_optional_cursors(self):
         client = self._build_client()
         with mock.patch.object(client, "private_request", return_value={"items": []}) as private_request:


### PR DESCRIPTION
## Summary
- skip artist/playlist/null entries returned by `music/audio_global_search/`
- keep `search_music()` returning only valid `Track` objects
- add a regression test for mixed music search results

## Test plan
- `.venv/bin/pytest tests/regression/test_fbsearch.py::FbSearchRegressionTestCase::test_search_music_skips_non_track_items`
- `.venv/bin/pytest tests/regression/test_fbsearch.py tests/regression/test_track.py tests/regression/test_upload.py -k 'fbsearch or search_music or track or music'`
- `.venv/bin/pytest tests/regression`
- `.venv/bin/ruff check .`

Closes #2520
