### PR TITLE
Add music app surface helpers

### DIFF
--- a/docs/usage-guide/track.md
+++ b/docs/usage-guide/track.md
@@ -10,6 +10,13 @@ Viewing and downloading tracks
 | track_download_by_url(url: str, filename: str = "", folder: Path = "") | Path | Download track by URL |
 | search_music(query: str) | List[Track] | Search music and return track objects |
 | music_in_feed_audio_browser(browse_session_id: str = None) | dict | Browse music candidates for feed photo and carousel uploads |
+| music_trending(product: str = "feed_post") | dict | Browse trending music candidates |
+| music_top_trends(product: str = "music_in_feed", page_size: int = 15) | dict | Browse top trending music candidates |
+| music_search_v2(query: str, product: str = "music_in_feed", from_typeahead: bool = False, search_session_id: str = None, browse_session_id: str = None) | dict | Search music through the current app endpoint |
+| music_keyword_search(query: str, product: str = "music_in_feed", num_keywords: int = 3, search_session_id: str = "", browse_session_id: str = None) | dict | Search music keyword suggestions |
+| music_clips_audio_browser(product: str = "story_camera_clips_v2", browse_session_id: str = None) | dict | Browse music candidates for the Reels/Clips camera |
+| music_verify_original_audio_title(original_audio_name: str) | bool | Validate an original audio title for Reels publishing |
+| music_bookmark(original_audio_id: str, surface_requested_from: str = "audio_aggregation_page") | bool | Bookmark an original audio track |
 
 ### Example:
 
@@ -93,3 +100,4 @@ Notes:
 
 * `track_info_by_canonical_id()` is the high-level typed path and usually the one you want for reels/clips music metadata.
 * `track_info_by_id()` returns the lower-level raw response shape, which is useful for debugging or when you already have an Instagram track ID.
+* The `music_*` helpers expose raw app music surfaces so callers can inspect rollout-specific fields and reuse IDs in upload flows.

--- a/instagrapi/mixins/track.py
+++ b/instagrapi/mixins/track.py
@@ -90,6 +90,225 @@ class TrackMixin:
             with_signature=False,
         )
 
