### PR TITLE
Add Reel music metadata upload helper

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -321,7 +321,9 @@ Upload medias to your feed. Common arguments:
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
 | clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
-| clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload Reels Clip as reel with music metadata
+| clip_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Reels music configure fields for manual `clip_upload(..., extra_data=...)`
+| clip_upload_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Media | Upload a Reel with music metadata without local audio muxing
+| clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload a Reel after locally muxing the track into the video with MoviePy
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
 

--- a/docs/usage-guide/pydroid.md
+++ b/docs/usage-guide/pydroid.md
@@ -33,6 +33,8 @@ The extra is intentionally not part of the default install, because it pulls in 
 * video album uploads, because album video items currently generate thumbnails internally
 * non-standard MP4 files that the built-in parser cannot read
 
+Use `clip_upload_with_music(..., thumbnail=...)` when you only need Reels music metadata and do not need local audio muxing.
+
 ## Error
 
 If ffmpeg is missing or cannot be executed, video thumbnail generation can fail with:

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from uuid import uuid4
 
 from instagrapi import config
@@ -627,33 +627,13 @@ class UploadClipMixin:
             tmpvideo = Path(_make_tmp_path(".mp4"))
             video.write_videofile(str(tmpvideo))
             # create the extra data to upload with it
-            data = dict(extra_data or {})
-            data["clips_audio_metadata"] = {
-                "original": {"volume_level": 0.0},
-                "song": {
-                    "volume_level": 1.0,
-                    "is_saved": "0",
-                    "artist_name": track.display_artist,
-                    "audio_asset_id": track.id,
-                    "audio_cluster_id": track.audio_cluster_id,
-                    "track_name": track.title,
-                    "is_picked_precapture": "1",
-                },
-            }
-            data["music_params"] = {
-                "audio_asset_id": track.id,
-                "audio_cluster_id": track.audio_cluster_id,
-                "audio_asset_start_time_in_ms": highlight_start_time,
-                "derived_content_start_time_in_ms": 0,
-                "overlap_duration_in_ms": int(video_duration * 1000),
-                "product": "story_camera_clips_v2",
-                "song_name": track.title,
-                "artist_name": track.display_artist,
-                "alacorn_session_id": "null",
-            }
-            if getattr(track, "music_canonical_id", None):
-                data["clips_audio_metadata"]["song"]["music_canonical_id"] = track.music_canonical_id
-                data["music_params"]["music_canonical_id"] = track.music_canonical_id
+            data = self.clip_music_extra_data(
+                track,
+                extra_data=extra_data,
+                audio_asset_start_time=highlight_start_time,
+                overlap_duration=int(video_duration * 1000),
+                original_volume=0.0,
+            )
             return self.clip_upload(tmpvideo, caption, extra_data=data)
         finally:
             for clip in (video, audio_clip):
@@ -664,6 +644,105 @@ class UploadClipMixin:
                 with contextlib.suppress(FileNotFoundError):
                     if tmp_path:
                         tmp_path.unlink()
