### PR TITLE
Align current flow request parameters

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -56,6 +56,8 @@ jobs:
         if: github.event.inputs.test_target == 'direct' || github.event.inputs.test_target == 'all'
         run: |
           pytest -sv \
+            tests/live/test_direct.py::ClientDirectTestCase::test_direct_search_live \
+            tests/live/test_direct.py::ClientDirectTestCase::test_direct_media_live \
             tests/live/test_direct.py::ClientDirectMediaLiveTestCase \
             tests/live/test_direct.py::ClientDirectThreadLiveTestCase::test_direct_thread_add_users_live
 

--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -113,6 +113,9 @@ class Client(
         self.session_retry_total = kwargs.pop("session_retry_total", 3)
         self.session_retry_backoff_factor = kwargs.pop("session_retry_backoff_factor", 2)
         self.session_retry_statuses = list(kwargs.pop("session_retry_statuses", [429, 500, 502, 503, 504]))
+        self.timezone_offset = kwargs.pop("timezone_offset", -14400)
+        self.timezone_name = kwargs.pop("timezone_name", "")
+        self.push_disabled = kwargs.pop("push_disabled", True)
 
         super().__init__(**kwargs)
 

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -257,6 +257,52 @@ class PostLoginFlowMixin:
             return "[]"
         return json.dumps(self._timeline_feed_view_info(seen_posts.split(",")))
 
+    @staticmethod
+    def _timeline_session_level_signals_json() -> str:
+        inactive_time = -1
+        return dumps(
+            {
+                "time_since_current_surface_session_start": 0,
+                "time_since_fg_session_start": 0,
+                "time_since_last_background": 0,
+                "num_ad_seen_current_surface_current_session": 0,
+                "app_entry": "normal",
+                "last_surfaces_visited_current_session": [],
+                "video_play_count": 0,
+                "video_pause_count": 0,
+                "video_dwell_time_sum": 0,
+                "video_dwell_time_max": 0,
+                "video_view_count": 0,
+                "video_intentional_audio_on": 0,
+                "video_intentional_audio_off": 0,
+                "video_audio_on_count": 0,
+                "feed_to_reels_iv_entry": 0,
+                "time_since_last_ad_click": inactive_time,
+                "time_since_last_ad_like": inactive_time,
+                "time_since_last_organic_like": inactive_time,
+                "time_since_last_like": inactive_time,
+                "time_since_last_organic_business_profile_visit": inactive_time,
+                "time_since_last_ad_imp": inactive_time,
+                "time_since_last_search": inactive_time,
+                "time_since_last_organic_engagement_event": inactive_time,
+                "time_since_last_ad_profile_visit": inactive_time,
+                "time_since_last_ad_cta": inactive_time,
+                "time_since_last_ad_caption_more_click": inactive_time,
+                "time_since_last_ad_comment_button": inactive_time,
+                "time_since_last_ad_share": inactive_time,
+                "time_since_last_ad_media_tap": inactive_time,
+                "time_since_last_ad_gesture": inactive_time,
+                "time_since_last_search_result_click": inactive_time,
+                "time_since_last_serp_click": inactive_time,
+                "time_since_last_organic_share": inactive_time,
+                "time_since_last_organic_comment": inactive_time,
+                "time_since_last_organic_caption_click": inactive_time,
+                "time_since_last_organic_media_tap": inactive_time,
+                "time_since_last_organic_gesture": inactive_time,
+                "num_search_clicks_current_session": 0,
+            }
+        )
+
     def get_timeline_feed(
         self,
         reason: TIMELINE_FEED_REASON = "pull_to_refresh",
@@ -291,22 +337,33 @@ class PostLoginFlowMixin:
             "X-CM-Bandwidth-KBPS": "-1.000",  # str(random.randint(2000, 5000)),
             "X-CM-Latency": str(random.randint(1, 5)),
         }
+        request_time_ms = str(int(time.time() * 1000))
         data = {
+            "app_start_time": request_time_ms,
             "has_camera_permission": "1",
             "feed_view_info": "[]",  # e.g. [{"media_id":"2634223601739446191_7450075998","version":24,
             # "media_pct":1.0,"time_info":{"10":63124,"25":63124,"50":63124,"75":63124},"latest_timestamp":1628253523186}]
+            "client_recorded_request_time_ms": request_time_ms,
+            "client_seen_store_media_list": "",
+            "client_view_state_media_list": "[]",
+            "device_timezone_name": "GMT",
+            "feed_reshare_info": "",
             "phone_id": self.phone_id,
             "reason": reason,
             "battery_level": 100,  # Random battery level is not simulating real bahaviour
             "timezone_offset": str(self.timezone_offset),
             # "_csrftoken": self.token, No longer in data
             "device_id": self.uuid,
+            "include_attribution_ui_data": "true",
+            "push_disabled": "true",
             "request_id": self.request_id,
+            "request_build_time": request_time_ms,
             "_uuid": self.uuid,
             "is_charging": random.randint(0, 1),
             "is_dark_mode": 1,  # Random dark mode is not simulating real bahaviour
             "will_sound_on": random.randint(0, 1),
             "session_id": self.client_session_id,
+            "session_level_signals": self._timeline_session_level_signals_json(),
             "bloks_versioning_id": self.bloks_versioning_id,
         }
         if reason in ["pull_to_refresh", "auto_refresh"]:
@@ -317,6 +374,9 @@ class PostLoginFlowMixin:
         if max_id:
             data["max_id"] = max_id
             data["reason"] = "pagination"
+            data["organic_realtime_information"] = "[]"
+            data["pagination_source"] = "feed_recs"
+            data["triggered_by_visible_spinner"] = "false"
             if seen_posts is None:
                 seen_posts = getattr(self, "_timeline_seen_posts", [])
 

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -346,7 +346,7 @@ class PostLoginFlowMixin:
             "client_recorded_request_time_ms": request_time_ms,
             "client_seen_store_media_list": "",
             "client_view_state_media_list": "[]",
-            "device_timezone_name": "GMT",
+            "device_timezone_name": self.timezone_name,
             "feed_reshare_info": "",
             "phone_id": self.phone_id,
             "reason": reason,
@@ -355,7 +355,7 @@ class PostLoginFlowMixin:
             # "_csrftoken": self.token, No longer in data
             "device_id": self.uuid,
             "include_attribution_ui_data": "true",
-            "push_disabled": "true",
+            "push_disabled": self._bool_to_ig_string(self.push_disabled),
             "request_id": self.request_id,
             "request_build_time": request_time_ms,
             "_uuid": self.uuid,
@@ -446,6 +446,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
     country_code = 1  # Phone code, default USA
     locale = "en_US"
     timezone_offset: int = -14400  # New York, GMT-4 in seconds
+    timezone_name: str = ""
+    push_disabled: bool = True
     public_request_retries_count = 3
     public_request_retries_timeout = 2
     session_retry_total = 3
@@ -500,6 +502,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         self.authorization_data = self.settings.get("authorization_data", {})
         self.last_login = self.settings.get("last_login")
         timezone_offset = self.settings.get("timezone_offset", self.timezone_offset)
+        timezone_name = self.settings.get("timezone_name", self.timezone_name)
+        push_disabled = self.settings.get("push_disabled", self.push_disabled)
         locale = self.settings.get("locale", self.locale)
         country = self.settings.get("country", self.country)
         country_code = self.settings.get("country_code", self.country_code)
@@ -521,7 +525,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             public_transport_impersonate=self.settings.get("public_transport_impersonate"),
         )
 
