### PR TITLE
Add Direct app parity helpers

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -5,7 +5,12 @@
 | `direct_threads(amount: int = 20, selected_filter: str = "", box: str = "", thread_message_limit: Optional[int] = None)` <br> Note: `selected_filter` = `""`, `"flagged"` or `"unread"`; `box` = `""`, `"primary"` or `"general"` | List[DirectThread] | Get all threads from inbox
 | direct_pending_inbox(amount: int = 20)                                    | List[DirectThread]      | Get all threads from pending inbox
 | direct_requests(amount: int = 20)                                         | List[DirectThread]      | Get message request threads (pending inbox / invitations)
+| direct_pending_requests_preview(pending_inbox_filters: Optional[List[str]] = None) | Dict             | Get lightweight pending request counters
 | direct_request_approve(thread_id: int)                                    | bool                    | Approve a message request thread
+| direct_has_interop_upgraded()                                             | bool                    | Check Direct interop upgrade state
+| direct_search_gen_ai_bots(amount: int = 20)                               | List[UserShort]         | Search generated AI bot suggestions
+| direct_channels(user_id: Optional[int] = None, thread_subtypes: Optional[List[int]] = None) | List[Dict] | Get Direct channels for a user
+| direct_set_e2ee_eligibility(e2ee_eligibility: int = 4)                    | bool                    | Set Direct E2EE eligibility state
 | direct_thread(thread_id: int, amount: int = 20)                           | DirectThread            | Get Thread with Messages
 | direct_messages(thread_id: int, amount: int = 20)                         | List[DirectMessage]     | Get only Messages in Thread
 | direct_message(thread_id: int, message_id: int, amount: int = 20)         | DirectMessage           | Get one Message from Thread by id