+    def music_trending(self, product: str = "feed_post") -> Dict:
+        """
+        Retrieve trending music candidates.
+
+        Parameters
+        ----------
+        product: str, optional
+            Music product surface. The Android app uses ``feed_post`` for the
+            successful current feed-post path.
+
+        Returns
+        -------
+        Dict
+            Raw response from ``music/trending/``.
+        """
+        return self.private_request(
+            "music/trending/",
+            data={"product": product, "_uuid": self.uuid},
+            with_signature=False,
+        )
+
+    def music_top_trends(self, product: str = "music_in_feed", page_size: int = 15) -> Dict:
+        """
+        Retrieve top trending music candidates.
+
+        Parameters
+        ----------
+        product: str, optional
+            Music product surface.
+        page_size: int, optional
+            Number of trend rows requested.
+
+        Returns
+        -------
+        Dict
+            Raw response from ``music/top_trends/``.
+        """
+        return self.private_request(
+            "music/top_trends/",
+            data={
+                "product": product,
+                "_uuid": self.uuid,
+                "page_size": str(page_size),
+            },
+            with_signature=False,
+        )
+
+    def music_search_v2(
+        self,
+        query: str,
+        product: str = "music_in_feed",
+        from_typeahead: bool = False,
+        search_session_id: Optional[str] = None,
+        browse_session_id: Optional[str] = None,
+    ) -> Dict:
+        """
+        Search music through the current ``music/search_v2/`` app endpoint.
+
+        Parameters
+        ----------
+        query: str
+            Search query.
+        product: str, optional
+            Music product surface.
+        from_typeahead: bool, optional
+            Whether the query came from a typeahead suggestion.
+        search_session_id: str, optional
+            Search session id. Generated when omitted.
+        browse_session_id: str, optional
+            Browse session id. Generated when omitted.
+
+        Returns
+        -------
+        Dict
+            Raw search response.
+        """
+        if search_session_id is None:
+            search_session_id = self.generate_uuid()
+        if browse_session_id is None:
+            browse_session_id = self.generate_uuid()
+        return self.private_request(
+            "music/search_v2/",
+            data={
+                "from_typeahead": self._bool_to_ig_string(from_typeahead),
+                "search_session_id": search_session_id,
+                "product": product,
+                "q": str(query),
+                "_uuid": self.uuid,
+                "browse_session_id": browse_session_id,
+            },
+            with_signature=False,
+        )
+
+    def music_keyword_search(
+        self,
+        query: str,
+        product: str = "music_in_feed",
+        num_keywords: int = 3,
+        search_session_id: str = "",
+        browse_session_id: Optional[str] = None,
+    ) -> Dict:
+        """
+        Search music keywords for typeahead.
+
+        Parameters
+        ----------
+        query: str
+            Search query.
+        product: str, optional
+            Music product surface.
+        num_keywords: int, optional
+            Number of keyword suggestions requested.
+        search_session_id: str, optional
+            Search session id.
+        browse_session_id: str, optional
+            Browse session id. Generated when omitted.
+
+        Returns
+        -------
+        Dict
+            Raw keyword response.
+        """
+        if browse_session_id is None:
+            browse_session_id = self.generate_uuid()
+        return self.private_request(
+            "music/keyword_search/",
+            params={
+                "num_keywords": str(num_keywords),
+                "search_session_id": search_session_id,
+                "product": product,
+                "q": str(query),
+                "browse_session_id": browse_session_id,
+            },
+        )
+
+    def music_bookmark(
+        self,
+        original_audio_id: str,
+        surface_requested_from: str = "audio_aggregation_page",
+    ) -> bool:
+        """
+        Bookmark an original audio track.
+
+        Parameters
+        ----------
+        original_audio_id: str
+            Original audio id to bookmark.
+        surface_requested_from: str, optional
+            App surface requesting the bookmark.
+
+        Returns
+        -------
+        bool
+            A boolean value.
+        """
+        result = self.private_request(
+            "music/bookmark_music/",
+            data={
+                "original_audio_id": str(original_audio_id),
+                "_uuid": self.uuid,
+                "surface_requested_from": surface_requested_from,
+            },
+            with_signature=False,
+        )
+        return bool(result.get("success")) or result.get("status") == "ok"
+
+    def music_clips_audio_browser(
+        self,
+        product: str = "story_camera_clips_v2",
+        browse_session_id: Optional[str] = None,
+    ) -> Dict:
+        """
+        Retrieve music candidates for the Reels/Clips camera surface.
+
+        Parameters
+        ----------
+        product: str, optional
+            Music product surface.
+        browse_session_id: str, optional
+            Browse session id. Generated when omitted.
+
+        Returns
+        -------
+        Dict
+            Raw response from ``music/clips_audio_browser/``.
+        """
+        if browse_session_id is None:
+            browse_session_id = self.generate_uuid()
+        return self.private_request(
+            "music/clips_audio_browser/",
+            data={
+                "product": product,
+                "_uuid": self.uuid,
+                "browse_session_id": browse_session_id,
+            },
+            with_signature=False,
+        )
+
+    def music_verify_original_audio_title(self, original_audio_name: str) -> bool:
+        """
+        Validate an original audio title for Reels publishing.
+
+        Parameters
+        ----------
+        original_audio_name: str
+            Proposed original audio title.
+
+        Returns
+        -------
+        bool
+            ``True`` when Instagram accepts the title.
+        """
+        result = self.private_request(
+            "music/verify_original_audio_title/",
+            data={"original_audio_name": original_audio_name, "_uuid": self.uuid},
+            with_signature=False,
+        )
+        return bool(result.get("is_valid"))
+
     def _feed_music_params(
         self,
         track: Union[Track, Dict],

--- a/tests/live/test_track.py
+++ b/tests/live/test_track.py
@@ -1,0 +1,26 @@
+from tests import helpers as _helpers
+from tests.helpers import *
+
+
+class ClientTrackLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for Track live tests")
+        try:
+            self.cl = self.fresh_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def test_music_app_surfaces_live(self):
+        self.assertTrue(self.cl.music_verify_original_audio_title("Original Audio"))
+
+        trending = self.cl.music_trending()
+        self.assertEqual(trending.get("status"), "ok")
+        self.assertIsInstance(trending.get("items"), list)
+
+        search = self.cl.music_search_v2("love")
+        self.assertEqual(search.get("status"), "ok")

--- a/tests/regression/test_track.py
+++ b/tests/regression/test_track.py
@@ -2,6 +2,132 @@ from tests.helpers import *
 
 
 class TrackMixinRegressionTestCase(unittest.TestCase):
+    def test_music_trending_posts_product_payload(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"items": [], "status": "ok"}) as private:
+            result = client.music_trending(product="feed_post")
+
+        self.assertEqual(result, {"items": [], "status": "ok"})
+        private.assert_called_once_with(
+            "music/trending/",
+            data={"product": "feed_post", "_uuid": "uuid-1"},
+            with_signature=False,
+        )
+
+    def test_music_top_trends_posts_page_size(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"items": [], "status": "ok"}) as private:
+            result = client.music_top_trends(page_size=15)
+
+        self.assertEqual(result, {"items": [], "status": "ok"})
+        private.assert_called_once_with(
+            "music/top_trends/",
+            data={"product": "music_in_feed", "_uuid": "uuid-1", "page_size": "15"},
+            with_signature=False,
+        )
+
+    def test_music_search_v2_posts_current_search_payload(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with (
+            mock.patch.object(client, "generate_uuid", side_effect=["search-session", "browse-session"]),
+            mock.patch.object(client, "private_request", return_value={"items": [], "status": "ok"}) as private,
+        ):
+            result = client.music_search_v2("drake")
+
+        self.assertEqual(result, {"items": [], "status": "ok"})
+        private.assert_called_once_with(
+            "music/search_v2/",
+            data={
+                "from_typeahead": "false",
+                "search_session_id": "search-session",
+                "product": "music_in_feed",
+                "q": "drake",
+                "_uuid": "uuid-1",
+                "browse_session_id": "browse-session",
+            },
+            with_signature=False,
+        )
+
+    def test_music_keyword_search_uses_query_params(self):
+        client = Client()
+
+        with (
+            mock.patch.object(client, "generate_uuid", return_value="browse-session"),
+            mock.patch.object(client, "private_request", return_value={"keywords": [], "status": "ok"}) as private,
+        ):
+            result = client.music_keyword_search("drake")
+
+        self.assertEqual(result, {"keywords": [], "status": "ok"})
+        private.assert_called_once_with(
+            "music/keyword_search/",
+            params={
+                "num_keywords": "3",
+                "search_session_id": "",
+                "product": "music_in_feed",
+                "q": "drake",
+                "browse_session_id": "browse-session",
+            },
+        )
+
+    def test_music_bookmark_posts_original_audio_id(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"success": True, "status": "ok"}) as private:
+            result = client.music_bookmark("1171063161088391")
+
+        self.assertTrue(result)
+        private.assert_called_once_with(
+            "music/bookmark_music/",
+            data={
+                "original_audio_id": "1171063161088391",
+                "_uuid": "uuid-1",
+                "surface_requested_from": "audio_aggregation_page",
+            },
+            with_signature=False,
+        )
+
+    def test_music_clips_audio_browser_posts_browse_session(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with (
+            mock.patch.object(client, "generate_uuid", return_value="browse-session"),
+            mock.patch.object(client, "private_request", return_value={"items": [], "status": "ok"}) as private,
+        ):
+            result = client.music_clips_audio_browser()
+
+        self.assertEqual(result, {"items": [], "status": "ok"})
+        private.assert_called_once_with(
+            "music/clips_audio_browser/",
+            data={
+                "product": "story_camera_clips_v2",
+                "_uuid": "uuid-1",
+                "browse_session_id": "browse-session",
+            },
+            with_signature=False,
+        )
+
+    def test_music_verify_original_audio_title_returns_valid_flag(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"is_valid": True, "status": "ok"}) as private:
+            result = client.music_verify_original_audio_title("Original Audio")
+
+        self.assertTrue(result)
+        private.assert_called_once_with(
+            "music/verify_original_audio_title/",
+            data={"original_audio_name": "Original Audio", "_uuid": "uuid-1"},
+            with_signature=False,
+        )
+
     def test_track_stream_info_by_id_sends_expected_endpoint_and_payload(self):
         client = Client()
         with mock.patch.object(client, "private_request", return_value={}) as private_request:


### PR DESCRIPTION
## Summary
- add raw music app-surface helpers for trending, top trends, search v2, keyword search, clips audio browser, original audio title validation, and bookmarking
- document the new Track/Music helpers
- add regression coverage and focused live coverage for read-only music app surfaces

## Testing
- python -m pytest tests/regression/test_track.py -q
- python -m ruff check instagrapi/mixins/track.py tests/regression/test_track.py tests/live/test_track.py docs/usage-guide/track.md
- python -m mkdocs build --strict
- live: tests/live/test_track.py::ClientTrackLiveTestCase::test_music_app_surfaces_live