-        self.set_timezone_offset(timezone_offset)
+        self.set_timezone_offset(timezone_offset, timezone_name=timezone_name or None)
+        self.set_push_disabled(push_disabled)
         self.set_device(self.settings.get("device_settings"))
         self.set_user_agent(self.settings.get("user_agent"))
         self.set_uuids(self.settings.get("uuids") or {})
@@ -797,6 +802,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "country_code": self.country_code,
             "locale": self.locale,
             "timezone_offset": self.timezone_offset,
+            "timezone_name": self.timezone_name,
+            "push_disabled": self.push_disabled,
             "request_timeout": self.request_timeout,
             "public_request_retries_count": self.public_request_retries_count,
             "public_request_retries_timeout": self.public_request_retries_timeout,

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -124,16 +124,41 @@ class UploadClipMixin:
     Helpers to upload CLIP videos
     """
 
-    def clip_info_for_creation(self) -> Dict:
+    @staticmethod
+    def _default_video_device_status() -> Dict[str, object]:
+        return {
+            "hw_av1_dec": False,
+            "hw_vp9_dec": False,
+            "hw_avc_dec": False,
+            "10bit_hw_av1_dec": False,
+            "10bit_hw_vp9_dec": False,
+            "is_hlg_supported": False,
+            "chip_vendor": "others",
+            "chip_name": "unknown",
+            "core_count": 0,
+            "max_ghz_sum": 0,
+            "min_ghz_sum": 0,
+        }
+
+    def clip_info_for_creation(self, device_status: Optional[Dict[str, object]] = None) -> Dict:
         """
         Get Reel creation preflight configuration for the current user.