@@ -41,6 +46,8 @@ Notes:
 * For `direct_send()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
 * Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
+* `direct_pending_requests_preview()` is the lightweight Android-app preview for request counters; use `direct_requests()` when you need the actual threads.
+* `direct_channels()` and `direct_search_gen_ai_bots()` expose raw app surfaces whose response shape may vary by rollout.
 * `direct_thread()` paginates internally until it collects `amount` messages or reaches the end of the thread.
 * `direct_message()` scans the latest `amount` messages in a thread and raises `DirectMessageNotFound` if the id is not present in that window.
 * Shared XMA items such as `xma_clip`, `xma_media_share`, `xma_story_share`, and `xma_profile` keep their original payload in `message.raw_xma`. When Instagram includes `target_url`, the normalized link is also available through `message.xma_share`.

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -222,6 +222,28 @@ class DirectMixin:
         """
         return self.direct_pending_inbox(amount)
 
+    def direct_pending_requests_preview(self, pending_inbox_filters: Optional[List[str]] = None) -> Dict:
+        """
+        Get the lightweight Direct message requests preview.
+
+        This mirrors the Android app's inbox bootstrap request and returns
+        counters such as ``pending_requests_total`` and
+        ``unread_pending_requests`` without loading the full pending inbox.
+
+        Parameters
+        ----------
+        pending_inbox_filters: List[str], optional
+            Optional pending inbox filters. Defaults to an empty list.
+
+        Returns
+        -------
+        Dict
+            Raw response from ``direct_v2/async_get_pending_requests_preview/``.
+        """
+        assert self.user_id, "Login required"
+        params = {"pending_inbox_filters": dumps(pending_inbox_filters or [])}
+        return self.private_request("direct_v2/async_get_pending_requests_preview/", params=params)
+
     def direct_pending_chunk(self, cursor: str = None) -> Tuple[List[DirectThread], str]:
         """
         Get direct threads of Pending inbox. Chunk
@@ -1418,6 +1440,65 @@ class DirectMixin:
             )
         return data
 
+    def direct_has_interop_upgraded(self) -> bool:
+        """
+        Check whether the account's Direct inbox has upgraded interop messaging.
+
+        Returns
+        -------
+        bool
+            ``True`` when the account reports upgraded Direct interop state.
+        """
+        assert self.user_id, "Login required"
+        result = self.private_request("direct_v2/has_interop_upgraded/")
+        return bool(result.get("has_interop_upgraded"))
+
+    def direct_search_gen_ai_bots(self, amount: int = 20) -> List[UserShort]:
+        """
+        Search Instagram's generated AI Direct bot suggestions.
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of AI bot suggestions requested from the API.
+
+        Returns
+        -------
+        List[UserShort]
+            User-like bot entries returned by Direct search.
+        """
+        assert self.user_id, "Login required"
+        result = self.private_request(
+            "direct_v2/search_gen_ai_bots/",
+            params={"num_ai_bots": str(amount)},
+        )
+        return [extract_user_short(item) for item in result.get("user_search_results", []) if item.get("username")]
+
+    def direct_channels(self, user_id: Optional[int] = None, thread_subtypes: Optional[List[int]] = None) -> List[Dict]:
+        """
+        Get all Direct channels for a user.
+
+        Parameters
+        ----------
+        user_id: int, optional
+            Instagram user id. Defaults to the authenticated user.
+        thread_subtypes: List[int], optional
+            Direct channel thread subtype filters. Defaults to ``[29]`` as used
+            by the Android app.
+
+        Returns
+        -------
+        List[Dict]
+            Raw channel entries from ``all_channels_list``.
+        """
+        assert self.user_id, "Login required"
+        params = {
+            "user_id": str(user_id or self.user_id),
+            "thread_subtypes": dumps(thread_subtypes or [29]),
+        }
+        result = self.private_request("direct_v2/get_all_channels/", params=params)
+        return result.get("all_channels_list", [])
+
     def direct_thread_by_participants(self, user_ids: List[int]) -> Dict:
         """
         Get direct thread by participants
@@ -1532,6 +1613,30 @@ class DirectMixin:
         result = self.private_request(
             f"direct_v2/threads/{thread_id}/add_user/",
             data={"_uuid": self.uuid, "user_ids": dumps([str(uid) for uid in user_ids])},
+            with_signature=False,
+        )
+        return result.get("status", "") == "ok"
+
+    def direct_set_e2ee_eligibility(self, e2ee_eligibility: int = 4) -> bool:
+        """
+        Set Direct end-to-end encryption eligibility state.
+
+        Parameters
+        ----------
+        e2ee_eligibility: int, optional
+            Raw eligibility value accepted by Instagram. The Android 428 app
+            sends ``4`` during Direct bootstrap.
+
+        Returns
+        -------
+        bool
+            A boolean value.
+        """
+        assert self.user_id, "Login required"
+
+        result = self.private_request(
+            "direct_v2/set_e2ee_eligibility/",
+            data={"_uuid": self.uuid, "e2ee_eligibility": str(e2ee_eligibility)},
             with_signature=False,
         )
         return result.get("status", "") == "ok"

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -96,6 +96,20 @@ class ClientDirectTestCase(_helpers.ClientPrivateTestCase):
         for user in users:
             self.assertIsInstance(user, UserShort)
 
+    def test_direct_bootstrap_helpers_live(self):
+        preview = self.cl.direct_pending_requests_preview()
+        self.assertIsInstance(preview, dict)
+        self.assertIn("pending_requests_total", preview)
+        self.assertIsInstance(self.cl.direct_has_interop_upgraded(), bool)
+
+        bots = self.cl.direct_search_gen_ai_bots(amount=2)
+        self.assertIsInstance(bots, list)
+        for bot in bots:
+            self.assertIsInstance(bot, UserShort)
+
+        channels = self.cl.direct_channels()
+        self.assertIsInstance(channels, list)
+
     def test_direct_media_live(self):
         threads = self.cl.direct_threads(amount=5)
         cleanup_message = None

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -185,6 +185,90 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertRegex(params["igd_request_log_tracking_id"], r"^[0-9a-f-]{36}$")
         self.assertEqual(params["media_type"], "media_shares")
 
+    def test_direct_pending_requests_preview_uses_current_preview_endpoint(self):
+        client = self.build_client()
+        response = {
+            "pending_requests_total": 1,
+            "unread_pending_requests": 1,
+            "status": "ok",
+        }
+
+        with mock.patch.object(client, "private_request", return_value=response) as private:
+            result = client.direct_pending_requests_preview()
+
+        self.assertEqual(result, response)
+        private.assert_called_once_with(
+            "direct_v2/async_get_pending_requests_preview/",
+            params={"pending_inbox_filters": "[]"},
+        )
+
+    def test_direct_has_interop_upgraded_returns_boolean_state(self):
+        client = self.build_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"has_interop_upgraded": False, "status": "ok"},
+        ) as private:
+            result = client.direct_has_interop_upgraded()
+
+        self.assertFalse(result)
+        private.assert_called_once_with("direct_v2/has_interop_upgraded/")
+
+    def test_direct_search_gen_ai_bots_returns_user_results(self):
+        client = self.build_client()
+        response = {
+            "user_search_results": [
+                {
+                    "pk": 64528677628,
+                    "username": "meta_ai",
+                    "full_name": "Meta AI",
+                    "profile_pic_url": "https://example.com/meta.jpg",
+                }
+            ],
+            "status": "ok",
+        }
+
+        with mock.patch.object(client, "private_request", return_value=response) as private:
+            result = client.direct_search_gen_ai_bots(amount=5)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].username, "meta_ai")
+        private.assert_called_once_with(
+            "direct_v2/search_gen_ai_bots/",
+            params={"num_ai_bots": "5"},
+        )
+
+    def test_direct_channels_uses_authenticated_user_by_default(self):
+        client = self.build_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"all_channels_list": [{"thread_id": "123"}], "status": "ok"},
+        ) as private:
+            result = client.direct_channels()
+
+        self.assertEqual(result, [{"thread_id": "123"}])
+        private.assert_called_once_with(
+            "direct_v2/get_all_channels/",
+            params={"user_id": "1", "thread_subtypes": "[29]"},
+        )
+
+    def test_direct_set_e2ee_eligibility_posts_unsigned_value(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private:
+            result = client.direct_set_e2ee_eligibility(4)
+
+        self.assertTrue(result)
+        private.assert_called_once_with(
+            "direct_v2/set_e2ee_eligibility/",
+            data={"_uuid": "uuid-1", "e2ee_eligibility": "4"},
+            with_signature=False,
+        )
+
     def test_direct_request_approve_delegates_to_pending_approve(self):
         client = self.build_client()
 


### PR DESCRIPTION
## Summary
- add Direct helpers for pending request preview, interop upgrade state, generated AI bot search, channels, and E2EE eligibility
- document the new Direct methods
- add regression coverage and focused live coverage for safe Direct bootstrap/read helpers

## Testing
- python -m pytest tests/regression/test_direct.py -q
- python -m ruff check instagrapi/mixins/direct.py tests/regression/test_direct.py tests/live/test_direct.py docs/usage-guide/direct.md
- python -m ruff format --check instagrapi/mixins/direct.py tests/regression/test_direct.py tests/live/test_direct.py
- python -m mkdocs build --strict
- live: tests/live/test_direct.py::ClientDirectTestCase::test_direct_bootstrap_helpers_live