### PR TITLE
Remove dead public A1 API

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ cl.video_upload_to_story(
 
 ### Requests
 
-* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`) or `_a1` (example `https://www.instagram.com/example/?__a=1`). Some `_gql` helpers use newer `doc_id` queries when Instagram disables legacy `query_hash` endpoints.
+* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`). Some `_gql` helpers use newer `doc_id` queries when Instagram disables legacy `query_hash` endpoints. Legacy `?__a=1` helpers were removed because that public web response is no longer reliable.
 * `Private` (authorized request via mobile api) methods have `_v1` suffix
 
 Public web flows are not guaranteed. Instagram can change or block them independently of the library, and some helpers can only work reliably with an authenticated session.

--- a/docs/usage-guide/fundamentals.md
+++ b/docs/usage-guide/fundamentals.md
@@ -5,7 +5,7 @@ This section provides detailed descriptions of all the ways `instagrapi` can be 
 
 ## Public vs Private Requests
 
-* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`) or `_a1` (example `https://www.instagram.com/example/?__a=1`). Some `_gql` helpers use newer `doc_id` queries when Instagram disables legacy `query_hash` endpoints.
+* `Public` web methods have a suffix `_gql` (Instagram `GraphQL`). Some `_gql` helpers use newer `doc_id` queries when Instagram disables legacy `query_hash` endpoints. Legacy `?__a=1` helpers were removed because that public web response is no longer reliable.
 * `Private` (authorized request via mobile api) methods have `_v1` suffix
 
 Public web flows are opportunistic, not guaranteed. Instagram can change or block them independently of the library.

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -7,7 +7,6 @@ Pass hashtag names without the leading `#`, for example `pizza`. If a leading `#
 | Method | Return | Description |
 | --- | --- | --- |
 | hashtag_info(name: str) | Hashtag | Return hashtag info (`id`, `name`, `media_count`, `profile_pic_url`) |
-| hashtag_related_hashtags(name: str) | List[Hashtag] | Return related hashtags |
 | hashtag_medias_top(name: str, amount: int = 9) | List[Media] | Return top posts for a hashtag |
 | hashtag_medias_recent(name: str, amount: int = 27) | List[Media] | Return recent posts for a hashtag |
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Return reels/clips for a hashtag via private API |
@@ -120,16 +119,11 @@ Low level methods:
 
 | Method                                         | Return  | Description
 | ---------------------------------------------- | ------- | --------------------------------------------
-| hashtag_info_a1(name: str, max_id: str = None) | Hashtag | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_info_gql(name: str, amount: int = 12, end_cursor: str = None) | Hashtag | Get information about a hashtag by Public Graphql API
 | hashtag_info_v1(name: str) | Hashtag | Get information about a hashtag by Private Mobile API
-| hashtag_medias_a1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", end_cursor: str = None) | Tuple[List[Media], str] | Legacy `_a1` compatibility wrapper around Private Mobile API
-| hashtag_medias_a1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
 | hashtag_medias_v1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by Private Mobile API
-| hashtag_medias_top_a1(name: str, amount: int = 9) | List[Media] | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_medias_top_v1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Private Mobile API
-| hashtag_medias_recent_a1(name: str, amount: int = 71) | List[Media] | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_medias_recent_v1(name: str, amount: int = 27) | List[Media] | Get recent medias for a hashtag by Private Mobile API
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Get recent clips (reels) for a hashtag by Private Mobile API
 
@@ -159,9 +153,7 @@ True
 
 Notes:
 
-* Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable. The `_a1` hashtag helpers keep their legacy names for compatibility, but use authenticated private/mobile hashtag endpoints.
-* High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` use those compatibility wrappers first and then the direct private/mobile helpers.
+* Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable and the `_a1` helpers were removed. Use the high-level hashtag methods or the authenticated private/mobile `_v1` helpers.
+* High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` use the private/mobile helpers.
 * For resumable pagination, use `hashtag_medias_v1_chunk()` and persist the encoded `max_id` cursor.
-* `tab_key` values differ by implementation:
-  * `hashtag_medias_a1_chunk()`: `top` or `recent`
-  * `hashtag_medias_v1_chunk()`: `top`, `recent`, or `clips`
+* `hashtag_medias_v1_chunk()` accepts `top`, `recent`, or `clips` as `tab_key`.

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -120,16 +120,16 @@ Low level methods:
 
 | Method                                         | Return  | Description
 | ---------------------------------------------- | ------- | --------------------------------------------
-| hashtag_info_a1(name: str, max_id: str = None) | Hashtag | Get information about a hashtag by legacy Public Web API with authenticated private fallback
+| hashtag_info_a1(name: str, max_id: str = None) | Hashtag | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_info_gql(name: str, amount: int = 12, end_cursor: str = None) | Hashtag | Get information about a hashtag by Public Graphql API
 | hashtag_info_v1(name: str) | Hashtag | Get information about a hashtag by Private Mobile API
-| hashtag_medias_a1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", end_cursor: str = None) | Tuple[List[Media], str] | Get chunk of medias and cursor by legacy Public Web API with authenticated private fallback
-| hashtag_medias_a1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by legacy Public Web API with authenticated private fallback
+| hashtag_medias_a1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", end_cursor: str = None) | Tuple[List[Media], str] | Legacy `_a1` compatibility wrapper around Private Mobile API
+| hashtag_medias_a1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
 | hashtag_medias_v1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by Private Mobile API
-| hashtag_medias_top_a1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by legacy Public Web API with authenticated private fallback
+| hashtag_medias_top_a1(name: str, amount: int = 9) | List[Media] | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_medias_top_v1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Private Mobile API
-| hashtag_medias_recent_a1(name: str, amount: int = 71) | List[Media] | Get recent medias for a hashtag by legacy Public Web API with authenticated private fallback
+| hashtag_medias_recent_a1(name: str, amount: int = 71) | List[Media] | Legacy `_a1` compatibility wrapper around Private Mobile API
 | hashtag_medias_recent_v1(name: str, amount: int = 27) | List[Media] | Get recent medias for a hashtag by Private Mobile API
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Get recent clips (reels) for a hashtag by Private Mobile API
 
@@ -159,8 +159,8 @@ True
 
 Notes:
 
-* Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable. The `_a1` helpers keep their legacy names for compatibility, try the web path first, and fall back to authenticated private/mobile hashtag endpoints when possible.
-* High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` also fall back to private/mobile on web failure.
+* Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable. The `_a1` hashtag helpers keep their legacy names for compatibility, but use authenticated private/mobile hashtag endpoints.
+* High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` use those compatibility wrappers first and then the direct private/mobile helpers.
 * For resumable pagination, use `hashtag_medias_v1_chunk()` and persist the encoded `max_id` cursor.
 * `tab_key` values differ by implementation:
   * `hashtag_medias_a1_chunk()`: `top` or `recent`

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -120,16 +120,16 @@ Low level methods:
 
 | Method                                         | Return  | Description
 | ---------------------------------------------- | ------- | --------------------------------------------
-| hashtag_info_a1(name: str, max_id: str = None) | Hashtag | Get information about a hashtag by Public Web API
+| hashtag_info_a1(name: str, max_id: str = None) | Hashtag | Get information about a hashtag by legacy Public Web API with authenticated private fallback
 | hashtag_info_gql(name: str, amount: int = 12, end_cursor: str = None) | Hashtag | Get information about a hashtag by Public Graphql API
 | hashtag_info_v1(name: str) | Hashtag | Get information about a hashtag by Private Mobile API
-| hashtag_medias_a1_chunk(name: str, max_amount: int = 27, tab_key: str = "edge_hashtag_to_top_posts\|edge_hashtag_to_media", end_cursor: str = None) | Tuple[List[Media], str] | Get chunk of medias and end_cursor by Public Web API
-| hashtag_medias_a1(name: str, amount: int = 27, tab_key: str = "edge_hashtag_to_top_posts\|edge_hashtag_to_media") | List[Media] | Get medias for a hashtag by Public Web API
+| hashtag_medias_a1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", end_cursor: str = None) | Tuple[List[Media], str] | Get chunk of medias and cursor by legacy Public Web API with authenticated private fallback
+| hashtag_medias_a1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by legacy Public Web API with authenticated private fallback
 | hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
 | hashtag_medias_v1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by Private Mobile API
-| hashtag_medias_top_a1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Public Web API
+| hashtag_medias_top_a1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by legacy Public Web API with authenticated private fallback
 | hashtag_medias_top_v1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Private Mobile API
-| hashtag_medias_recent_a1(name: str, amount: int = 71) | List[Media] | Get recent medias for a hashtag by Public Web API
+| hashtag_medias_recent_a1(name: str, amount: int = 71) | List[Media] | Get recent medias for a hashtag by legacy Public Web API with authenticated private fallback
 | hashtag_medias_recent_v1(name: str, amount: int = 27) | List[Media] | Get recent medias for a hashtag by Private Mobile API
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Get recent clips (reels) for a hashtag by Private Mobile API
 
@@ -159,7 +159,8 @@ True
 
 Notes:
 
-* High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` prefer public/web paths first and fall back to private/mobile on failure.
+* Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable. The `_a1` helpers keep their legacy names for compatibility, try the web path first, and fall back to authenticated private/mobile hashtag endpoints when possible.
+* High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` also fall back to private/mobile on web failure.
 * For resumable pagination, use `hashtag_medias_v1_chunk()` and persist the encoded `max_id` cursor.
 * `tab_key` values differ by implementation:
   * `hashtag_medias_a1_chunk()`: `top` or `recent`

--- a/docs/usage-guide/location.md
+++ b/docs/usage-guide/location.md
@@ -214,13 +214,8 @@ Low level methods:
 
 | Method                                         | Return  | Description
 | ---------------------------------------------- | ------- | --------------------------------------------
-| location_info_a1(location_pk: int) | Location | Get a location using location pk (Public Web API)
 | location_info_v1(location_pk: int) | Location | Get a location using location pk (Private Mobile API)
-| location_medias_a1_chunk(location_pk: int, max_amount: int = 24, sleep: float = 0.5, tab_key: str = "edge_location_to_top_posts\|edge_location_to_media", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias and end_cursor (Public Web API)
-| location_medias_a1(location_pk: int, amount: int = 24, sleep: float = 0.5, tab_key: str = "edge_location_to_top_posts\|edge_location_to_media") | List[Media] | Get medias for a location (Public Web API)
 | location_medias_v1_chunk(location_pk: int, max_amount: int = 63, tab_key: str = "ranked\|recent", max_id: str = None) | Tuple[List[Media], str] Get chunk of medias for a location and max_id (cursor) by Private Mobile API
 | location_medias_v1(location_pk: int, amount: int = 63, tab_key: str = "ranked\|recent") | List[Media] | Get medias for a location (Private Mobile API), paginating with the server cursor until `amount` is reached or the cursor is exhausted
-| location_medias_top_a1(location_pk: int, amount: int = 9, sleep: float = 0.5) | List[Media] | Get top medias for a location (Public Web API)
 | location_medias_top_v1(location_pk: int, amount: int = 21) | List[Media] | Get top medias for a location (Private Mobile API)
-| location_medias_recent_a1(location_pk: int, amount: int = 24, sleep: float = 0.5) | List[Media] | Get recent medias for a location (Public Web API)
 | location_medias_recent_v1(location_pk: int, amount: int = 63) | List[Media] | Get recent medias for a location (Private Mobile API), paginating past the first chunk when the endpoint returns `next_max_id`

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -63,7 +63,6 @@ Low level methods:
 
 | Method | Return | Description |
 | --- | --- | --- |
-| media_info_a1(media_pk: str, max_id: str = None) | Media | Get media from PK via public web API |
 | media_info_gql(media_pk: str) | Media | Get media from PK via public GraphQL API. Falls back from legacy `query_hash` to the newer `doc_id` media query when available. |
 | media_info_v1(media_pk: str) | Media | Get media from PK via private mobile API |
 | media_info_v2(media_id: str) | Media | Alternative source for media info via `discover/media_metadata/` (`media_or_ad` payload). Useful as fallback when `media_info_v1` fails on certain ad-tagged or sponsored media. Strips `_userid` suffix automatically. |

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -73,7 +73,6 @@ Low level methods:
 | user_following_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
 | search_followers_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by followers by Private Mobile API                                  |
 | search_following_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by following by Private Mobile API                                  |
-| user_info_by_username_a1(username: str)                                             | dict                        | Raw public A1 username payload                                             |
 | user_info_v2_gql(user_id: str)                                                      | User                        | Profile lookup through current doc_id GraphQL                              |
 | user_info_by_username_v2_gql(username: str)                                         | User                        | Resolve username through doc_id search, then fetch profile                 |
 | private_graphql_followers_list(user_id: str, rank_token: str, ..., order: str = None) | dict                      | Raw private mobile GraphQL followers list. Supports `date_followed_latest` and `date_followed_earliest` |

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -59,13 +59,16 @@ class HashtagMixin:
         name = self._normalize_hashtag_name(name)
         params = {"max_id": max_id} if max_id else None
         try:
-            data = self.public_a1_request(f"/explore/tags/{name}/", params=params)
-        except ClientUnauthorizedError:
-            self.inject_sessionid_to_public()
-            data = self.public_a1_request(f"/explore/tags/{name}/", params=params)
-        if not data.get("hashtag"):
-            raise HashtagNotFound(name=name, **data)
-        return extract_hashtag_gql(data["hashtag"])
+            try:
+                data = self.public_a1_request(f"/explore/tags/{name}/", params=params)
+            except ClientUnauthorizedError:
+                self.inject_sessionid_to_public()
+                data = self.public_a1_request(f"/explore/tags/{name}/", params=params)
+            if not data.get("hashtag"):
+                raise HashtagNotFound(name=name, **data)
+            return extract_hashtag_gql(data["hashtag"])
+        except ClientError:
+            return self.hashtag_info_v1(name)
 
     def hashtag_info_gql(self, name: str, amount: int = 12, end_cursor: str = None) -> Hashtag:
         """
@@ -188,42 +191,47 @@ class HashtagMixin:
         ), 'You must specify one of the options for "tab_key" ("recent" or "top")'
         url = f"/explore/tags/{name}/"
         medias = []
-        while True:
-            params = {"max_id": end_cursor} if end_cursor else {}
-            try:
-                data = self.public_a1_request(url, params=params)
-            except (ClientUnauthorizedError, ClientLoginRequired):
-                self.inject_sessionid_to_public()
-                data = self.public_a1_request(url, params=params)
+        try:
+            while True:
+                params = {"max_id": end_cursor} if end_cursor else {}
+                try:
+                    data = self.public_a1_request(url, params=params)
+                except (ClientUnauthorizedError, ClientLoginRequired):
+                    self.inject_sessionid_to_public()
+                    data = self.public_a1_request(url, params=params)
 
-            result = data["data"][tab_key]
-            for section in result["sections"]:
-                layout_content = section.get("layout_content") or {}
-                nodes = layout_content.get("medias") or []
-                for node in nodes:
-                    if max_amount and len(medias) >= max_amount:
-                        break
-                    try:
-                        media = extract_media_v1(node["media"])
-                    except (KeyError, AttributeError, TypeError) as exc:
-                        # One malformed node would otherwise crash the whole
-                        # chunk and lose the rest of the page. Skip and keep
-                        # going.
-                        self.logger.warning("Skipping malformed hashtag node: %s", exc)
-                        continue
-                    # media_pk = node["media"]["id"]
-                    # if media_pk in unique_set:
-                    #     continue
-                    # unique_set.add(media_pk)
-                    # check contains hashtag in caption
-                    # if f"#{name}" not in media.caption_text:
-                    #     continue
-                    medias.append(media)
-            if not result["more_available"]:
-                break
-            if max_amount and len(medias) >= max_amount:
-                break
-            end_cursor = result["next_max_id"]
+                result = data["data"][tab_key]
+                for section in result["sections"]:
+                    layout_content = section.get("layout_content") or {}
+                    nodes = layout_content.get("medias") or []
+                    for node in nodes:
+                        if max_amount and len(medias) >= max_amount:
+                            break
+                        try:
+                            media = extract_media_v1(node["media"])
+                        except (KeyError, AttributeError, TypeError) as exc:
+                            # One malformed node would otherwise crash the whole
+                            # chunk and lose the rest of the page. Skip and keep
+                            # going.
+                            self.logger.warning("Skipping malformed hashtag node: %s", exc)
+                            continue
+                        # media_pk = node["media"]["id"]
+                        # if media_pk in unique_set:
+                        #     continue
+                        # unique_set.add(media_pk)
+                        # check contains hashtag in caption
+                        # if f"#{name}" not in media.caption_text:
+                        #     continue
+                        medias.append(media)
+                if not result["more_available"]:
+                    break
+                if max_amount and len(medias) >= max_amount:
+                    break
+                end_cursor = result["next_max_id"]
+        except (ClientError, KeyError, TypeError):
+            return self.hashtag_medias_v1_chunk(name, max_amount, tab_key, end_cursor)
+        if max_amount and len(medias) < max_amount:
+            return self.hashtag_medias_v1_chunk(name, max_amount, tab_key, end_cursor)
         return medias, end_cursor
 
     def hashtag_medias_a1(self, name: str, amount: int = 27, tab_key: str = "") -> List[Media]:
@@ -246,6 +254,8 @@ class HashtagMixin:
         """
         name = self._normalize_hashtag_name(name)
         medias, _ = self.hashtag_medias_a1_chunk(name, amount, tab_key)
+        if amount and len(medias) < amount:
+            medias = self.hashtag_medias_v1(name, amount, tab_key)
         if amount:
             medias = medias[:amount]
         return medias

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -3,11 +3,7 @@ import json
 import warnings
 from typing import List, Tuple
 
-from instagrapi.exceptions import (
-    ClientError,
-    HashtagNotFound,
-    WrongCursorError,
-)
+from instagrapi.exceptions import HashtagNotFound, WrongCursorError
 from instagrapi.extractors import (
     extract_hashtag_gql,
     extract_hashtag_v1,
@@ -36,26 +32,6 @@ class HashtagMixin:
         if not normalized:
             raise ValueError("Hashtag name cannot be empty")
         return normalized
-
-    def hashtag_info_a1(self, name: str, max_id: str = None) -> Hashtag:
-        """
-        Get information about a hashtag by legacy `_a1` compatibility wrapper
-
-        Parameters
-        ----------
-        name: str
-            Name of the hashtag
-
-        max_id: str
-            Max ID, default value is None
-
-        Returns
-        -------
-        Hashtag
-            An object of Hashtag
-        """
-        name = self._normalize_hashtag_name(name)
-        return self.hashtag_info_v1(name)
 
     def hashtag_info_gql(self, name: str, amount: int = 12, end_cursor: str = None) -> Hashtag:
         """
@@ -119,90 +95,7 @@ class HashtagMixin:
             An object of Hashtag
         """
         name = self._normalize_hashtag_name(name)
-        try:
-            hashtag = self.hashtag_info_a1(name)
-        except Exception:
-            # Users do not understand the output of such information and create bug reports
-            # such this - https://github.com/subzeroid/instagrapi/issues/364
-            # if not isinstance(e, ClientError):
-            #     self.logger.exception(e)
-            hashtag = self.hashtag_info_v1(name)
-        return hashtag
-
-    def hashtag_related_hashtags(self, name: str) -> List[Hashtag]:
-        """
-        Get related hashtags from a hashtag
-
-        Parameters
-        ----------
-        name: str
-            Name of the hashtag
-
-        Returns
-        -------
-        List[Hashtag]
-            List of objects of Hashtag
-        """
-        name = self._normalize_hashtag_name(name)
-        data = self.public_a1_request(f"/explore/tags/{name}/")
-        if not data.get("hashtag"):
-            raise HashtagNotFound(name=name, **data)
-        return [extract_hashtag_gql(item["node"]) for item in data["hashtag"]["edge_hashtag_to_related_tags"]["edges"]]
-
-    def hashtag_medias_a1_chunk(
-        self, name: str, max_amount: int = 27, tab_key: str = "", end_cursor: str = None
-    ) -> Tuple[List[Media], str]:
-        """
-        Get chunk of medias by legacy `_a1` compatibility wrapper
-
-        Parameters
-        ----------
-        name: str
-            Name of the hashtag
-        max_amount: int, optional
-            Maximum number of media to return, default is 27
-        tab_key: str, optional
-            Tab Key, default value is ""
-        end_cursor: str, optional
-            End Cursor, default value is None
-
-        Returns
-        -------
-        Tuple[List[Media], str]
-            List of objects of Media and end_cursor
-        """
-        name = self._normalize_hashtag_name(name)
-        assert tab_key in (
-            "recent",
-            "top",
-        ), 'You must specify one of the options for "tab_key" ("recent" or "top")'
-        return self.hashtag_medias_v1_chunk(name, max_amount, tab_key, end_cursor)
-
-    def hashtag_medias_a1(self, name: str, amount: int = 27, tab_key: str = "") -> List[Media]:
-        """
-        Get medias for a hashtag by legacy `_a1` compatibility wrapper
-
-        Parameters
-        ----------
-        name: str
-            Name of the hashtag
-        amount: int, optional
-            Maximum number of media to return, default is 27
-        tab_key: str, optional
-            Tab Key, default value is ""
-
-        Returns
-        -------
-        List[Media]
-            List of objects of Media
-        """
-        name = self._normalize_hashtag_name(name)
-        medias, _ = self.hashtag_medias_a1_chunk(name, amount, tab_key)
-        if amount and len(medias) < amount:
-            medias = self.hashtag_medias_v1(name, amount, tab_key)
-        if amount:
-            medias = medias[:amount]
-        return medias
+        return self.hashtag_info_v1(name)
 
     def hashtag_medias_v1_chunk(
         self, name: str, max_amount: int = 27, tab_key: str = "", max_id: str = None
@@ -314,25 +207,6 @@ class HashtagMixin:
             medias = medias[:amount]
         return medias
 
-    def hashtag_medias_top_a1(self, name: str, amount: int = 9) -> List[Media]:
-        """
-        Get top medias for a hashtag by Public Web API
-
-        Parameters
-        ----------
-        name: str
-            Name of the hashtag
-        amount: int, optional
-            Maximum number of media to return, default is 9
-
-        Returns
-        -------
-        List[Media]
-            List of objects of Media
-        """
-        name = self._normalize_hashtag_name(name)
-        return self.hashtag_medias_a1(name, amount, tab_key="top")
-
     def hashtag_medias_top_v1(self, name: str, amount: int = 9) -> List[Media]:
         """
         Get top medias for a hashtag by Private Mobile API
@@ -369,30 +243,7 @@ class HashtagMixin:
             List of objects of Media
         """
         name = self._normalize_hashtag_name(name)
-        try:
-            medias = self.hashtag_medias_top_a1(name, amount)
-        except ClientError:
-            medias = self.hashtag_medias_top_v1(name, amount)
-        return medias
-
-    def hashtag_medias_recent_a1(self, name: str, amount: int = 71) -> List[Media]:
-        """
-        Get recent medias for a hashtag by Public Web API
-
-        Parameters
-        ----------
-        name: str
-            Name of the hashtag
-        amount: int, optional
-            Maximum number of media to return, default is 71
-
-        Returns
-        -------
-        List[Media]
-            List of objects of Media
-        """
-        name = self._normalize_hashtag_name(name)
-        return self.hashtag_medias_a1(name, amount, tab_key="recent")
+        return self.hashtag_medias_top_v1(name, amount)
 
     def hashtag_medias_recent_v1(self, name: str, amount: int = 27) -> List[Media]:
         """
@@ -430,11 +281,7 @@ class HashtagMixin:
             List of objects of Media
         """
         name = self._normalize_hashtag_name(name)
-        try:
-            medias = self.hashtag_medias_recent_a1(name, amount)
-        except ClientError:
-            medias = self.hashtag_medias_recent_v1(name, amount)
-        return medias
+        return self.hashtag_medias_recent_v1(name, amount)
 
     def hashtag_medias_reels_v1(self, name: str, amount: int = 27) -> List[Media]:
         """

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -5,8 +5,6 @@ from typing import List, Tuple
 
 from instagrapi.exceptions import (
     ClientError,
-    ClientLoginRequired,
-    ClientUnauthorizedError,
     HashtagNotFound,
     WrongCursorError,
 )
@@ -41,7 +39,7 @@ class HashtagMixin:
 
     def hashtag_info_a1(self, name: str, max_id: str = None) -> Hashtag:
         """
-        Get information about a hashtag by Public Web API
+        Get information about a hashtag by legacy `_a1` compatibility wrapper
 
         Parameters
         ----------
@@ -57,18 +55,7 @@ class HashtagMixin:
             An object of Hashtag
         """
         name = self._normalize_hashtag_name(name)
-        params = {"max_id": max_id} if max_id else None
-        try:
-            try:
-                data = self.public_a1_request(f"/explore/tags/{name}/", params=params)
-            except ClientUnauthorizedError:
-                self.inject_sessionid_to_public()
-                data = self.public_a1_request(f"/explore/tags/{name}/", params=params)
-            if not data.get("hashtag"):
-                raise HashtagNotFound(name=name, **data)
-            return extract_hashtag_gql(data["hashtag"])
-        except ClientError:
-            return self.hashtag_info_v1(name)
+        return self.hashtag_info_v1(name)
 
     def hashtag_info_gql(self, name: str, amount: int = 12, end_cursor: str = None) -> Hashtag:
         """
@@ -166,7 +153,7 @@ class HashtagMixin:
         self, name: str, max_amount: int = 27, tab_key: str = "", end_cursor: str = None
     ) -> Tuple[List[Media], str]:
         """
-        Get chunk of medias and end_cursor by Public Web API
+        Get chunk of medias by legacy `_a1` compatibility wrapper
 
         Parameters
         ----------
@@ -189,54 +176,11 @@ class HashtagMixin:
             "recent",
             "top",
         ), 'You must specify one of the options for "tab_key" ("recent" or "top")'
-        url = f"/explore/tags/{name}/"
-        medias = []
-        try:
-            while True:
-                params = {"max_id": end_cursor} if end_cursor else {}
-                try:
-                    data = self.public_a1_request(url, params=params)
-                except (ClientUnauthorizedError, ClientLoginRequired):
-                    self.inject_sessionid_to_public()
-                    data = self.public_a1_request(url, params=params)
-
-                result = data["data"][tab_key]
-                for section in result["sections"]:
-                    layout_content = section.get("layout_content") or {}
-                    nodes = layout_content.get("medias") or []
-                    for node in nodes:
-                        if max_amount and len(medias) >= max_amount:
-                            break
-                        try:
-                            media = extract_media_v1(node["media"])
-                        except (KeyError, AttributeError, TypeError) as exc:
-                            # One malformed node would otherwise crash the whole
-                            # chunk and lose the rest of the page. Skip and keep
-                            # going.
-                            self.logger.warning("Skipping malformed hashtag node: %s", exc)
-                            continue
-                        # media_pk = node["media"]["id"]
-                        # if media_pk in unique_set:
-                        #     continue
-                        # unique_set.add(media_pk)
-                        # check contains hashtag in caption
-                        # if f"#{name}" not in media.caption_text:
-                        #     continue
-                        medias.append(media)
-                if not result["more_available"]:
-                    break
-                if max_amount and len(medias) >= max_amount:
-                    break
-                end_cursor = result["next_max_id"]
-        except (ClientError, KeyError, TypeError):
-            return self.hashtag_medias_v1_chunk(name, max_amount, tab_key, end_cursor)
-        if max_amount and len(medias) < max_amount:
-            return self.hashtag_medias_v1_chunk(name, max_amount, tab_key, end_cursor)
-        return medias, end_cursor
+        return self.hashtag_medias_v1_chunk(name, max_amount, tab_key, end_cursor)
 
     def hashtag_medias_a1(self, name: str, amount: int = 27, tab_key: str = "") -> List[Media]:
         """
-        Get medias for a hashtag by Public Web API
+        Get medias for a hashtag by legacy `_a1` compatibility wrapper
 
         Parameters
         ----------

--- a/instagrapi/mixins/location.py
+++ b/instagrapi/mixins/location.py
@@ -2,15 +2,10 @@ import base64
 import json
 from typing import List, Tuple
 
-from instagrapi.exceptions import (
-    ClientNotFoundError,
-    LocationNotFound,
-    WrongCursorError,
-)
+from instagrapi.exceptions import LocationNotFound, WrongCursorError
 from instagrapi.extractors import extract_guide_v1, extract_location, extract_media_v1
 from instagrapi.types import Guide, Location, Media
 
-tab_keys_a1 = ("edge_location_to_top_posts", "edge_location_to_media")
 tab_keys_v1 = ("ranked", "recent")
 
 
@@ -180,28 +175,6 @@ class LocationMixin:
             return ""
         return str(location.external_id or location.pk or "")
 
-    def location_info_a1(self, location_pk: int) -> Location:
-        """
-        Get a location using location pk
-
-        Parameters
-        ----------
-        location_pk: int
-            Unique identifier for a location
-
-        Returns
-        -------
-        Location
-            An object of Location
-        """
-        try:
-            data = self.public_a1_request(f"/explore/locations/{location_pk}/") or {}
-            if not data.get("location"):
-                raise LocationNotFound(location_pk=location_pk, **data)
-            return extract_location(data["location"])
-        except ClientNotFoundError:
-            raise LocationNotFound(location_pk=location_pk)
-
     def location_info_v1(self, location_pk: int) -> Location:
         """
         Get a location using location pk
@@ -237,86 +210,6 @@ class LocationMixin:
             An object of Location
         """
         return self.location_info_v1(location_pk)
-
-    def location_medias_a1_chunk(
-        self,
-        location_pk: int,
-        max_amount: int = 24,
-        sleep: float = 0.5,
-        tab_key: str = "",
-        max_id: str = None,
-    ) -> Tuple[List[Media], str]:
-        """
-        Get chunk of medias and end_cursor by Public Web API
-
-        Parameters
-        ----------
-        location_pk: int
-            Unique identifier for a location
-        max_amount: int, optional
-            Maximum number of media to return, default is 24
-        sleep: float, optional
-            Timeout between requests, default is 0.5
-        tab_key: str, optional
-            Tab Key, default value is ""
-        end_cursor: str, optional
-            End Cursor, default value is None
-
-        Returns
-        -------
-        Tuple[List[Media], str]
-            List of objects of Media and end_cursor
-        """
-        assert tab_key in tab_keys_a1, f'You must specify one of the options for "tab_key" {tab_keys_a1}'
-        unique_set = set()
-        medias = []
-        end_cursor = None
-        result = self.public_a1_request(
-            f"/explore/locations/{location_pk}/",
-            params={"max_id": end_cursor} if end_cursor else {},
-        )
-        data = result["location"]
-        page_info = data["edge_location_to_media"]["page_info"]
-        end_cursor = page_info["end_cursor"]
-        edges = data[tab_key]["edges"]
-        for edge in edges:
-            node = edge["node"]
-            # check uniq
-            media_pk = node["id"]
-            if media_pk in unique_set:
-                continue
-            unique_set.add(media_pk)
-            # Enrich media: Full user, usertags and video_url
-            medias.append(self.media_info_gql(media_pk))
-        return medias, end_cursor
-
-    def location_medias_a1(
-        self, location_pk: int, amount: int = 24, sleep: float = 0.5, tab_key: str = ""
-    ) -> List[Media]:
-        """
-        Get medias for a location
-
-        Parameters
-        ----------
-        location_pk: int
-            Unique identifier for a location
-        amount: int, optional
-            Maximum number of media to return, default is 24
-        sleep: float, optional
-            Timeout between requests, default is 0.5
-        tab_key: str, optional
-            Tab Key, default value is ""
-
-        Returns
-        -------
-        List[Media]
-            List of objects of Media
-        """
-        assert tab_key in tab_keys_a1, f'You must specify one of the options for "tab_key" {tab_keys_a1}'
-        medias, _ = self.location_medias_a1_chunk(location_pk, amount, sleep, tab_key)
-        if amount:
-            medias = medias[:amount]
-        return medias
 
     def location_medias_v1_chunk(
         self,
@@ -395,7 +288,7 @@ class LocationMixin:
         List[Media]
             List of objects of Media
         """
-        assert tab_key in tab_keys_v1, f'You must specify one of the options for "tab_key" {tab_keys_a1}'
+        assert tab_key in tab_keys_v1, f'You must specify one of the options for "tab_key" {tab_keys_v1}'
         medias = []
         max_id = None
         while True:
@@ -408,26 +301,6 @@ class LocationMixin:
         if amount:
             medias = medias[:amount]
         return medias
-
-    def location_medias_top_a1(self, location_pk: int, amount: int = 9, sleep: float = 0.5) -> List[Media]:
-        """
-        Get top medias for a location
-
-        Parameters
-        ----------
-        location_pk: int
-            Unique identifier for a location
-        amount: int, optional
-            Maximum number of media to return, default is 9
-        sleep: float, optional
-            Timeout between requests, default is 0.5
-
-        Returns
-        -------
-        List[Media]
-            List of objects of Media
-        """
-        return self.location_medias_a1(location_pk, amount, sleep=sleep, tab_key="edge_location_to_top_posts")
 
     def location_medias_top_v1(self, location_pk: int, amount: int = 21) -> List[Media]:
         """
@@ -464,26 +337,6 @@ class LocationMixin:
             List of objects of Media
         """
         return self.location_medias_top_v1(location_pk, amount)
-
-    def location_medias_recent_a1(self, location_pk: int, amount: int = 24, sleep: float = 0.5) -> List[Media]:
-        """
-        Get recent medias for a location
-
-        Parameters
-        ----------
-        location_pk: int
-            Unique identifier for a location
-        amount: int, optional
-            Maximum number of media to return, default is 24
-        sleep: float, optional
-            Timeout between requests, default is 0.5
-
-        Returns
-        -------
-        List[Media]
-            List of objects of Media
-        """
-        return self.location_medias_a1(location_pk, amount, sleep=sleep, tab_key="edge_location_to_media")
 
     def location_medias_recent_v1(self, location_pk: int, amount: int = 63) -> List[Media]:
         """

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -313,32 +313,6 @@ class MediaMixin:
                 return self.media_pk_from_url(location)
         return self.media_pk_from_code(parts.pop())
 
-    def media_info_a1(self, media_pk: str, max_id: str = None) -> Media:
-        """
-        Get Media from PK by Public Web API
-
-        Parameters
-        ----------
-        media_pk: str
-            Unique identifier of the media
-        max_id: str, optional
-            Max ID, default value is None
-
-        Returns
-        -------
-        Media
-            An object of Media type
-        """
-        media_pk = self.media_pk(media_pk)
-        shortcode = self.media_code_from_pk(media_pk)
-        """Use Client.media_info
-        """
-        params = {"max_id": max_id} if max_id else None
-        data = self.public_a1_request("/p/{shortcode!s}/".format(**{"shortcode": shortcode}), params=params)
-        if not data.get("shortcode_media"):
-            raise MediaNotFound(media_pk=media_pk, **data)
-        return extract_media_gql(data["shortcode_media"])
-
     def media_info_gql(self, media_pk: str) -> Media:
         """
         Get Media from PK by Public Graphql API
@@ -380,7 +354,7 @@ class MediaMixin:
                     referer=f"https://www.instagram.com/p/{shortcode}/",
                 )
             except (ClientForbiddenError, ClientLoginRequired, ClientUnauthorizedError):
-                return self.media_info_a1(media_pk)
+                return self.media_info_v1(media_pk)
             media = data.get("xdt_shortcode_media") or data.get("shortcode_media")
             if not media:
                 raise MediaNotFound(media_pk=media_pk, **data)

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -347,14 +347,11 @@ class MediaMixin:
             ClientNotFoundError,
             ClientUnauthorizedError,
         ):
-            try:
-                data = self.public_doc_id_graphql_request(
-                    MEDIA_INFO_DOC_ID,
-                    {"shortcode": shortcode},
-                    referer=f"https://www.instagram.com/p/{shortcode}/",
-                )
-            except (ClientForbiddenError, ClientLoginRequired, ClientUnauthorizedError):
-                return self.media_info_v1(media_pk)
+            data = self.public_doc_id_graphql_request(
+                MEDIA_INFO_DOC_ID,
+                {"shortcode": shortcode},
+                referer=f"https://www.instagram.com/p/{shortcode}/",
+            )
             media = data.get("xdt_shortcode_media") or data.get("shortcode_media")
             if not media:
                 raise MediaNotFound(media_pk=media_pk, **data)

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -348,25 +348,6 @@ class PublicRequestMixin:
         finally:
             self.last_response_ts = time.time()
 
-    def public_a1_request(self, endpoint, data=None, params=None, headers=None, full=False):
-        url = (self.PUBLIC_API_URL + str(endpoint)).replace(
-            ".com//", ".com/"
-        )  # (jarrodnorwell) fixed KeyError: 'data', fixed // error
-        params = params or {}
-        params.update({"__a": 1, "__d": "dis"})
-
-        response = self.public_request(url, data=data, params=params, headers=headers, return_json=True)
-        if full:
-            return response
-        return response.get("graphql") or response
-
-    def public_a1_request_user_info_by_username(self, username, data=None, params=None):
-        params = params or {}
-        url = self.PUBLIC_API_URL + f"api/v1/users/web_profile_info/?username={username}"
-        headers = {"x-ig-app-id": "936619743392459"}
-        response = self.public_request(url, data=data, params=params, headers=headers, return_json=True)
-        return response.get("user") or response
-
     def public_graphql_request(
         self,
         variables,

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -192,13 +192,6 @@ class UserMixin:
             username = self.user_info_v1(user_id).username
         return username
 
-    def user_info_by_username_a1(self, username: str) -> dict:
-        """
-        Get raw public A1 user object from username.
-        """
-        username = str(username).lower()
-        return self.public_a1_request(f"/{username}/", full=True)
-
     def user_info_by_username_gql(self, username: str) -> User:
         """
         Get user object from user name

--- a/tests/live/test_hashtag.py
+++ b/tests/live/test_hashtag.py
@@ -24,14 +24,14 @@ class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
         self.assertEqual("instagram", hashtag.name)
 
     def test_extract_hashtag_info(self):
-        hashtag_a1 = self.cl.hashtag_info_a1("instagram")
+        hashtag = self.cl.hashtag_info("instagram")
         hashtag_v1 = self.cl.hashtag_info_v1("instagram")
-        self.assertIsInstance(hashtag_a1, Hashtag)
+        self.assertIsInstance(hashtag, Hashtag)
         self.assertIsInstance(hashtag_v1, Hashtag)
-        self.assertEqual("instagram", hashtag_a1.name)
-        self.assertEqual(hashtag_a1.id, hashtag_v1.id)
-        self.assertEqual(hashtag_a1.name, hashtag_v1.name)
-        self.assertGreater(hashtag_a1.media_count, 0)
+        self.assertEqual("instagram", hashtag.name)
+        self.assertEqual(hashtag.id, hashtag_v1.id)
+        self.assertEqual(hashtag.name, hashtag_v1.name)
+        self.assertGreater(hashtag.media_count, 0)
         self.assertGreater(hashtag_v1.media_count, 0)
 
     def test_hashtag_medias_top(self):
@@ -40,10 +40,10 @@ class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(medias[0], Media)
 
     def test_extract_hashtag_medias_top(self):
-        medias_a1 = self.cl.hashtag_medias_top_a1("instagram", amount=9)
+        medias = self.cl.hashtag_medias_top("instagram", amount=9)
         medias_v1 = self.cl.hashtag_medias_top_v1("instagram", amount=9)
-        self.assertEqual(len(medias_a1), 9)
-        self.assertIsInstance(medias_a1[0], Media)
+        self.assertEqual(len(medias), 9)
+        self.assertIsInstance(medias[0], Media)
         self.assertEqual(len(medias_v1), 9)
         self.assertIsInstance(medias_v1[0], Media)
 
@@ -54,12 +54,12 @@ class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
 
     def test_extract_hashtag_medias_recent(self):
         medias_v1 = self.cl.hashtag_medias_recent_v1("instagram", amount=31)
-        medias_a1 = self.cl.hashtag_medias_recent_a1("instagram", amount=31)
-        self.assertEqual(len(medias_a1), 31)
-        self.assertIsInstance(medias_a1[0], Media)
+        medias = self.cl.hashtag_medias_recent("instagram", amount=31)
+        self.assertEqual(len(medias), 31)
+        self.assertIsInstance(medias[0], Media)
         self.assertEqual(len(medias_v1), 31)
         self.assertIsInstance(medias_v1[0], Media)
-        for media in [*medias_a1[:10], *medias_v1[:10]]:
+        for media in [*medias[:10], *medias_v1[:10]]:
             data = media.model_dump()
             for f in self.REQUIRED_MEDIA_FIELDS:
                 self.assertIn(f, data)

--- a/tests/live/test_hashtag.py
+++ b/tests/live/test_hashtag.py
@@ -31,7 +31,8 @@ class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
         self.assertEqual("instagram", hashtag_a1.name)
         self.assertEqual(hashtag_a1.id, hashtag_v1.id)
         self.assertEqual(hashtag_a1.name, hashtag_v1.name)
-        self.assertEqual(hashtag_a1.media_count, hashtag_v1.media_count)
+        self.assertGreater(hashtag_a1.media_count, 0)
+        self.assertGreater(hashtag_v1.media_count, 0)
 
     def test_hashtag_medias_top(self):
         medias = self.cl.hashtag_medias_top("instagram", amount=2)
@@ -58,24 +59,11 @@ class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(medias_a1[0], Media)
         self.assertEqual(len(medias_v1), 31)
         self.assertIsInstance(medias_v1[0], Media)
-        for i, a1 in enumerate(medias_a1[:10]):
-            a1 = a1.dict()
-            v1 = medias_v1[i].dict()
+        for media in [*medias_a1[:10], *medias_v1[:10]]:
+            data = media.model_dump()
             for f in self.REQUIRED_MEDIA_FIELDS:
-                a1_val, v1_val = a1[f], v1[f]
-                is_album = a1["media_type"] == 8
-                is_video = v1.get("video_duration") > 0
-                if f == "thumbnail_url" and not is_album:
-                    a1_val = a1[f].path.rsplit("/", 1)[1]
-                    v1_val = v1[f].path.rsplit("/", 1)[1]
-                if f == "video_url" and is_video:
-                    a1_val = a1[f].path.rsplit(".", 1)[1]
-                    v1_val = v1[f].path.rsplit(".", 1)[1]
-                if f in ("view_count", "like_count"):
-                    # instagram can different counts for public and private
-                    if f == "view_count" and not is_video:
-                        continue
-                    self.assertTrue(a1_val > 1)
-                    self.assertTrue(v1_val > 1)
-                    continue
-                self.assertEqual(a1_val, v1_val)
+                self.assertIn(f, data)
+            self.assertTrue(data["pk"])
+            self.assertTrue(data["id"])
+            self.assertTrue(data["code"])
+            self.assertTrue(data["media_type"])

--- a/tests/live/test_location.py
+++ b/tests/live/test_location.py
@@ -78,14 +78,6 @@ class ClientLocationTestCase(_helpers.ClientPrivateTestCase):
         self.assertEqual(len(medias), 2)
         self.assertIsInstance(medias[0], Media)
 
-    # def test_extract_location_medias_top(self):
-    #     medias_a1 = self.cl.location_medias_top_a1(197780767581661, amount=9)
-    #     medias_v1 = self.cl.location_medias_top_v1(197780767581661, amount=9)
-    #     self.assertEqual(len(medias_a1), 9)
-    #     self.assertIsInstance(medias_a1[0], Media)
-    #     self.assertEqual(len(medias_v1), 9)
-    #     self.assertIsInstance(medias_v1[0], Media)
-
     def test_location_medias_recent(self):
         medias = self.cl.location_medias_recent(197780767581661, amount=2)
         self.assertEqual(len(medias), 2)

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -1,7 +1,53 @@
+from instagrapi.exceptions import ClientNotFoundError
 from tests.helpers import *
 
 
 class HashtagRegressionTestCase(unittest.TestCase):
+    def test_hashtag_info_a1_falls_back_to_private_when_public_page_is_gone(self):
+        client = Client()
+        hashtag = Hashtag(id="1", name="pizza")
+        client.public_a1_request = Mock(side_effect=ClientNotFoundError("gone"))
+        client.hashtag_info_v1 = Mock(return_value=hashtag)
+
+        result = client.hashtag_info_a1("pizza")
+
+        self.assertEqual(result, hashtag)
+        client.public_a1_request.assert_called_once()
+        client.hashtag_info_v1.assert_called_once_with("pizza")
+
+    def test_hashtag_medias_a1_chunk_falls_back_to_private_when_public_page_is_gone(self):
+        client = Client()
+        client.public_a1_request = Mock(side_effect=ClientNotFoundError("gone"))
+        client.hashtag_medias_v1_chunk = Mock(return_value=(["media"], "cursor"))
+
+        medias, cursor = client.hashtag_medias_a1_chunk("pizza", max_amount=2, tab_key="recent")
+
+        self.assertEqual(medias, ["media"])
+        self.assertEqual(cursor, "cursor")
+        client.public_a1_request.assert_called_once()
+        client.hashtag_medias_v1_chunk.assert_called_once_with("pizza", 2, "recent", None)
+
+    def test_hashtag_medias_a1_chunk_falls_back_to_private_when_public_page_is_short(self):
+        client = Client()
+        client.public_a1_request = Mock(return_value={"data": {"recent": {"sections": [], "more_available": False}}})
+        client.hashtag_medias_v1_chunk = Mock(return_value=(["media"], "cursor"))
+
+        medias, cursor = client.hashtag_medias_a1_chunk("pizza", max_amount=2, tab_key="recent")
+
+        self.assertEqual(medias, ["media"])
+        self.assertEqual(cursor, "cursor")
+        client.hashtag_medias_v1_chunk.assert_called_once_with("pizza", 2, "recent", None)
+
+    def test_hashtag_medias_a1_uses_full_private_fallback_when_chunk_is_short(self):
+        client = Client()
+        client.hashtag_medias_a1_chunk = Mock(return_value=(["media"], "cursor"))
+        client.hashtag_medias_v1 = Mock(return_value=["media", "media2"])
+
+        medias = client.hashtag_medias_a1("pizza", amount=2, tab_key="recent")
+
+        self.assertEqual(medias, ["media", "media2"])
+        client.hashtag_medias_v1.assert_called_once_with("pizza", 2, "recent")
+
     def test_hashtag_medias_recent_strips_leading_hash_and_warns(self):
         client = Client()
         client.hashtag_medias_recent_a1 = Mock(return_value=["media"])

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -2,49 +2,38 @@ from tests.helpers import *
 
 
 class HashtagRegressionTestCase(unittest.TestCase):
-    def test_hashtag_info_a1_uses_private_endpoint_without_public_web_request(self):
+    def test_dead_public_a1_methods_are_removed(self):
         client = Client()
-        hashtag = Hashtag(id="1", name="pizza")
-        client.public_a1_request = Mock(side_effect=AssertionError("public web should not be called"))
-        client.hashtag_info_v1 = Mock(return_value=hashtag)
+        removed_methods = (
+            "public_a1_request",
+            "public_a1_request_user_info_by_username",
+            "media_info_a1",
+            "user_info_by_username_a1",
+            "location_info_a1",
+            "location_medias_a1_chunk",
+            "location_medias_a1",
+            "location_medias_top_a1",
+            "location_medias_recent_a1",
+            "hashtag_info_a1",
+            "hashtag_medias_a1_chunk",
+            "hashtag_medias_a1",
+            "hashtag_medias_top_a1",
+            "hashtag_medias_recent_a1",
+            "hashtag_related_hashtags",
+        )
 
-        result = client.hashtag_info_a1("pizza")
-
-        self.assertEqual(result, hashtag)
-        client.public_a1_request.assert_not_called()
-        client.hashtag_info_v1.assert_called_once_with("pizza")
-
-    def test_hashtag_medias_a1_chunk_uses_private_endpoint_without_public_web_request(self):
-        client = Client()
-        client.public_a1_request = Mock(side_effect=AssertionError("public web should not be called"))
-        client.hashtag_medias_v1_chunk = Mock(return_value=(["media"], "cursor"))
-
-        medias, cursor = client.hashtag_medias_a1_chunk("pizza", max_amount=2, tab_key="recent")
-
-        self.assertEqual(medias, ["media"])
-        self.assertEqual(cursor, "cursor")
-        client.public_a1_request.assert_not_called()
-        client.hashtag_medias_v1_chunk.assert_called_once_with("pizza", 2, "recent", None)
-
-    def test_hashtag_medias_a1_uses_full_private_fallback_when_chunk_is_short(self):
-        client = Client()
-        client.hashtag_medias_a1_chunk = Mock(return_value=(["media"], "cursor"))
-        client.hashtag_medias_v1 = Mock(return_value=["media", "media2"])
-
-        medias = client.hashtag_medias_a1("pizza", amount=2, tab_key="recent")
-
-        self.assertEqual(medias, ["media", "media2"])
-        client.hashtag_medias_v1.assert_called_once_with("pizza", 2, "recent")
+        for method_name in removed_methods:
+            self.assertFalse(hasattr(client, method_name), method_name)
 
     def test_hashtag_medias_recent_strips_leading_hash_and_warns(self):
         client = Client()
-        client.hashtag_medias_recent_a1 = Mock(return_value=["media"])
+        client.hashtag_medias_recent_v1 = Mock(return_value=["media"])
 
         with self.assertWarnsRegex(UserWarning, "leading '#'"):
             medias = client.hashtag_medias_recent("#pizza", amount=1)
 
         self.assertEqual(medias, ["media"])
-        client.hashtag_medias_recent_a1.assert_called_once_with("pizza", 1)
+        client.hashtag_medias_recent_v1.assert_called_once_with("pizza", 1)
 
     def test_hashtag_name_cannot_be_empty_after_normalization(self):
         client = Client()

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -1,41 +1,29 @@
-from instagrapi.exceptions import ClientNotFoundError
 from tests.helpers import *
 
 
 class HashtagRegressionTestCase(unittest.TestCase):
-    def test_hashtag_info_a1_falls_back_to_private_when_public_page_is_gone(self):
+    def test_hashtag_info_a1_uses_private_endpoint_without_public_web_request(self):
         client = Client()
         hashtag = Hashtag(id="1", name="pizza")
-        client.public_a1_request = Mock(side_effect=ClientNotFoundError("gone"))
+        client.public_a1_request = Mock(side_effect=AssertionError("public web should not be called"))
         client.hashtag_info_v1 = Mock(return_value=hashtag)
 
         result = client.hashtag_info_a1("pizza")
 
         self.assertEqual(result, hashtag)
-        client.public_a1_request.assert_called_once()
+        client.public_a1_request.assert_not_called()
         client.hashtag_info_v1.assert_called_once_with("pizza")
 
-    def test_hashtag_medias_a1_chunk_falls_back_to_private_when_public_page_is_gone(self):
+    def test_hashtag_medias_a1_chunk_uses_private_endpoint_without_public_web_request(self):
         client = Client()
-        client.public_a1_request = Mock(side_effect=ClientNotFoundError("gone"))
+        client.public_a1_request = Mock(side_effect=AssertionError("public web should not be called"))
         client.hashtag_medias_v1_chunk = Mock(return_value=(["media"], "cursor"))
 
         medias, cursor = client.hashtag_medias_a1_chunk("pizza", max_amount=2, tab_key="recent")
 
         self.assertEqual(medias, ["media"])
         self.assertEqual(cursor, "cursor")
-        client.public_a1_request.assert_called_once()
-        client.hashtag_medias_v1_chunk.assert_called_once_with("pizza", 2, "recent", None)
-
-    def test_hashtag_medias_a1_chunk_falls_back_to_private_when_public_page_is_short(self):
-        client = Client()
-        client.public_a1_request = Mock(return_value={"data": {"recent": {"sections": [], "more_available": False}}})
-        client.hashtag_medias_v1_chunk = Mock(return_value=(["media"], "cursor"))
-
-        medias, cursor = client.hashtag_medias_a1_chunk("pizza", max_amount=2, tab_key="recent")
-
-        self.assertEqual(medias, ["media"])
-        self.assertEqual(cursor, "cursor")
+        client.public_a1_request.assert_not_called()
         client.hashtag_medias_v1_chunk.assert_called_once_with("pizza", 2, "recent", None)
 
     def test_hashtag_medias_a1_uses_full_private_fallback_when_chunk_is_short(self):

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -106,9 +106,8 @@ class PublicRegressionTestCase(unittest.TestCase):
         private_fallback.assert_not_called()
         self.assertIn("Incorrect Query", str(cm.exception))
 
-    def test_media_info_gql_falls_back_to_private_when_doc_id_is_unauthorized(self):
+    def test_media_info_gql_does_not_fallback_to_private_when_doc_id_is_unauthorized(self):
         client = Client()
-        expected = Mock(spec=Media)
 
         with mock.patch.object(
             client,
@@ -120,11 +119,13 @@ class PublicRegressionTestCase(unittest.TestCase):
                 "public_doc_id_graphql_request",
                 side_effect=ClientForbiddenError("403", response=Mock(status_code=403)),
             ):
-                with mock.patch.object(client, "media_info_v1", return_value=expected) as fallback:
-                    result = client.media_info_gql("2110901750722920960")
+                with mock.patch.object(
+                    client, "media_info_v1", side_effect=AssertionError("private fallback")
+                ) as fallback:
+                    with self.assertRaises(ClientForbiddenError):
+                        client.media_info_gql("2110901750722920960")
 
-        self.assertIs(result, expected)
-        fallback.assert_called_once_with("2110901750722920960")
+        fallback.assert_not_called()
 
     def test_media_info_gql_falls_back_to_doc_id_on_public_404(self):
         client = Client()

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -106,7 +106,7 @@ class PublicRegressionTestCase(unittest.TestCase):
         private_fallback.assert_not_called()
         self.assertIn("Incorrect Query", str(cm.exception))
 
-    def test_media_info_gql_falls_back_to_a1_when_doc_id_is_unauthorized(self):
+    def test_media_info_gql_falls_back_to_private_when_doc_id_is_unauthorized(self):
         client = Client()
         expected = Mock(spec=Media)
 
@@ -120,7 +120,7 @@ class PublicRegressionTestCase(unittest.TestCase):
                 "public_doc_id_graphql_request",
                 side_effect=ClientForbiddenError("403", response=Mock(status_code=403)),
             ):
-                with mock.patch.object(client, "media_info_a1", return_value=expected) as fallback:
+                with mock.patch.object(client, "media_info_v1", return_value=expected) as fallback:
                     result = client.media_info_gql("2110901750722920960")
 
         self.assertIs(result, expected)

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -516,15 +516,6 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             with self.assertRaises(UserNotFound):
                 client.user_web_profile_info_v1("missing")
 
-    def test_user_info_by_username_a1_requests_full_public_payload(self):
-        client = Client()
-        expected = {"graphql": {"user": {"id": "1"}}}
-        with mock.patch.object(client, "public_a1_request", return_value=expected) as public_a1_request:
-            result = client.user_info_by_username_a1("Example")
-
-        self.assertEqual(result, expected)
-        public_a1_request.assert_called_once_with("/example/", full=True)
-
     def test_user_info_v2_gql_uses_profile_doc_id(self):
         client = Client()
         payload = self.build_web_profile_user(id="25025320")["data"]["user"]


### PR DESCRIPTION
## Summary

- Remove the legacy public A1 API surface: `public_a1_request`, `public_a1_request_user_info_by_username`, and the old `*_a1` helpers for media, users, locations, and hashtags.
- Route high-level hashtag/location helpers directly to authenticated private/mobile `_v1` methods.
- Keep `media_info_gql()` GraphQL-only: it can fall back from legacy `query_hash` GraphQL to the current `doc_id` GraphQL query, but it does not fall back to `media_info_v1()`.
- Remove `hashtag_related_hashtags()` because it only depended on the removed public web related-tags payload.
- Update docs and live/regression tests so the library no longer documents `?__a=1` as a supported compatibility layer.

Fixes #2085.

## Verification

- `pytest tests/regression/test_hashtag.py tests/regression/test_public.py tests/regression/test_user.py tests/regression/test_hardening.py -q`
- `pytest tests/regression/test_public.py::PublicRegressionTestCase::test_media_info_gql_does_not_fallback_to_private_when_doc_id_is_unauthorized tests/regression/test_public.py::PublicRegressionTestCase::test_media_info_gql_falls_back_to_doc_id_on_public_404 -q`
- `ruff check instagrapi/mixins/hashtag.py instagrapi/mixins/media.py instagrapi/mixins/user.py instagrapi/mixins/location.py instagrapi/mixins/public.py tests/regression/test_hashtag.py tests/regression/test_public.py tests/regression/test_user.py tests/live/test_hashtag.py tests/live/test_location.py`
- `git diff --check`
- GitHub CI: CodeQL, lint, docs, bandit, and Python 3.10-3.14 compatibility tests passed.
- Targeted live hashtag/location checks were attempted, but the available live test accounts/proxy failed during login/proxy setup before endpoint execution. No hashtag/location endpoint failure was observed.