+
+        Parameters
+        ----------
+        device_status: Dict[str, object], optional
+            Device video capability status sent by the Instagram Android app.
 
         Returns
         -------
         Dict
             A dictionary of response from the call
         """
-        return self.private_request("clips/clips_info_for_creation/")
+        device_status = device_status or self._default_video_device_status()
+        return self.private_request(
+            "clips/clips_info_for_creation/",
+            params={"device_status": json.dumps(device_status)},
+        )
 
     def clip_trial_eligible(self) -> bool:
         """
@@ -166,19 +191,7 @@ class UploadClipMixin:
         Dict
             A dictionary of response from the call
         """
-        device_status = device_status or {
-            "hw_av1_dec": False,
-            "hw_vp9_dec": False,
-            "hw_avc_dec": False,
-            "10bit_hw_av1_dec": False,
-            "10bit_hw_vp9_dec": False,
-            "is_hlg_supported": False,
-            "chip_vendor": "others",
-            "chip_name": "unknown",
-            "core_count": 0,
-            "max_ghz_sum": 0,
-            "min_ghz_sum": 0,
-        }
+        device_status = device_status or self._default_video_device_status()
         return self.private_request(
             "clips/user/share_to_fb_config/",
             params={"device_status": json.dumps(device_status)},

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -155,7 +155,7 @@ class DirectMixin:
             "fetch_reason": "initial_snapshot",
             "include_old_mrs": "false",
             "no_pending_badge": "true",
-            "push_disabled": "true",
+            "push_disabled": self._bool_to_ig_string(self.push_disabled),
         }
         if selected_filter:
             assert selected_filter in SELECTED_FILTERS, (

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -71,6 +71,12 @@ class DirectMixin:
     Helpers for managing Direct Messaging
     """
 
