### PR TITLE
Add Bloks Facebook Reels link helper

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -354,6 +354,7 @@ contains availability flags, not the full Account Center destination state, and 
 with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination,
 instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated
 automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
+`bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram.
 
 ### Example:
 

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -1,8 +1,76 @@
+from typing import Any, Dict, List, Optional
+
 from instagrapi.utils.serialization import dumps
 
 
 class BloksMixin:
     bloks_versioning_id = ""
+
+    def bloks_async_action(self, action: str, params: Dict, bloks_versioning_id: str = "") -> Dict:
+        """
+        Perform a raw Bloks async action.
+
+        Parameters
+        ----------
+        action: str
+            Async action, for example ``com.bloks.www.fxcal.link.async``.
+        params: Dict
+            Bloks ``params`` payload.
+        bloks_versioning_id: str, optional
+            Bloks versioning id. Uses ``Client.bloks_versioning_id`` when omitted.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        versioning_id = bloks_versioning_id or self.bloks_versioning_id
+        assert versioning_id, "Client.bloks_versioning_id is empty (hash is expected)"
+        data = {
+            "params": dumps(params),
+            "_uuid": self.uuid,
+            "bk_client_context": dumps({"bloks_version": versioning_id, "styles_id": "instagram"}),
+            "bloks_versioning_id": versioning_id,
+        }
+        return self.private_request(f"bloks/async_action/{action}/", data=data, with_signature=False)
+
+    def bloks_fxcal_link_reels_share(
+        self,
+        flow: str = "ig_fb_reels_composer_rowshare",
+        logging_event: str = "linking_flow_initiated",
+        cds_client_value: int = 1,
+        opaque_verified_native_auth_data: Optional[str] = None,
+        native_auth_data: Optional[List[Dict[str, Any]]] = None,
+        account_type: int = 0,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Start the Account Center link flow used by Reel Facebook sharing.
+
+        This exposes the raw app surface. It starts the Bloks linking flow but
+        does not guarantee that Facebook linking can be completed without the
+        interactive Instagram app UI and native authentication context.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        params = {
+            "server_params": {
+                "flow": flow,
+                "logging_event": logging_event,
+                "cds_client_value": cds_client_value,
+                "opaque_verified_native_auth_data": opaque_verified_native_auth_data,
+                "native_auth_data": native_auth_data or [],
+                "account_type": account_type,
+            }
+        }
+        return self.bloks_async_action(
+            "com.bloks.www.fxcal.link.async",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
 
     def bloks_action(self, action: str, data: dict) -> bool:
         """Performing actions for bloks

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -38,6 +38,7 @@ from tests.live.test_user import (
     ClientUserTestCase,
 )
 from tests.regression.test_auth_story import AuthAndStoryRegressionTestCase
+from tests.regression.test_bloks import BloksRegressionTestCase
 from tests.regression.test_challenge import ChallengeRegressionTestCase
 from tests.regression.test_comments import CommentRepliesRegressionTestCase
 from tests.regression.test_direct import DirectMixinRegressionTestCase

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -1,0 +1,52 @@
+from tests.helpers import *
+
+
+class BloksRegressionTestCase(unittest.TestCase):
+    def build_client(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.bloks_versioning_id = "bloks-version"
+        return client
+
+    def test_bloks_async_action_posts_unsigned_bloks_payload(self):
+        client = self.build_client()
+        params = {"server_params": {"flow": "example_flow"}}
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.bloks_async_action("com.example.action", params)
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "bloks/async_action/com.example.action/",
+            data={
+                "params": dumps(params),
+                "_uuid": "uuid-1",
+                "bk_client_context": dumps({"bloks_version": "bloks-version", "styles_id": "instagram"}),
+                "bloks_versioning_id": "bloks-version",
+            },
+            with_signature=False,
+        )
+
+    def test_bloks_fxcal_link_reels_share_uses_current_flow_payload(self):
+        client = self.build_client()
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "bloks_async_action", return_value=expected) as bloks_async_action:
+            result = client.bloks_fxcal_link_reels_share(cds_client_value=2)
+
+        self.assertEqual(result, expected)
+        bloks_async_action.assert_called_once_with(
+            "com.bloks.www.fxcal.link.async",
+            {
+                "server_params": {
+                    "flow": "ig_fb_reels_composer_rowshare",
+                    "logging_event": "linking_flow_initiated",
+                    "cds_client_value": 2,
+                    "opaque_verified_native_auth_data": None,
+                    "native_auth_data": [],
+                    "account_type": 0,
+                }
+            },
+            bloks_versioning_id="",
+        )


### PR DESCRIPTION
## Summary
- add a generic raw Bloks async-action helper for unsigned app Bloks payloads
- add `bloks_fxcal_link_reels_share()` for the Account Center link action used by Reel Facebook sharing
- document that the helper starts the raw app linking flow and does not replace interactive Facebook linking
- add regression coverage for the payload shape

## Testing
- RED: .venv/bin/python -m pytest tests/regression/test_bloks.py -q (2 missing-method failures before implementation)
- .venv/bin/python -m pytest tests/regression/test_bloks.py -q
- .venv/bin/python -m ruff check instagrapi/mixins/bloks.py tests/regression/test_bloks.py tests/__init__.py docs/usage-guide/media.md
- .venv/bin/python -m ruff format --check instagrapi/mixins/bloks.py tests/regression/test_bloks.py tests/__init__.py
- .venv/bin/python -m mkdocs build --strict

Note: no live Facebook linking test was run because completing this Account Center flow depends on an interactive linked Facebook account state.