### PR TITLE
Refresh media comment action payload

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - media
+          - comment
           - upload
           - direct
           - timeline
@@ -43,6 +44,10 @@ jobs:
       - name: Run media test
         if: github.event.inputs.test_target == 'media' || github.event.inputs.test_target == 'all'
         run: pytest -sv tests/live/test_media.py::ClientMediaTestCase tests/live/test_comments.py::ClientCommentRepliesLiveTestCase
+
+      - name: Run comment write test
+        if: github.event.inputs.test_target == 'comment' || github.event.inputs.test_target == 'all'
+        run: pytest -sv tests/live/test_comments.py::ClientCommentExtendTestCase::test_media_comment
 
       - name: Run upload live tests
         if: github.event.inputs.test_target == 'upload' || github.event.inputs.test_target == 'all'

--- a/docs/usage-guide/comment.md
+++ b/docs/usage-guide/comment.md
@@ -126,3 +126,4 @@ Notes:
 * `media_comment_replies()` fetches `inline_child_comments` for a parent comment and paginates with the returned child cursor.
 * `comment_pin()` / `comment_unpin()` only work on media owned by the authenticated account.
 * Reply creation is supported through `replied_to_comment_id`; reply retrieval is supported through `media_comment_replies()`.
+* Comment creation is a write action and can still trigger Instagram spam or trust checks. Reuse saved sessions, keep volume low on new accounts, and stop when Instagram returns feedback/challenge responses.

--- a/instagrapi/mixins/comment.py
+++ b/instagrapi/mixins/comment.py
@@ -444,8 +444,16 @@ class CommentMixin:
         media_id = self.media_id(media_id)
         data = {
             "delivery_class": "organic",
-            "feed_position": "0",
-            "container_module": "self_comments_v2_feed_contextual_self_profile",  # "comments_v2",
+            "feed_position": str(random.randint(0, 6)),
+            "container_module": "feed_timeline",
+            "media_id": media_id,
+            "_uid": str(self.user_id),
+            "tap_source": "button",
+            "is_2m_enabled": "false",
+            "is_carousel_bumped_post": "false",
+            "is_from_swipe": "false",
+            "floating_context_items": "[]",
+            "media_pct_watched": "0",
             "user_breadcrumb": self.gen_user_breadcrumb(len(text)),
             "idempotence_token": self.generate_uuid(),
             "comment_text": text,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -167,7 +167,7 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.TestCase):
         parts = urlsplit(TEST_ACCOUNTS_URL)
         query = dict(parse_qsl(parts.query, keep_blank_values=True))
         if count is None:
-            query.setdefault("count", "5")
+            query["count"] = "5"
         else:
             query["count"] = str(count)
         return urlunsplit(

--- a/tests/live/test_comments.py
+++ b/tests/live/test_comments.py
@@ -51,11 +51,46 @@ class ClientCommentRepliesLiveTestCase(_helpers.ClientPrivateTestCase):
 
 
 class ClientCommentExtendTestCase(_helpers.ClientPrivateTestCase):
+    def cleanup_comment(self, media_id, comment_pk):
+        try:
+            self.cl.comment_bulk_delete(media_id, [comment_pk])
+        except Exception as exc:
+            print(f"Comment live cleanup comment_bulk_delete failed: {exc.__class__.__name__} {exc}")
+
+    def cleanup_media(self, media_id):
+        try:
+            self.cl.media_delete(media_id)
+        except Exception as exc:
+            print(f"Comment live cleanup media_delete failed: {exc.__class__.__name__} {exc}")
+
+    def assertCommentAccessible(self, media_id, comment_pk, text, attempts=5, delay=3):
+        last_error = None
+        for attempt in range(attempts):
+            if attempt:
+                time.sleep(delay)
+            try:
+                comments = self.cl.media_comments_v1(media_id, amount=20)
+            except Exception as exc:
+                last_error = exc
+                continue
+            for item in comments:
+                if str(item.pk) == str(comment_pk) and item.text == text:
+                    return item
+        self.fail(f"Comment {comment_pk} was not readable after {attempts} attempts: {last_error}")
+
     def test_media_comment(self):
         text = "Test text [%s]" % datetime.now().strftime("%s")
         now = datetime.now(tz=UTC())
-        comment = self.cl.media_comment_v1(2276404890775267248, text)
+        caption_text = "Comment live fixture [%s]" % datetime.now().strftime("%s")
+        path = self.copy_media_fixture("examples/kanada.jpg")
+        media = self.cl.photo_upload(path, caption_text)
+        self.addCleanup(self.cleanup_media, media.id)
+        self.assertUploadedMediaAccessible(media, media_type=1, caption_text=caption_text)
+        media_id = media.id
+        comment = self.cl.media_comment(media_id, text)
+        self.addCleanup(self.cleanup_comment, media_id, comment.pk)
         self.assertIsInstance(comment, Comment)
+        self.assertCommentAccessible(media_id, comment.pk, text)
         comment = comment.dict()
         for key, val in {
             "text": text,

--- a/tests/regression/test_comments.py
+++ b/tests/regression/test_comments.py
@@ -2,6 +2,12 @@ from tests.helpers import *
 
 
 class CommentRepliesRegressionTestCase(unittest.TestCase):
+    def _build_logged_in_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        client.android_device_id = "android-device"
+        return client
+
     def _reply_payload(self, pk, text="reply", replied_to_comment_id="100"):
         return {
             "pk": str(pk),
@@ -14,6 +20,38 @@ class CommentRepliesRegressionTestCase(unittest.TestCase):
             "has_liked_comment": False,
             "comment_like_count": 0,
         }
+
+    def test_media_comment_posts_current_action_context(self):
+        client = self._build_logged_in_client()
+        expected_comment = self._reply_payload("101", text="hello")
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"comment": expected_comment},
+        ) as private_request:
+            comment = client.media_comment("123_456", "hello", replied_to_comment_id=100)
+
+        self.assertIsInstance(comment, Comment)
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/123_456/comment/")
+        self.assertEqual(data["media_id"], "123_456")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["_uuid"], client.uuid)
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["delivery_class"], "organic")
+        self.assertEqual(data["tap_source"], "button")
+        self.assertEqual(data["is_2m_enabled"], "false")
+        self.assertEqual(data["is_carousel_bumped_post"], "false")
+        self.assertEqual(data["is_from_swipe"], "false")
+        self.assertEqual(data["floating_context_items"], "[]")
+        self.assertEqual(data["media_pct_watched"], "0")
+        self.assertEqual(data["container_module"], "feed_timeline")
+        self.assertIn(data["feed_position"], {str(i) for i in range(7)})
+        self.assertEqual(data["comment_text"], "hello")
+        self.assertEqual(data["replied_to_comment_id"], 100)
+        self.assertIn("user_breadcrumb", data)
+        self.assertIn("idempotence_token", data)
 
     def test_media_comment_replies_fetches_inline_child_comments(self):
         client = Client()