+
+    def clip_music_extra_data(
+        self,
+        track: Union[Track, Dict],
+        extra_data: Dict[str, object] = {},
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: int = 30000,
+        original_volume: float = 1.0,
+        music_volume: float = 1.0,
+        product: str = "story_camera_clips_v2",
+        alacorn_session_id: str = "null",
+    ) -> Dict[str, object]:
+        """
+        Build Reel music metadata for ``clip_upload(..., extra_data=...)``.
+
+        This helper only adds the metadata fields used by the app configure
+        request. It does not download or mux audio into the local video file.
+        """
+        audio_asset_id = self._track_value(track, "audio_asset_id") or self._track_value(track, "id")
+        audio_cluster_id = self._track_value(track, "audio_cluster_id")
+        assert audio_asset_id, "track.audio_asset_id or track.id is required"
+        assert audio_cluster_id, "track.audio_cluster_id is required"
+        if audio_asset_start_time is None:
+            audio_asset_start_time = self._track_highlight_start(track)
+
+        artist_name = self._track_value(track, "display_artist") or ""
+        track_name = self._track_value(track, "title") or ""
+        data = dict(extra_data or {})
+        data["clips_audio_metadata"] = {
+            "original": {"volume_level": original_volume},
+            "song": {
+                "volume_level": music_volume,
+                "is_saved": "0",
+                "artist_name": artist_name,
+                "audio_asset_id": audio_asset_id,
+                "audio_cluster_id": audio_cluster_id,
+                "track_name": track_name,
+                "is_picked_precapture": "1",
+            },
+        }
+        data["music_params"] = {
+            "audio_asset_id": audio_asset_id,
+            "audio_cluster_id": audio_cluster_id,
+            "audio_asset_start_time_in_ms": int(audio_asset_start_time),
+            "derived_content_start_time_in_ms": 0,
+            "overlap_duration_in_ms": int(overlap_duration),
+            "product": product,
+            "song_name": track_name,
+            "artist_name": artist_name,
+            "alacorn_session_id": alacorn_session_id,
+        }
+        music_canonical_id = self._track_value(track, "music_canonical_id")
+        if music_canonical_id:
+            data["clips_audio_metadata"]["song"]["music_canonical_id"] = music_canonical_id
+            data["music_params"]["music_canonical_id"] = music_canonical_id
+        return data
+
+    def clip_upload_with_music(
+        self,
+        path: Path,
+        caption: str,
+        track: Union[Track, Dict],
+        thumbnail: Path = None,
+        usertags: List[Usertag] = [],
+        location: Location = None,
+        extra_data: Dict[str, object] = {},
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: int = 30000,
+        original_volume: float = 1.0,
+        music_volume: float = 1.0,
+        product: str = "story_camera_clips_v2",
+        alacorn_session_id: str = "null",
+        **kwargs,
+    ) -> Media:
+        """
+        Upload a Reel with music metadata without local audio muxing.
+
+        Pass ``thumbnail=...`` to avoid automatic thumbnail generation in
+        environments where ffmpeg is not available.
+        """
+        data = self.clip_music_extra_data(
+            track,
+            extra_data=extra_data,
+            audio_asset_start_time=audio_asset_start_time,
+            overlap_duration=overlap_duration,
+            original_volume=original_volume,
+            music_volume=music_volume,
+            product=product,
+            alacorn_session_id=alacorn_session_id,
+        )
+        return self.clip_upload(
+            path,
+            caption,
+            thumbnail=thumbnail,
+            usertags=usertags,
+            location=location,
+            extra_data=data,
+            **kwargs,
+        )
 
     def clip_configure(
         self,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,7 +30,11 @@ from tests.live.test_signup import SignUpTestCase
 from tests.live.test_story import ClientStoryTestCase
 from tests.live.test_timeline import ClientTimelineLiveTestCase
 from tests.live.test_totp import TOTPTestCase
-from tests.live.test_upload import ClientFeedMusicUploadLiveTestCase, ClienUploadTestCase
+from tests.live.test_upload import (
+    ClientClipMusicMetadataUploadLiveTestCase,
+    ClientFeedMusicUploadLiveTestCase,
+    ClienUploadTestCase,
+)
 from tests.live.test_user import (
     ClientFollowRequestLiveTestCase,
     ClientGraphQLQueryLiveTestCase,

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -152,6 +152,96 @@ class ClienUploadTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(self.cl.media_delete(media.id))
 
 
+class ClientClipMusicMetadataUploadLiveTestCase(_helpers.ClientPrivateTestCase):
+    thumbnail_path = Path("examples/kanada.jpg")
+
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for Reel music metadata upload live tests")
+        try:
+            self.cl = self.fresh_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def make_clip_mp4(self):
+        try:
+            import imageio_ffmpeg
+        except ImportError:
+            self.skipTest("imageio_ffmpeg is required to generate a Reel fixture")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as tmp:
+            path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+
+        try:
+            subprocess.run(
+                [
+                    imageio_ffmpeg.get_ffmpeg_exe(),
+                    "-y",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=c=black:s=720x1280:r=30:d=4",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "sine=frequency=440:duration=4",
+                    "-shortest",
+                    "-c:v",
+                    "libx264",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "64k",
+                    str(path),
+                ],
+                check=True,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            self.skipTest(f"Could not generate Reel fixture: {exc}")
+        return path
+
+    def first_music_track(self):
+        tracks = self.cl.search_music("Runaway")
+        if not tracks:
+            self.skipTest("search_music did not return a usable track")
+        return tracks[0]
+
+    def cleanup_uploaded_media(self, media):
+        if not media:
+            return
+        try:
+            self.assertTrue(self.cl.media_delete(media.id))
+        except Exception as exc:
+            print(f"Reel music metadata upload cleanup media_delete failed: {exc.__class__.__name__} {exc}")
+
+    def test_clip_upload_with_music_live(self):
+        path = self.make_clip_mp4()
+        track = self.first_music_track()
+        media = None
+        try:
+            media = self.cl.clip_upload_with_music(
+                path,
+                "Reel music metadata live test",
+                track,
+                thumbnail=self.thumbnail_path,
+                overlap_duration=4000,
+            )
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.media_type, 2)
+            self.assertEqual(media.product_type, "clips")
+        finally:
+            self.cleanup_uploaded_media(media)
+
+
 class ClientFeedMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):
     photo_path = Path("examples/kanada.jpg")
     album_paths = [Path("examples/kanada.jpg"), Path("examples/background.png")]

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -396,6 +396,83 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(upload_extra["music_params"]["artist_name"], "Album artist")
         self.assertEqual(upload_extra["music_params"]["alacorn_session_id"], "alacorn-1")
 
+    def test_clip_music_extra_data_builds_reels_music_payload_from_dict(self):
+        client = self.build_client()
+        track = {
+            "id": "track-id",
+            "audio_cluster_id": "cluster-id",
+            "highlight_start_times_in_ms": [40500],
+            "title": "Runaway",
+            "display_artist": "AURORA",
+            "music_canonical_id": "canonical-id",
+        }
+
+        result = client.clip_music_extra_data(track, overlap_duration=34000)
+
+        self.assertEqual(
+            result["clips_audio_metadata"],
+            {
+                "original": {"volume_level": 1.0},
+                "song": {
+                    "volume_level": 1.0,
+                    "is_saved": "0",
+                    "artist_name": "AURORA",
+                    "audio_asset_id": "track-id",
+                    "audio_cluster_id": "cluster-id",
+                    "track_name": "Runaway",
+                    "is_picked_precapture": "1",
+                    "music_canonical_id": "canonical-id",
+                },
+            },
+        )
+        self.assertEqual(
+            result["music_params"],
+            {
+                "audio_asset_id": "track-id",
+                "audio_cluster_id": "cluster-id",
+                "audio_asset_start_time_in_ms": 40500,
+                "derived_content_start_time_in_ms": 0,
+                "overlap_duration_in_ms": 34000,
+                "product": "story_camera_clips_v2",
+                "song_name": "Runaway",
+                "artist_name": "AURORA",
+                "alacorn_session_id": "null",
+                "music_canonical_id": "canonical-id",
+            },
+        )
+
+    def test_clip_upload_with_music_adds_reels_music_metadata_without_mutating_extra_data(self):
+        client = self.build_client()
+        extra_data = {"disable_comments": 1}
+        track = types.SimpleNamespace(
+            id="track-id",
+            audio_cluster_id="cluster-id",
+            highlight_start_times_in_ms=[1500],
+            title="Track title",
+            display_artist="Artist",
+        )
+
+        with mock.patch.object(client, "clip_upload", return_value="uploaded") as clip_upload:
+            result = client.clip_upload_with_music(
+                Path("clip.mp4"),
+                "caption",
+                track,
+                extra_data=extra_data,
+                overlap_duration=2500,
+            )
+
+        self.assertEqual(result, "uploaded")
+        self.assertEqual(extra_data, {"disable_comments": 1})
+        clip_upload.assert_called_once()
+        self.assertEqual(clip_upload.call_args.args[:2], (Path("clip.mp4"), "caption"))
+        upload_extra = clip_upload.call_args.kwargs["extra_data"]
+        self.assertEqual(upload_extra["disable_comments"], 1)
+        self.assertEqual(upload_extra["music_params"]["audio_asset_id"], "track-id")
+        self.assertEqual(upload_extra["music_params"]["audio_cluster_id"], "cluster-id")
+        self.assertEqual(upload_extra["music_params"]["audio_asset_start_time_in_ms"], 1500)
+        self.assertEqual(upload_extra["music_params"]["overlap_duration_in_ms"], 2500)
+        self.assertIn("clips_audio_metadata", upload_extra)
+
     def test_photo_story_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 


### PR DESCRIPTION
## Summary
- add `clip_music_extra_data()` to build Reels `clips_audio_metadata` and `music_params` for manual `clip_upload(..., extra_data=...)`
- add `clip_upload_with_music()` for music metadata uploads without local MoviePy audio muxing
- reuse the shared metadata builder in `clip_upload_as_reel_with_music()`
- document the metadata-only path and Pydroid/ffmpeg implication
- add regression and focused live coverage

## Testing
- RED: .venv/bin/python -m pytest tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_music_extra_data_builds_reels_music_payload_from_dict tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_upload_with_music_adds_reels_music_metadata_without_mutating_extra_data -q (2 missing-method failures before implementation)
- .venv/bin/python -m pytest tests/regression/test_upload.py -q
- .venv/bin/python -m ruff check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py tests/__init__.py docs/usage-guide/media.md docs/usage-guide/pydroid.md
- .venv/bin/python -m ruff format --check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py tests/__init__.py
- .venv/bin/python -m mkdocs build --strict
- live: tests/live/test_upload.py::ClientClipMusicMetadataUploadLiveTestCase::test_clip_upload_with_music_live