### PR TITLE
Align social action payloads

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -583,12 +583,19 @@ class MediaMixin:
             A boolean value
         """
         assert self.user_id, "Login required"
-        media_id = self.media_pk(media_id)
+        media_id = str(media_id)
         data = {
             "inventory_source": "media_or_ad",
             "media_id": media_id,
+            "_uid": str(self.user_id),
             "radio_type": "wifi-none",
+            "delivery_class": "organic",
+            "tap_source": "button",
+            "is_2m_enabled": "false",
+            "is_from_swipe": "false",
             "is_carousel_bumped_post": "false",
+            "floating_context_items": "[]",
+            "media_pct_watched": "0",
             "container_module": "feed_timeline",
             "feed_position": str(random.randint(0, 6)),
         }

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1160,7 +1160,14 @@ class UserMixin:
         if user_id in self._users_following.get(self.user_id, []):
             self.logger.debug("User %s already followed", user_id)
             return False
-        data = self.with_action_data({"user_id": user_id})
+        data = self.with_action_data(
+            {
+                "user_id": user_id,
+                "_uid": str(self.user_id),
+                "include_follow_friction_check": "1",
+                "container_module": "profile",
+            }
+        )
         result = self.private_request(f"friendships/create/{user_id}/", data)
         if self.user_id in self._users_following:
             self._users_following.pop(self.user_id)  # reset
@@ -1181,7 +1188,13 @@ class UserMixin:
         """
         assert self.user_id, "Login required"
         user_id = str(user_id)
-        data = self.with_action_data({"user_id": user_id})
+        data = self.with_action_data(
+            {
+                "user_id": user_id,
+                "_uid": str(self.user_id),
+                "container_module": "profile",
+            }
+        )
         result = self.private_request(f"friendships/destroy/{user_id}/", data)
         if self.user_id in self._users_following:
             self._users_following[self.user_id].pop(user_id, None)

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -70,8 +70,12 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(likers[0], UserShort)
 
     def test_media_like_by_pk(self):
-        media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/ByU3LAslgWY/")
-        self.assertTrue(self.cl.media_like(media_pk))
+        user_id = self.user_id_from_username("instagram")
+        media = self.cl.user_medias_v1(user_id, amount=1)[0]
+        try:
+            self.assertTrue(self.cl.media_like(media.pk))
+        finally:
+            self.cl.media_unlike(media.pk)
 
     def test_media_edit(self):
         # Upload photo
@@ -128,19 +132,18 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
             cleanup(path)
 
     def test_media_like_and_unlike(self):
-        media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")
-        self.assertTrue(self.cl.media_unlike(media_pk))
-        media = self.cl.media_info_v1(media_pk)
-        like_count = int(media.like_count)
+        user_id = self.user_id_from_username("instagram")
+        media = self.cl.user_medias_v1(user_id, amount=1)[0]
+        media_pk = media.pk
+        self.assertTrue(self.cl.media_unlike(media.id))
         # like
         self.assertTrue(self.cl.media_like(media.id))
         media = self.cl.media_info_v1(media_pk)  # refresh after like
-        new_like_count = int(media.like_count)
-        self.assertEqual(new_like_count, like_count + 1)
+        self.assertTrue(media.has_liked)
         # unlike
         self.assertTrue(self.cl.media_unlike(media.id))
         media = self.cl.media_info_v1(media_pk)  # refresh after unlike
-        self.assertEqual(media.like_count, like_count)
+        self.assertFalse(media.has_liked)
 
 
 class ClientCompareExtractTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -175,12 +175,14 @@ class ClientUserExtendTestCase(_helpers.ClientPrivateTestCase):
 
     def test_user_follow_unfollow(self):
         user_id = self.user_id_from_username("instagram")
-        self.cl.user_follow(user_id)
-        following = self.cl.user_following(self.cl.user_id)
-        self.assertIn(user_id, following)
-        self.cl.user_unfollow(user_id)
-        following = self.cl.user_following(self.cl.user_id)
-        self.assertNotIn(user_id, following)
+        try:
+            self.assertTrue(self.cl.user_follow(user_id))
+            relationship = self.cl.user_friendship_v1(user_id)
+            self.assertTrue(relationship.following)
+        finally:
+            self.cl.user_unfollow(user_id)
+        relationship = self.cl.user_friendship_v1(user_id)
+        self.assertFalse(relationship.following)
 
     # def test_send_new_note(self):
     #     self.cl.create_note("Hello from Instagrapi!", 0)

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -101,6 +101,39 @@ class CheckOffensiveCommentV2RegressionTestCase(unittest.TestCase):
             client.media_check_offensive_comment_v2("9_8", "rude")
 
 
+class MediaActionPayloadRegressionTestCase(unittest.TestCase):
+    def _build_logged_in_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        client.uuid = "uuid"
+        client.android_device_id = "android-device"
+        return client
+
+    def test_media_like_preserves_full_media_id_and_posts_current_action_context(self):
+        client = self._build_logged_in_client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"status": "ok"},
+        ) as private_request:
+            self.assertTrue(client.media_like("123_456"))
+
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/123_456/like/")
+        self.assertEqual(data["media_id"], "123_456")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["delivery_class"], "organic")
+        self.assertEqual(data["tap_source"], "button")
+        self.assertEqual(data["is_2m_enabled"], "false")
+        self.assertEqual(data["is_from_swipe"], "false")
+        self.assertEqual(data["floating_context_items"], "[]")
+        self.assertEqual(data["media_pct_watched"], "0")
+        self.assertEqual(data["container_module"], "feed_timeline")
+        self.assertIn(data["feed_position"], {str(i) for i in range(7)})
+
+
 class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
     def _media_v1_payload(self, pk="1"):
         return {

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -372,6 +372,45 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(result, {"1": False, "2": True})
         decline.assert_has_calls([mock.call("1"), mock.call("2")])
 
+    def test_user_follow_posts_current_action_context(self):
+        client = self.build_private_client()
+        client.android_device_id = "android-device"
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"friendship_status": {"following": True}},
+        ) as private_request:
+            self.assertTrue(client.user_follow("42"))
+
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "friendships/create/42/")
+        self.assertEqual(data["user_id"], "42")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["include_follow_friction_check"], "1")
+        self.assertEqual(data["container_module"], "profile")
+
+    def test_user_unfollow_posts_current_action_context(self):
+        client = self.build_private_client()
+        client.android_device_id = "android-device"
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"friendship_status": {"following": False}},
+        ) as private_request:
+            self.assertTrue(client.user_unfollow("42"))
+
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "friendships/destroy/42/")
+        self.assertEqual(data["user_id"], "42")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["container_module"], "profile")
+
     def test_chaining_sends_expected_params_and_returns_payload(self):
         client = Client()
         expected = {"users": [{"pk": "9", "username": "suggested"}]}


### PR DESCRIPTION
## Summary
- Align `media_like` / `media_unlike` payloads with the current Android app action context and preserve full media IDs when provided.
- Align `user_follow` / `user_unfollow` payloads with the current profile action context.
- Stabilize related live tests so they use current media and friendship state instead of stale media fixtures or public like-count deltas.

Closes #2525.

## Test Plan
- `pytest -q tests/regression`
- `ruff check instagrapi/mixins/media.py instagrapi/mixins/user.py tests/regression/test_media.py tests/regression/test_user.py tests/live/test_media.py tests/live/test_user.py`
- `git diff --check`
- Targeted live check: `test_media_like_by_pk`, `test_media_like_and_unlike`, `test_user_follow_unfollow`