+    def _direct_request_tracking_params(self) -> Dict[str, str]:
+        return {
+            "eb_device_id": "0",
+            "igd_request_log_tracking_id": self.generate_uuid(),
+        }
+
     def direct_threads(
         self,
         amount: int = 20,
@@ -140,11 +146,16 @@ class DirectMixin:
         """
         assert self.user_id, "Login required"
         params = {
+            **self._direct_request_tracking_params(),
             "visual_message_return_type": "unseen",
             "thread_message_limit": "10",
             "persistentBadging": "true",
             "limit": "20",
             "is_prefetching": "false",
+            "fetch_reason": "initial_snapshot",
+            "include_old_mrs": "false",
+            "no_pending_badge": "true",
+            "push_disabled": "true",
         }
         if selected_filter:
             assert selected_filter in SELECTED_FILTERS, (
@@ -1349,11 +1360,13 @@ class DirectMixin:
         assert mode in SEARCH_MODES, f'Unsupported mode="{mode}" {SEARCH_MODES}'
 
         params = {
+            "max_ai_bot_results": "0",
             "max_ig_bus_results": "10",
             "mode": mode,
             "show_threads": "true",
             "query": str(query),
             "max_ig_results": "10",
+            "max_ibc_results": "20",
             "max_fb_results": "0",
         }
         result = self.private_request(
@@ -1381,6 +1394,7 @@ class DirectMixin:
             List of Tuples with DirectMessage (matched query) and its DirectThread
         """
         params = {
+            "hide_locked_threads": '{"message_content":"false"}',
             "offsets": '{"message_content":"0","reshared_content":""}',
             "query": query,
             "result_types": '["message_content","reshared_content"]',
@@ -1883,7 +1897,11 @@ class DirectMixin:
             A list of objects of Media
         """
         assert self.user_id, "Login required"
-        params = {"limit": 20, "media_type": "photos_and_videos"}
+        params = {
+            **self._direct_request_tracking_params(),
+            "limit": 20,
+            "media_type": "media_shares",
+        }
         max_timestamp = None
         items = []
         while True:

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -297,7 +297,27 @@ class PrivateRequestMixin:
             self.set_country(locale.rsplit("_", 1)[1])
         return True
 
-    def set_timezone_offset(self, seconds: int = 0):
+    @staticmethod
+    def _timezone_name_from_offset(seconds: int) -> str:
+        seconds = int(seconds)
+        if seconds == 0:
+            return "GMT"
+        sign = "+" if seconds > 0 else "-"
+        seconds = abs(seconds)
+        hours, remainder = divmod(seconds, 3600)
+        minutes = remainder // 60
+        return f"GMT{sign}{hours:02d}:{minutes:02d}"
+
+    @staticmethod
+    def _bool_to_ig_string(value: bool) -> str:
+        return "true" if bool(value) else "false"
+
+    def set_timezone_name(self, timezone_name: str = ""):
+        """Set your timezone name for request metadata."""
+        self.settings["timezone_name"] = self.timezone_name = str(timezone_name)
+        return True
+
+    def set_timezone_offset(self, seconds: int = 0, timezone_name=None):
         """Set you timezone offset in seconds
 
         Parameters
@@ -311,6 +331,14 @@ class PrivateRequestMixin:
             A boolean value
         """
         self.settings["timezone_offset"] = self.timezone_offset = int(seconds)
+        self.set_timezone_name(
+            self._timezone_name_from_offset(self.timezone_offset) if timezone_name is None else timezone_name
+        )
+        return True
+
+    def set_push_disabled(self, disabled: bool = True):
+        """Configure whether request metadata reports push as disabled."""
+        self.settings["push_disabled"] = self.push_disabled = bool(disabled)
         return True
 
     def set_ig_u_rur(self, value):

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -89,6 +89,37 @@ class ClientDirectTestCase(_helpers.ClientPrivateTestCase):
         except DirectThreadNotFound:
             pass
 
+    def test_direct_search_live(self):
+        users = self.cl.direct_search("instagram")
+
+        self.assertIsInstance(users, list)
+        for user in users:
+            self.assertIsInstance(user, UserShort)
+
+    def test_direct_media_live(self):
+        threads = self.cl.direct_threads(amount=5)
+        cleanup_message = None
+        if threads:
+            thread_id = threads[0].id
+        else:
+            instagram = self.user_id_from_username("instagram")
+            cleanup_message = self.cl.direct_send("Media lookup ping", user_ids=[instagram])
+            thread_id = cleanup_message.thread_id
+
+        try:
+            medias = self.cl.direct_media(thread_id, amount=1)
+        finally:
+            if cleanup_message:
+                try:
+                    self.cl.direct_message_unsend(cleanup_message.thread_id, cleanup_message.id)
+                    self.cl.direct_thread_hide(cleanup_message.thread_id)
+                except Exception as exc:
+                    logger.warning("Direct media lookup cleanup failed: %s", exc)
+
+        self.assertIsInstance(medias, list)
+        for media in medias:
+            self.assertIsInstance(media, Media)
+
 
 class ClientDirectMediaLiveTestCase(_helpers.ClientPrivateTestCase):
     def __init__(self, *args, **kwargs):

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -350,6 +350,13 @@ class ClientTrialReelUploadLiveTestCase(_helpers.ClientPrivateTestCase):
         self.skipTest("No fresh account has Trial Reels enabled")
 
 
+class ClientClipCreationPreflightLiveTestCase(_helpers.ClientPrivateTestCase):
+    def test_clip_info_for_creation_live(self):
+        result = self.cl.clip_info_for_creation()
+
+        self.assertEqual(result.get("status"), "ok")
+
+
 class ClientFacebookReelCrosspostLiveTestCase(_helpers.ClientPrivateTestCase):
     def __init__(self, *args, **kwargs):
         self.cl = None

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -2,6 +2,24 @@ from tests.helpers import *
 
 
 class ClipPinRegressionTestCase(unittest.TestCase):
+    def test_clip_info_for_creation_sends_device_status(self):
+        client = Client()
+        expected = {"status": "ok", "trial_config": {"is_enabled": True}}
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value=expected,
+        ) as private_request:
+            result = client.clip_info_for_creation()
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "clips/clips_info_for_creation/")
+        device_status = json.loads(private_request.call_args.kwargs["params"]["device_status"])
+        self.assertEqual(device_status["chip_vendor"], "others")
+        self.assertFalse(device_status["hw_av1_dec"])
+
     def test_clip_pin_uses_reels_grid_payload(self):
         client = Client()
         with mock.patch.object(

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -117,6 +117,63 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertIs(result, expected)
         pending.assert_called_once_with(7)
 
+    def test_direct_threads_chunk_sends_current_inbox_query_params(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "private_request", return_value={"inbox": {"threads": []}}) as private:
+            threads, cursor = client.direct_threads_chunk()
+
+        self.assertEqual(threads, [])
+        self.assertIsNone(cursor)
+        params = private.call_args.kwargs["params"]
+        self.assertEqual(params["eb_device_id"], "0")
+        self.assertRegex(params["igd_request_log_tracking_id"], r"^[0-9a-f-]{36}$")
+        self.assertEqual(params["fetch_reason"], "initial_snapshot")
+        self.assertEqual(params["include_old_mrs"], "false")
+        self.assertEqual(params["no_pending_badge"], "true")
+        self.assertEqual(params["push_disabled"], "true")
+
+    def test_direct_search_sends_current_ranked_recipient_limits(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "private_request", return_value={"ranked_recipients": []}) as private:
+            result = client.direct_search("alice")
+
+        self.assertEqual(result, [])
+        params = private.call_args.kwargs["params"]
+        self.assertEqual(params["max_ai_bot_results"], "0")
+        self.assertEqual(params["max_ibc_results"], "20")
+
+    def test_direct_message_search_hides_locked_threads(self):
+        client = self.build_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"status": "ok", "message_search_results": {}},
+        ) as private:
+            result = client.direct_message_search("alice")
+
+        self.assertEqual(result, [])
+        params = private.call_args.kwargs["params"]
+        self.assertEqual(params["hide_locked_threads"], '{"message_content":"false"}')
+
+    def test_direct_media_sends_current_thread_media_query_params(self):
+        client = self.build_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"items": [], "more_available": False},
+        ) as private:
+            result = client.direct_media(123)
+
+        self.assertEqual(result, [])
+        params = private.call_args.kwargs["params"]
+        self.assertEqual(params["eb_device_id"], "0")
+        self.assertRegex(params["igd_request_log_tracking_id"], r"^[0-9a-f-]{36}$")
+        self.assertEqual(params["media_type"], "media_shares")
+
     def test_direct_request_approve_delegates_to_pending_approve(self):
         client = self.build_client()
 

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -133,6 +133,17 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(params["no_pending_badge"], "true")
         self.assertEqual(params["push_disabled"], "true")
 
+    def test_direct_threads_chunk_uses_configured_push_state(self):
+        client = self.build_client()
+        client.set_push_disabled(False)
+
+        with mock.patch.object(client, "private_request", return_value={"inbox": {"threads": []}}) as private:
+            client.direct_threads_chunk()
+
+        params = private.call_args.kwargs["params"]
+        self.assertEqual(params["push_disabled"], "false")
+        self.assertFalse(client.get_settings()["push_disabled"])
+
     def test_direct_search_sends_current_ranked_recipient_limits(self):
         client = self.build_client()
 

--- a/tests/regression/test_timeline.py
+++ b/tests/regression/test_timeline.py
@@ -121,3 +121,41 @@ class TimelineRegressionTestCase(unittest.TestCase):
         self.assertEqual(second_data["seen_posts"], "111_1,222_1")
         feed_view_info = json.loads(second_data["feed_view_info"])
         self.assertEqual([item["media_id"] for item in feed_view_info], ["111_1", "222_1"])
+
+    def test_get_timeline_feed_sends_current_app_request_metadata(self):
+        client = Client()
+        client.private_request = Mock(return_value={"feed_items": []})
+
+        with mock.patch("instagrapi.mixins.auth.time.time", return_value=1778379170.083):
+            client.get_timeline_feed("cold_start_fetch")
+
+        data = json.loads(client.private_request.call_args.args[1])
+        self.assertEqual(data["app_start_time"], "1778379170083")
+        self.assertEqual(data["client_recorded_request_time_ms"], "1778379170083")
+        self.assertEqual(data["client_seen_store_media_list"], "")
+        self.assertEqual(data["client_view_state_media_list"], "[]")
+        self.assertEqual(data["device_timezone_name"], "GMT")
+        self.assertEqual(data["feed_reshare_info"], "")
+        self.assertEqual(data["include_attribution_ui_data"], "true")
+        self.assertEqual(data["push_disabled"], "true")
+        self.assertEqual(data["request_build_time"], "1778379170083")
+        session_level_signals = json.loads(data["session_level_signals"])
+        self.assertEqual(session_level_signals["app_entry"], "normal")
+        self.assertEqual(session_level_signals["video_play_count"], 0)
+
+    def test_get_timeline_feed_sends_current_app_pagination_metadata(self):
+        client = Client()
+        client.private_request = Mock(
+            side_effect=[
+                {"feed_items": [{"media_or_ad": {"id": "111_1"}}], "next_max_id": "next-page"},
+                {"feed_items": []},
+            ]
+        )
+
+        client.get_timeline_feed("cold_start_fetch")
+        client.get_timeline_feed(max_id="next-page")
+
+        data = json.loads(client.private_request.call_args_list[1].args[1])
+        self.assertEqual(data["organic_realtime_information"], "[]")
+        self.assertEqual(data["pagination_source"], "feed_recs")
+        self.assertEqual(data["triggered_by_visible_spinner"], "false")

--- a/tests/regression/test_timeline.py
+++ b/tests/regression/test_timeline.py
@@ -125,6 +125,7 @@ class TimelineRegressionTestCase(unittest.TestCase):
     def test_get_timeline_feed_sends_current_app_request_metadata(self):
         client = Client()
         client.private_request = Mock(return_value={"feed_items": []})
+        client.set_timezone_offset(0)
 
         with mock.patch("instagrapi.mixins.auth.time.time", return_value=1778379170.083):
             client.get_timeline_feed("cold_start_fetch")
@@ -142,6 +143,41 @@ class TimelineRegressionTestCase(unittest.TestCase):
         session_level_signals = json.loads(data["session_level_signals"])
         self.assertEqual(session_level_signals["app_entry"], "normal")
         self.assertEqual(session_level_signals["video_play_count"], 0)
+
+    def test_get_timeline_feed_uses_configured_timezone_name_and_push_state(self):
+        client = Client(settings={"timezone_offset": 10800, "timezone_name": "Europe/Moscow", "push_disabled": False})
+        client.private_request = Mock(return_value={"feed_items": []})
+
+        client.get_timeline_feed("cold_start_fetch")
+
+        data = json.loads(client.private_request.call_args.args[1])
+        self.assertEqual(data["timezone_offset"], "10800")
+        self.assertEqual(data["device_timezone_name"], "Europe/Moscow")
+        self.assertEqual(data["push_disabled"], "false")
+        self.assertEqual(client.get_settings()["timezone_name"], "Europe/Moscow")
+        self.assertFalse(client.get_settings()["push_disabled"])
+
+    def test_get_timeline_feed_accepts_timezone_and_push_constructor_kwargs(self):
+        client = Client(timezone_offset=10800, timezone_name="Europe/Moscow", push_disabled=False)
+        client.private_request = Mock(return_value={"feed_items": []})
+
+        client.get_timeline_feed("cold_start_fetch")
+
+        data = json.loads(client.private_request.call_args.args[1])
+        self.assertEqual(data["timezone_offset"], "10800")
+        self.assertEqual(data["device_timezone_name"], "Europe/Moscow")
+        self.assertEqual(data["push_disabled"], "false")
+
+    def test_get_timeline_feed_derives_timezone_name_from_offset(self):
+        client = Client()
+        client.private_request = Mock(return_value={"feed_items": []})
+        client.set_timezone_offset(19800)
+
+        client.get_timeline_feed("cold_start_fetch")
+
+        data = json.loads(client.private_request.call_args.args[1])
+        self.assertEqual(data["timezone_offset"], "19800")
+        self.assertEqual(data["device_timezone_name"], "GMT+05:30")
 
     def test_get_timeline_feed_sends_current_app_pagination_metadata(self):
         client = Client()

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -185,7 +185,11 @@ class UploadRegressionTestCase(unittest.TestCase):
         with mock.patch.object(client, "private_request", return_value=expected) as private_request:
             result = client.clip_info_for_creation()
 
-        private_request.assert_called_once_with("clips/clips_info_for_creation/")
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "clips/clips_info_for_creation/")
+        device_status = json.loads(private_request.call_args.kwargs["params"]["device_status"])
+        self.assertEqual(device_status["chip_vendor"], "others")
+        self.assertFalse(device_status["hw_av1_dec"])
         self.assertEqual(result, expected)
 
     def test_clip_trial_eligible_reads_creation_trial_config(self):


### PR DESCRIPTION
## Summary
- align timeline feed metadata and pagination payload fields with the current Android app profile
- add current Direct query parameters for inbox, ranked recipient search, message search, and thread media lookup
- send video device status for Reels creation preflight and reuse the same default device-status payload for related Reels helpers
- add regression coverage plus cheap live coverage for the touched Direct/Reels preflight flows

Closes #2527.

## Tests
- `.venv/bin/pytest -q tests/regression`
- `.venv/bin/python -m ruff check instagrapi tests`
- `.venv/bin/python -m ruff format --check instagrapi tests`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/live-account-tests.yml")'`\n- targeted live checks for timeline pagination, Direct search, Reels creation preflight, and Direct media lookup with a temporary thread