### PR TITLE
Add media note endpoints

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -41,6 +41,8 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_oembed(url: str) | dict | Return short oEmbed-style media info by URL |
 | media_like(media_id: str) | bool | Like media |
 | media_unlike(media_id: str) | bool | Unlike media |
+| media_note_create(media_id: str, text: str = "", audience: int = 7, note_style: int = 13, extra_data: Optional[Dict] = None) | dict | Create a note attached to a media item |
+| media_note_delete(note_id: str, extra_data: Optional[Dict] = None) | bool | Delete a note attached to a media item |
 | media_seen(media_ids: List[str], skipped_media_ids: List[str] = []) | bool | Mark media as seen |
 | media_likers(media_id: str) | List\[UserShort] | Return users who liked this post |
 | media_likers_gql(media_pk: str, amount: int = 0) | List\[dict] | Return users who liked this post through the web GraphQL doc_id endpoint |
@@ -58,6 +60,10 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_get_livestream_info(broadcast_id: str) | dict | Get livestream info |
 | media_get_livestream_comments(broadcast_id: str) | dict | Get livestream comments |
 | media_get_livestream_viewers(broadcast_id: str) | dict | Get livestream viewers |
+
+Media notes are separate from Direct inbox Notes. Use `media_note_create()` and
+`media_note_delete()` for the note surface attached to a post or Reel; use the
+[Notes guide](notes.md) for Direct inbox Notes.
 
 Low level methods:
 

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -3,7 +3,7 @@ import random
 import time
 from copy import deepcopy
 from datetime import datetime
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from instagrapi.exceptions import (
@@ -618,6 +618,88 @@ class MediaMixin:
             A boolean value
         """
         return self.media_like(media_id, revert=True)
+
+    def media_note_create(
+        self,
+        media_id: str,
+        text: str = "",
+        audience: int = 7,
+        note_style: int = 13,
+        extra_data: Optional[Dict] = None,
+    ) -> Dict:
+        """
+        Create a note attached to a media item.
+
+        This is separate from Direct inbox Notes created by
+        :meth:`create_note`; it mirrors the Android app's
+        ``media/create_note/v2/`` flow for notes attached to posts/Reels.
+
+        Parameters
+        ----------
+        media_id: str
+            Full media id, for example ``"3884795301060104481_52448022913"``.
+        text: str, optional
+            Note text.
+        audience: int, optional
+            Raw media-note audience value. The Android app sends ``7``.
+        note_style: int, optional
+            Raw media-note style value. The Android app sends ``13``.
+        extra_data: Dict, optional
+            Additional app-surface fields such as ``tracking_token``,
+            ``ranking_info_token`` or ``nav_chain`` when the caller has them.
+
+        Returns
+        -------
+        Dict
+            Raw created note response.
+        """
+        assert self.user_id, "Login required"
+        data = {
+            "inventory_source": "recommended_clips_chaining_model",
+            "media_client_position": "0",
+            "media_id": str(media_id),
+            "note_style": str(note_style),
+            "carousel_index": "-1",
+            "text": text,
+            "_uuid": self.uuid,
+            "audience": str(audience),
+            "event_source": "ufi",
+            "container_module": "clips_viewer_clips_tab",
+        }
+        if extra_data:
+            data.update(extra_data)
+        return self.private_request("media/create_note/v2/", data=data, with_signature=False)
+
+    def media_note_delete(self, note_id: str, extra_data: Optional[Dict] = None) -> bool:
+        """
+        Delete a note attached to a media item.
+
+        Parameters
+        ----------
+        note_id: str
+            ID of the media note to delete.
+        extra_data: Dict, optional
+            Additional app-surface fields such as ``tracking_token``,
+            ``ranking_info_token`` or ``nav_chain`` when the caller has them.
+
+        Returns
+        -------
+        bool
+            A boolean value.
+        """
+        assert self.user_id, "Login required"
+        data = {
+            "inventory_source": "recommended_clips_chaining_model",
+            "carousel_index": "-1",
+            "_uuid": self.uuid,
+            "event_source": "ufi",
+            "container_module": "clips_viewer_clips_tab",
+            "note_id": str(note_id),
+        }
+        if extra_data:
+            data.update(extra_data)
+        result = self.private_request("media/delete_note/", data=data, with_signature=False)
+        return result.get("status", "") == "ok"
 
     def user_medias_paginated_gql(
         self, user_id: str, amount: int = 0, sleep: int = 2, end_cursor=None

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -145,6 +145,19 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
         media = self.cl.media_info_v1(media_pk)  # refresh after unlike
         self.assertFalse(media.has_liked)
 
+    def test_media_note_create_and_delete(self):
+        user_id = self.user_id_from_username("instagram")
+        media = self.cl.user_medias_v1(user_id, amount=1)[0]
+        note = None
+        try:
+            note = self.cl.media_note_create(media.id, text="")
+            self.assertEqual(note.get("status"), "ok")
+            self.assertTrue(note.get("id"))
+            self.assertEqual(note.get("text"), "")
+        finally:
+            if note and note.get("id"):
+                self.assertTrue(self.cl.media_note_delete(note["id"]))
+
 
 class ClientCompareExtractTestCase(_helpers.ClientPrivateTestCase):
     def assertLocation(self, v1, gql):

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -133,6 +133,62 @@ class MediaActionPayloadRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["container_module"], "feed_timeline")
         self.assertIn(data["feed_position"], {str(i) for i in range(7)})
 
+    def test_media_note_create_posts_current_v2_payload(self):
+        client = self._build_logged_in_client()
+        expected = {
+            "id": "17881913307564398",
+            "media_id": "3884795301060104481",
+            "text": "seen this",
+            "status": "ok",
+        }
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.media_note_create(
+                "3884795301060104481_52448022913",
+                text="seen this",
+                extra_data={"ranking_info_token": "rank-token"},
+            )
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "media/create_note/v2/",
+            data={
+                "inventory_source": "recommended_clips_chaining_model",
+                "media_client_position": "0",
+                "media_id": "3884795301060104481_52448022913",
+                "note_style": "13",
+                "carousel_index": "-1",
+                "text": "seen this",
+                "_uuid": "uuid",
+                "audience": "7",
+                "event_source": "ufi",
+                "container_module": "clips_viewer_clips_tab",
+                "ranking_info_token": "rank-token",
+            },
+            with_signature=False,
+        )
+
+    def test_media_note_delete_posts_current_v2_payload(self):
+        client = self._build_logged_in_client()
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.media_note_delete("17881913307564398", extra_data={"ranking_info_token": "rank-token"})
+
+        self.assertTrue(result)
+        private_request.assert_called_once_with(
+            "media/delete_note/",
+            data={
+                "inventory_source": "recommended_clips_chaining_model",
+                "carousel_index": "-1",
+                "_uuid": "uuid",
+                "event_source": "ufi",
+                "container_module": "clips_viewer_clips_tab",
+                "note_id": "17881913307564398",
+                "ranking_info_token": "rank-token",
+            },
+            with_signature=False,
+        )
+
 
 class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
     def _media_v1_payload(self, pk="1"):


### PR DESCRIPTION
## Summary
- add `media_note_create()` and `media_note_delete()` for notes attached to media/Reels
- keep Direct inbox `create_note()` / `delete_note()` unchanged
- document the separate media-note surface and add regression + live coverage

## Testing
- python -m pytest tests/regression/test_media.py -q
- python -m ruff check instagrapi/mixins/media.py tests/regression/test_media.py tests/live/test_media.py docs/usage-guide/media.md
- python -m mkdocs build --strict
- live: tests/live/test_media.py::ClientMediaExtendTestCase::test_media_note_create_and_delete