### PR TITLE
Document sessionid login limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ cl = Client()
 cl.login_by_sessionid("<your_sessionid>")
 ```
 
-`login_by_sessionid()` is best treated as a lightweight compatibility path. For long-lived automation, prefer the normal
-`login() -> dump_settings() -> load_settings()/set_settings()` session flow.
+`login_by_sessionid()` is best treated as a lightweight compatibility path. For long-lived automation, prefer the normal `login() -> dump_settings() -> load_settings()/set_settings()` session flow.
+
+If a browser/web `sessionid` returns `login_required` or logs the browser out, Instagram rejected that session for the private mobile API. Use a stable password login once, save settings with `dump_settings()`, and reuse those settings instead of repeatedly importing browser cookies.
 
 ## Typical Tasks
 

--- a/docs/usage-guide/best-practices.md
+++ b/docs/usage-guide/best-practices.md
@@ -146,6 +146,7 @@ These patterns often create support issues that are not library bugs:
 * sharing one noisy IP across many unrelated accounts
 * retrying `429`, `PleaseWaitFewMinutes`, `FeedbackRequired`, or challenges in a tight loop
 * mixing browser `sessionid` reuse with frequent private API password logins
+* treating a browser/web `sessionid` as equivalent to a stable private mobile session after Instagram returns `login_required`
 * changing password, email, phone, profile, and posting behavior from a fresh proxy at the same time
 * running write-heavy automation immediately after account creation or recovery
 * ignoring `client.last_json` and treating every exception as a generic transient failure

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -71,9 +71,11 @@ print(cl.user_info(cl.user_id))
 | login(username: str, password: str)  | bool    | Login by username and password (get new cookies if it does not exist in settings)
 | login(username: str, password: str, verification\_code: str) | bool | Login by username and password with 2FA verification code (use Google Authenticator or something similar to generate TOTP code, not work with SMS)
 | relogin()                            | bool    | Re-login with clean cookies (required cl.username and cl.password)
-| login\_by\_sessionid(sessionid: str) | bool    | Lightweight compatibility login using a browser/session cookie value
+| login\_by\_sessionid(sessionid: str) | bool    | Lightweight compatibility login using a session cookie value
 | inject\_sessionid\_to\_public()      | bool    | Inject sessionid from Private Session to Public Session
 | logout()                             | bool    | Logout
+
+`login_by_sessionid()` only works when Instagram accepts that `sessionid` for the private mobile API. A browser/web `sessionid` can be rejected with `login_required` or invalidated server-side; for long-lived automation, prefer `login()` once, then `dump_settings()` and reuse the saved settings.
 
 You can pass settings to the Client (and save cookies), it has the following format:
 

--- a/examples/session_login.py
+++ b/examples/session_login.py
@@ -20,7 +20,7 @@ def login_with_persistence() -> Client:
 
 
 def login_with_sessionid(sessionid: str) -> Client:
-    """Return Client logged in only with a sessionid."""
+    """Return Client logged in only with a sessionid accepted by private API."""
     cl = Client()
     cl.login_by_sessionid(sessionid)
     return cl

--- a/tests/live/test_sessionid.py
+++ b/tests/live/test_sessionid.py
@@ -1,0 +1,15 @@
+from tests import helpers as _helpers
+from tests.helpers import *
+
+
+class SessionIdLoginTestCase(_helpers.ClientPrivateTestCase):
+    def test_login_by_sessionid_allows_private_followup_requests(self):
+        sessionid = self.cl.sessionid
+        if not sessionid:
+            self.skipTest("Logged-in test client did not expose sessionid")
+
+        cl = Client(proxy=self.cl.proxy)
+
+        self.assertTrue(cl.login_by_sessionid(sessionid))
+        self.assertEqual(str(cl.account_info().pk), str(self.cl.user_id))
+        self.assertIsInstance(cl.get_timeline_feed("cold_start_fetch"), dict)


### PR DESCRIPTION
## Summary
- clarify that login_by_sessionid only works when Instagram accepts the session for private mobile API calls
- document browser/web sessionid login_required and invalidation behavior
- add targeted live coverage for login_by_sessionid followed by private account/timeline requests

## Verification
- .venv/bin/python -m pytest tests/regression/test_auth_story.py -q
- .venv/bin/python -m ruff check README.md docs/usage-guide/interactions.md docs/usage-guide/best-practices.md examples/session_login.py tests/live/test_sessionid.py
- .venv/bin/python -m mkdocs build --strict
- sk.test: python -m pytest tests/live/test_sessionid.py -q