### PR TITLE
Fix signup SMS challenge flow

### DIFF
--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -47,6 +47,7 @@ cl.login(IG_USERNAME, IG_PASSWORD)
 Notes:
 
 * `challenge_code_handler(username, choice)` should return the received code as a string. Returning a falsey value means no code is available yet.
+* Signup SMS challenges use the `phone_number` passed to `signup(...)` and call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 * Current `master` raises a clearer `ChallengeRequired` for `/auth_platform/?apc=...` flows. That path is not yet supported automatically and still requires manual verification.
 * For long-running automation, persist client settings around challenge handling so you can retry without rebuilding the entire device/session state.
 

--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -1,18 +1,21 @@
 import random
 import secrets
 import time
+from typing import Optional
 from urllib.parse import urlsplit
 from uuid import uuid4
 
 from instagrapi.exceptions import (
     AgeEligibilityError,
     CaptchaChallengeRequired,
+    ChallengeRequired,
     ClientError,
     EmailInvalidError,
     EmailNotAvailableError,
     EmailVerificationSendError,
 )
 from instagrapi.extractors import extract_user_short
+from instagrapi.mixins.challenge import ChallengeChoice
 from instagrapi.types import UserShort
 
 CHOICE_EMAIL = 1
@@ -94,7 +97,7 @@ class SignUpMixin:
             data = self.accounts_create(**kwargs)
             if data.get("message") != "challenge_required":
                 break
-            if self.challenge_flow(data["challenge"]):
+            if self.challenge_flow(data["challenge"], phone_number=phone_number, username=username):
                 kwargs.update({"suggestedUsername": "", "sn_result": "MLA"})
             retries += 1
         return extract_user_short(data["created_user"])
@@ -208,18 +211,43 @@ class SignUpMixin:
         }
         return self.private_request("accounts/create/", data, domain="www.instagram.com")
 
-    def challenge_flow(self, data):
+    def challenge_flow(
+        self,
+        data,
+        phone_number: str = "",
+        username: str = "",
+        wait_seconds: Optional[int] = None,
+        attempts: int = 10,
+    ) -> bool:
         data = self.challenge_api(data)
-        while True:
+        wait_seconds = self.wait_seconds if wait_seconds is None else wait_seconds
+        username = username or getattr(self, "username", "")
+
+        for _ in range(10):
+            if data.get("status") == "ok":
+                return True
             if data.get("message") == "challenge_required":
                 data = self.challenge_captcha(data["challenge"])
                 continue
-            elif data.get("challengeType") == "SubmitPhoneNumberForm":
-                data = self.challenge_submit_phone_number(data)
+            if data.get("challengeType") == "SubmitPhoneNumberForm":
+                if not phone_number:
+                    raise ClientError("phone_number is required for signup SMS challenge")
+                data = self.challenge_submit_phone_number(data, phone_number)
                 continue
-            elif data.get("challengeType") == "VerifySMSCodeFormForSMSCaptcha":
-                data = self.challenge_verify_sms_captcha(data)
+            if data.get("challengeType") == "VerifySMSCodeFormForSMSCaptcha":
+                security_code = ""
+                for attempt in range(attempts):
+                    security_code = self.challenge_code_handler(username, ChallengeChoice.SMS)
+                    if security_code:
+                        break
+                    if wait_seconds:
+                        time.sleep(wait_seconds * (attempt + 1))
+                if not security_code:
+                    raise ChallengeRequired("SMS code required for signup challenge")
+                data = self.challenge_verify_sms_captcha(data, security_code)
                 continue
+            raise ClientError(f"Unsupported signup challenge step: {data}")
+        raise ClientError(f"Signup challenge flow did not complete: {data}")
 
     def challenge_api(self, data):
         resp = self.private.get(

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -1,3 +1,4 @@
+from instagrapi.mixins.challenge import ChallengeChoice
 from tests.helpers import *
 
 
@@ -110,3 +111,121 @@ class SignupHelperRegressionTestCase(unittest.TestCase):
             )
 
         client.private.post.assert_not_called()