--- a/tests/regression/test_helpers.py
+++ b/tests/regression/test_helpers.py
@@ -1,0 +1,26 @@
+from tests import helpers as helper_module
+from tests.helpers import *
+
+
+class LiveAccountHelperRegressionTestCase(unittest.TestCase):
+    def test_build_test_accounts_url_overrides_existing_default_count(self):
+        case = object.__new__(helper_module.ClientPrivateTestCase)
+        with mock.patch.object(
+            helper_module,
+            "TEST_ACCOUNTS_URL",
+            "https://accounts.example.test/take?pool=live&count=1",
+        ):
+            url = case.build_test_accounts_url()
+
+        self.assertEqual(url, "https://accounts.example.test/take?pool=live&count=5")
+
+    def test_build_test_accounts_url_uses_requested_count(self):
+        case = object.__new__(helper_module.ClientPrivateTestCase)
+        with mock.patch.object(
+            helper_module,
+            "TEST_ACCOUNTS_URL",
+            "https://accounts.example.test/take?pool=live&count=1",
+        ):
+            url = case.build_test_accounts_url(count=8)
+
+        self.assertEqual(url, "https://accounts.example.test/take?pool=live&count=8")


### PR DESCRIPTION
## Summary
- refresh `media_comment` write payload to include current action context fields used by feed write actions
- add regression coverage for comment creation payload and reply handling
- fix live account helper URL building so workflow account pools are not accidentally pinned to one stale account
- fix the live comment test to upload its own media, call `media_comment`, read the created comment back, and cleanup via `comment_bulk_delete` / `media_delete`
- add a dedicated `comment` target to the live account workflow
- document that comment creation remains a write action subject to Instagram spam/trust checks

Refs #2097.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_comments.py -q`
- `.venv/bin/python -m pytest tests/regression/test_helpers.py tests/regression/test_comments.py -q`
- `.venv/bin/python -m pytest tests/regression/test_comments.py tests/regression/test_media.py::MediaActionPayloadRegressionTestCase tests/regression/test_hardening.py::HardeningRegressionTestCase::test_send_private_request_promotes_404_not_found_body_to_challenge -q`
- `.venv/bin/python -m pytest -sv tests/regression/test_extractors.py::ExtractorsRegressionTestCase tests/regression/test_public.py::PublicRegressionTestCase tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase tests/regression/test_direct.py::DirectMixinRegressionTestCase tests/regression/test_challenge.py::ChallengeRegressionTestCase tests/regression/test_comments.py::CommentRepliesRegressionTestCase tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase tests/regression/test_download.py::DownloadRegressionTestCase tests/regression/test_notes.py::NoteMixinRegressionTestCase tests/regression/test_location.py::LocationMixinRegressionTestCase tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase tests/regression/test_user.py::UserMixinRegressionTestCase tests/regression/test_timeline.py::TimelineRegressionTestCase tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase tests/regression/test_upload.py::UploadRegressionTestCase`
- `.venv/bin/python -m ruff check instagrapi tests`
- `.venv/bin/python -m ruff format --check instagrapi tests`
- `.venv/bin/python -m mkdocs build --strict`
- `.venv/bin/python -m build`

## Live verification
- Local `tests/live/test_comments.py::ClientCommentExtendTestCase::test_media_comment` did not reach the comment endpoint because account setup failed on proxy tunnel `302 Found` during `launcher/sync/`.
- GitHub live account workflow `comment` target passed: https://github.com/subzeroid/instagrapi/actions/runs/26124367512