### PR TITLE
Support submit_phone login challenge

### DIFF
--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -40,6 +40,7 @@ def challenge_code_handler(username, choice):
     return False
 
 cl = Client()
+cl.phone_number = "+15551234567"  # required for submit_phone challenges
 cl.challenge_code_handler = challenge_code_handler
 cl.login(IG_USERNAME, IG_PASSWORD)
 ```
@@ -47,6 +48,7 @@ cl.login(IG_USERNAME, IG_PASSWORD)
 Notes:
 
 * `challenge_code_handler(username, choice)` should return the received code as a string. Returning a falsey value means no code is available yet.
+* Login `submit_phone` challenges use `client.phone_number`, then call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 * Signup SMS challenges use the `phone_number` passed to `signup(...)` and call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 * Current `master` raises a clearer `ChallengeRequired` for `/auth_platform/?apc=...` flows. That path is not yet supported automatically and still requires manual verification.
 * For long-running automation, persist client settings around challenge handling so you can retry without rebuilding the entire device/session state.

--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -433,8 +433,16 @@ class ChallengeResolveMixin:
                 },
             )
             return True
-        elif step_name in ("verify_email", "verify_email_code", "select_verify_method"):
-            choice = ChallengeChoice.EMAIL
+        elif step_name in (
+            "verify_email",
+            "verify_email_code",
+            "verify_phone",
+            "verify_phone_code",
+            "verify_sms",
+            "verify_sms_code",
+            "select_verify_method",
+        ):
+            choice = ChallengeChoice.SMS if "phone" in step_name or "sms" in step_name else ChallengeChoice.EMAIL
             if step_name == "select_verify_method":
                 """
                 {'step_name': 'select_verify_method',
@@ -468,6 +476,18 @@ class ChallengeResolveMixin:
             assert self.last_json.get("action", "") == "close"
             assert self.last_json.get("status", "") == "ok"
             return True
+        elif step_name == "submit_phone":
+            phone_number = getattr(self, "phone_number", None)
+            if not phone_number:
+                raise ChallengeRequired(
+                    "Phone number required to continue submit_phone challenge. "
+                    "Set client.phone_number or complete the flow manually.",
+                    **{key: value for key, value in self.last_json.items() if key != "message"},
+                )
+            self._send_private_request(challenge_url, {"phone_number": phone_number})
+            if self.last_json.get("step_name") == step_name:
+                raise ChallengeError(f"submit_phone challenge did not advance after phone submission: {self.last_json}")
+            return self.challenge_resolve_simple(challenge_url)
         elif step_name == "":
             assert self.last_json.get("action", "") == "close"
             assert self.last_json.get("status", "") == "ok"

--- a/tests/regression/test_challenge.py
+++ b/tests/regression/test_challenge.py
@@ -1,3 +1,4 @@
+from instagrapi.mixins.challenge import ChallengeChoice
 from tests.helpers import *
 
 
@@ -325,6 +326,64 @@ class ChallengeRegressionTestCase(unittest.TestCase):
             client.challenge_resolve_simple("/challenge/test/")
 
         self.assertIn("Unexpected final challenge step", str(cm.exception))
+
+    def test_challenge_resolve_simple_submit_phone_posts_number_then_sms_code(self):
+        client = Client()
+        client.username = "example"
+        client.phone_number = "+15551234567"
+        client.last_json = {
+            "step_name": "submit_phone",
+            "step_data": {"phone_number": "+1 *** *** 4567"},
+            "challenge_context": "{}",
+            "status": "ok",
+        }
+
+        def fake_send_private_request(endpoint, data):
+            if "phone_number" in data:
+                client.last_json = {
+                    "step_name": "verify_phone",
+                    "step_data": {"phone_number": "+1 *** *** 4567"},
+                    "challenge_context": "{}",
+                    "status": "ok",
+                }
+            elif "security_code" in data:
+                client.last_json = {"action": "close", "status": "ok"}
+
+        client._send_private_request = Mock(side_effect=fake_send_private_request)
+        client.challenge_code_or_raised = Mock(return_value="123456")
+
+        result = client.challenge_resolve_simple("/challenge/test/")
+
+        self.assertTrue(result)
+        self.assertEqual(
+            client._send_private_request.call_args_list[0].args,
+            ("/challenge/test/", {"phone_number": "+15551234567"}),
+        )
+        client.challenge_code_or_raised.assert_called_once_with(
+            ChallengeChoice.SMS,
+            wait_seconds=5,
+            attempts=24,
+        )
+        self.assertEqual(
+            client._send_private_request.call_args_list[1].args,
+            ("/challenge/test/", {"security_code": "123456"}),
+        )
+
+    def test_challenge_resolve_simple_submit_phone_requires_configured_phone_number(self):
+        client = Client()
+        client.username = "example"
+        client.phone_number = None
+        client.last_json = {
+            "step_name": "submit_phone",
+            "step_data": {"phone_number": "+1 *** *** 4567"},
+            "challenge_context": "{}",
+            "status": "ok",
+        }
+
+        with self.assertRaises(ChallengeRequired) as cm:
+            client.challenge_resolve_simple("/challenge/test/")
+
+        self.assertIn("Phone number required", str(cm.exception))
 
     def test_challenge_resolve_contact_form_raises_clear_error_for_unexpected_verify_step(
         self,


### PR DESCRIPTION
## Summary
- handle `submit_phone` in the simple login challenge resolver instead of raising `ChallengeUnknownStep`
- treat phone/SMS verification steps as `ChallengeChoice.SMS`
- document `client.phone_number` for login `submit_phone` challenges

Closes #2025.

## Test Plan
- .venv/bin/python -m pytest tests/regression/test_challenge.py::ChallengeRegressionTestCase::test_challenge_resolve_simple_submit_phone_posts_number_then_sms_code tests/regression/test_challenge.py::ChallengeRegressionTestCase::test_challenge_resolve_simple_submit_phone_requires_configured_phone_number -q
- .venv/bin/python -m pytest tests/regression/test_challenge.py -q
- .venv/bin/python -m pytest tests/regression/test_signup.py -q
- .venv/bin/python -m pytest -sv tests/regression/test_extractors.py::ExtractorsRegressionTestCase tests/regression/test_public.py::PublicRegressionTestCase tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase tests/regression/test_direct.py::DirectMixinRegressionTestCase tests/regression/test_challenge.py::ChallengeRegressionTestCase tests/regression/test_comments.py::CommentRepliesRegressionTestCase tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase tests/regression/test_download.py::DownloadRegressionTestCase tests/regression/test_notes.py::NoteMixinRegressionTestCase tests/regression/test_location.py::LocationMixinRegressionTestCase tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase tests/regression/test_user.py::UserMixinRegressionTestCase tests/regression/test_timeline.py::TimelineRegressionTestCase tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase tests/regression/test_upload.py::UploadRegressionTestCase
- .venv/bin/python -m ruff check instagrapi tests
- .venv/bin/python -m ruff format --check instagrapi tests
- .venv/bin/python -m mkdocs build --strict
- .venv/bin/python -m build