+
+    def test_challenge_flow_submits_phone_number_then_sms_code(self):
+        client = Client()
+        start = {"api_path": "/challenge/start", "challenge_context": "{}"}
+        submit_phone_step = {
+            "challengeType": "SubmitPhoneNumberForm",
+            "navigation": {"forward": "/challenge/phone"},
+            "challenge_context": "{}",
+        }
+        verify_sms_step = {
+            "challengeType": "VerifySMSCodeFormForSMSCaptcha",
+            "navigation": {"forward": "/challenge/sms"},
+            "challenge_context": "{}",
+        }
+
+        with mock.patch.object(client, "challenge_api", return_value=submit_phone_step):
+            with mock.patch.object(
+                client,
+                "challenge_submit_phone_number",
+                return_value=verify_sms_step,
+            ) as submit_phone:
+                with mock.patch.object(
+                    client,
+                    "challenge_verify_sms_captcha",
+                    return_value={"status": "ok"},
+                ) as verify_sms:
+                    with mock.patch.object(client, "challenge_code_handler", return_value="123456") as code_handler:
+                        result = client.challenge_flow(
+                            start,
+                            phone_number="+15551234567",
+                            username="example",
+                            wait_seconds=0,
+                        )
+
+        self.assertTrue(result)
+        submit_phone.assert_called_once_with(submit_phone_step, "+15551234567")
+        code_handler.assert_called_once()
+        self.assertEqual(code_handler.call_args.args[0], "example")
+        self.assertEqual(code_handler.call_args.args[1], ChallengeChoice.SMS)
+        verify_sms.assert_called_once_with(verify_sms_step, "123456")
+
+    def test_challenge_flow_requires_phone_number_for_sms_challenge(self):
+        client = Client()
+        start = {"api_path": "/challenge/start", "challenge_context": "{}"}
+        submit_phone_step = {
+            "challengeType": "SubmitPhoneNumberForm",
+            "navigation": {"forward": "/challenge/phone"},
+            "challenge_context": "{}",
+        }
+
+        with mock.patch.object(client, "challenge_api", return_value=submit_phone_step):
+            with self.assertRaises(ClientError) as ctx:
+                client.challenge_flow(start, username="example", wait_seconds=0)
+
+        self.assertIn("phone_number is required", str(ctx.exception))
+
+    def test_challenge_flow_requires_sms_code(self):
+        client = Client()
+        start = {"api_path": "/challenge/start", "challenge_context": "{}"}
+        verify_sms_step = {
+            "challengeType": "VerifySMSCodeFormForSMSCaptcha",
+            "navigation": {"forward": "/challenge/sms"},
+            "challenge_context": "{}",
+        }
+
+        with mock.patch.object(client, "challenge_api", return_value=verify_sms_step):
+            with mock.patch.object(client, "challenge_code_handler", return_value=False):
+                with self.assertRaises(ChallengeRequired) as ctx:
+                    client.challenge_flow(
+                        start,
+                        phone_number="+15551234567",
+                        username="example",
+                        wait_seconds=0,
+                        attempts=1,
+                    )
+
+        self.assertIn("SMS code required", str(ctx.exception))
+
+    def test_signup_passes_phone_number_to_challenge_flow(self):
+        client = Client()
+        client.wait_seconds = 0
+        challenge = {"api_path": "/challenge/start", "challenge_context": "{}"}
+
+        with mock.patch.object(client, "get_signup_config", return_value={}):
+            with mock.patch.object(client, "check_email", return_value={"valid": True, "available": True}):
+                with mock.patch.object(client, "send_verify_email", return_value={"email_sent": True}):
+                    with mock.patch.object(client, "challenge_code_handler", return_value="654321"):
+                        with mock.patch.object(
+                            client,
+                            "check_confirmation_code",
+                            return_value={"signup_code": "signup-code"},
+                        ):
+                            with mock.patch.object(
+                                client,
+                                "accounts_create",
+                                side_effect=[
+                                    {"message": "challenge_required", "challenge": challenge},
+                                    {"created_user": {"pk": "1", "username": "example"}},
+                                ],
+                            ):
+                                with mock.patch.object(client, "challenge_flow", return_value=True) as challenge_flow:
+                                    with mock.patch(
+                                        "instagrapi.mixins.signup.extract_user_short",
+                                        return_value="created-user",
+                                    ):
+                                        result = client.signup(
+                                            "example",
+                                            "password",
+                                            "example@example.com",
+                                            "+15551234567",
+                                        )
+
+        self.assertEqual(result, "created-user")
+        challenge_flow.assert_called_once_with(
+            challenge,
+            phone_number="+15551234567",
+            username="example",
+        )


### PR DESCRIPTION
## Summary
- pass signup phone number and username into the signup challenge flow
- support SubmitPhoneNumberForm -> VerifySMSCodeFormForSMSCaptcha with challenge_code_handler(..., ChallengeChoice.SMS)
- return clearly when the challenge is solved and raise explicit errors when phone number or SMS code is missing
- document signup SMS challenge handling

## Testing
- RED: python -m pytest tests/regression/test_signup.py -q (4 new failures before implementation)
- .venv/bin/python -m pytest tests/regression/test_signup.py -q
- .venv/bin/python -m ruff check instagrapi/mixins/signup.py tests/regression/test_signup.py docs/usage-guide/challenge_resolver.md
- .venv/bin/python -m ruff format --check instagrapi/mixins/signup.py tests/regression/test_signup.py
- .venv/bin/python -m mkdocs build --strict

Note: no live SMS test was run because real signup SMS challenges are nondeterministic and depend on external phone delivery.