### PR TITLE
Fallback to recent media after photo configure

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -180,6 +180,52 @@ class MediaMixin:
             )
         return media
 
+    def _current_media_ids(self, amount: int = 20):
+        user_id = self.user_id or getattr(self, "_user_id", None)
+        if not user_id:
+            return None
+        try:
+            return {str(media.id) for media in self.user_medias_v1(user_id, amount=amount)}
+        except Exception as e:
+            self.logger.debug("Unable to read current feed media before upload: %s", e)
+            return None
+
+    def _new_media_after_upload(self, previous_media_ids, attempts: int = 5, delay: int = 3, amount: int = 20):
+        user_id = self.user_id or getattr(self, "_user_id", None)
+        if previous_media_ids is None or not user_id:
+            return None
+        for attempt in range(attempts):
+            try:
+                medias = self.user_medias_v1(user_id, amount=amount)
+            except Exception as e:
+                self.logger.debug("Unable to read uploaded feed media on attempt %s: %s", attempt, e)
+            else:
+                for media in medias:
+                    if str(media.id) not in previous_media_ids:
+                        return media
+            if attempt < attempts - 1:
+                time.sleep(delay)
+        return None
+
+    def _extract_configured_media_or_recent(
+        self,
+        configured,
+        exception_cls,
+        context: str,
+        previous_media_ids,
+    ):
+        media = self._extract_configured_media(configured)
+        if media is not None:
+            return media
+        media = self._new_media_after_upload(previous_media_ids)
+        if media is not None:
+            return media
+        raise exception_cls(
+            f"{context} configure succeeded without media payload and uploaded media was not visible",
+            response=self.last_response,
+            **(self.last_json if isinstance(self.last_json, dict) else {}),
+        )
+
     def _current_story_ids(self, amount: int = 20):
         user_id = self.user_id or getattr(self, "_user_id", None)
         if not user_id:

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -258,6 +258,7 @@ class UploadPhotoMixin:
         if path.suffix.lower() not in valid_extensions:
             raise ValueError("Invalid file format. Only JPG/JPEG/PNG/WEBP files are supported.")
 
+        previous_media_ids = self._current_media_ids()
         upload_id, width, height = self.photo_rupload(path, upload_id)
         for attempt in range(10):
             self.logger.debug(f"Attempt #{attempt} to configure Photo: {path}")
@@ -273,10 +274,11 @@ class UploadPhotoMixin:
             )
             if configured:
                 self.expose()
-                return self._extract_configured_media_or_raise(
+                return self._extract_configured_media_or_recent(
                     configured,
                     PhotoConfigureError,
                     "Photo upload",
+                    previous_media_ids,
                 )
         raise PhotoConfigureError(response=self.last_response, **self.last_json)
 

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1,3 +1,4 @@
+from instagrapi.extractors import extract_media_v1
 from tests.helpers import *
 
 
@@ -230,16 +231,32 @@ class UploadRegressionTestCase(unittest.TestCase):
         with mock.patch.object(client, "clip_info_for_creation", return_value={"status": "ok"}):
             self.assertFalse(client.clip_trial_eligible())
 
-    def test_photo_upload_raises_clear_error_when_configure_has_no_media(self):
+    def test_photo_upload_falls_back_to_recent_media_when_configure_has_no_media(self):
+        client = self.build_client()
+        existing_media = extract_media_v1(self.build_media_payload(media_type=1))
+        uploaded_media = extract_media_v1(dict(self.build_media_payload(media_type=1), pk="2", id="2_1", code="def"))
+
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(client, "photo_configure", return_value={"status": "ok"}):
+                with mock.patch.object(
+                    client, "user_medias_v1", side_effect=[[existing_media], [uploaded_media, existing_media]]
+                ):
+                    with mock.patch("time.sleep"):
+                        media = client.photo_upload(Path("example.jpg"), "caption")
+
+        self.assertEqual(media.id, uploaded_media.id)
+
+    def test_photo_upload_raises_clear_error_when_configure_has_no_media_and_recent_media_missing(self):
         client = self.build_client()
 
         with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
             with mock.patch.object(client, "photo_configure", return_value={"status": "ok"}):
-                with mock.patch("time.sleep"):
-                    with self.assertRaises(PhotoConfigureError) as ctx:
-                        client.photo_upload(Path("example.jpg"), "caption")
+                with mock.patch.object(client, "user_medias_v1", return_value=[]):
+                    with mock.patch("time.sleep"):
+                        with self.assertRaises(PhotoConfigureError) as ctx:
+                            client.photo_upload(Path("example.jpg"), "caption")
 
-        self.assertIn("without media payload", str(ctx.exception))
+        self.assertIn("without media payload and uploaded media was not visible", str(ctx.exception))
 
     def test_photo_upload_extracts_configure_media_when_expose_overwrites_last_json(self):
         client = self.build_client()


### PR DESCRIPTION
## Summary
- add a feed-media readback fallback when `photo_configure` succeeds but Instagram omits the `media` payload
- return the newly visible user media instead of failing immediately on `{"status": "ok"}` configure responses
- keep a clear configure error when no uploaded media becomes visible

## Tests
- `.venv/bin/python -m pytest tests/regression/test_upload.py tests/regression/test_comments.py -q`
- `.venv/bin/python -m ruff check instagrapi tests`
- `.venv/bin/python -m ruff format --check instagrapi tests`
- `.venv/bin/python -m mkdocs build --strict`

## Live verification
- The same async fallback patch was applied to a fresh `aiograpi` clone on `sk.test`; `tests/legacy.py::ClientCommentExtendTestCase::test_media_comment` passed after uploading media, reading it back through the fallback, posting a comment, reading the comment back, and cleaning up.