### PR TITLE
Add low-level Bloks two-factor helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cl.delete_note(note.id)
 ## Features
 
 * Uses [Web API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) and [Mobile API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) flows where available
-* Supports login by password, 2FA, and `sessionid`
+* Supports login by password, 2FA, `sessionid`, and low-level [Bloks 2FA](https://subzeroid.github.io/instagrapi/usage-guide/totp.html#bloks-two-factor-flow) helpers for newer verification flows
 * Includes email/SMS-based [challenge resolver](https://subzeroid.github.io/instagrapi/usage-guide/challenge_resolver.html) hooks
 * Uploads and downloads photos, videos, albums, IGTV, reels, and stories
 * Works with users, media, comments, locations, hashtags, collections, notes, direct messages, and insights

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Support chat in Telegram: [aiograpi_support](https://t.me/aiograpi_support)
 ## Features
 
 1. Uses [Public API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) (web, opportunistic) and [Private API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) (mobile app, authorized) flows depending on the situation
-2. [Login](https://subzeroid.github.io/instagrapi/usage-guide/interactions.html) by username and password, including 2FA and by sessionid
+2. [Login](https://subzeroid.github.io/instagrapi/usage-guide/interactions.html) by username and password, including 2FA, low-level [Bloks 2FA](usage-guide/totp.md#bloks-two-factor-flow) helpers, and by sessionid
 3. [Challenge Resolver](https://subzeroid.github.io/instagrapi/usage-guide/challenge_resolver.html) have Email and SMS handlers
 4. Support [upload](https://subzeroid.github.io/instagrapi/usage-guide/media.html) a Photo, Video, IGTV, Reels, Albums and Stories
 5. Support work with [User](https://subzeroid.github.io/instagrapi/usage-guide/user.html), [Media](https://subzeroid.github.io/instagrapi/usage-guide/media.html), [Comment](https://subzeroid.github.io/instagrapi/usage-guide/comment.html), [Insights](https://subzeroid.github.io/instagrapi/usage-guide/insight.html), [Collections](https://subzeroid.github.io/instagrapi/usage-guide/collection.html), [Location](https://subzeroid.github.io/instagrapi/usage-guide/location.html) (Place), [Hashtag](https://subzeroid.github.io/instagrapi/usage-guide/hashtag.html) and [Direct Message](https://subzeroid.github.io/instagrapi/usage-guide/direct.html) objects
@@ -115,7 +115,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`Resource`](usage-guide/media.md) - Part of Media (for albums)
   * [`MediaOembed`](usage-guide/media.md) - Short version of Media
   * [`Account`](usage-guide/account.md) - Full private info for your account (e.g. email, phone_number)
-  * [`TOTP`](usage-guide/totp.md) - 2FA TOTP helpers (generate seed, enable/disable TOTP, generate code as Google Authenticator)
+  * [`TOTP`](usage-guide/totp.md) - 2FA TOTP helpers, code generation, and low-level Bloks verification helpers
   * [`User`](usage-guide/user.md) - Full public user data
   * [`UserShort`](usage-guide/user.md) - Short public user data (used in Usertag, Comment, Media, Direct Message)
   * [`Usertag`](usage-guide/user.md) - Tag user in Media (coordinates + UserShort)

--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -35,3 +35,38 @@ Notes:
 * `totp_generate_seed()` gives you the secret key you would normally scan into an authenticator app.
 * `totp_generate_code()` is a local helper and can be used anywhere you already have the TOTP seed.
 * Save the backup codes returned by `totp_enable()` immediately. Instagram does not guarantee that you can fetch the same codes again later.
+
+## Bloks two-factor flow
+
+Some accounts are moved by Instagram to a newer CAA/Bloks two-factor flow. In that case the legacy `accounts/two_factor_login/` endpoint can reject a valid code with `Invalid Parameters`.
+
+`Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram requires the newer flow, use the low-level Bloks helpers with the `two_step_verification_context` returned by the login challenge response:
+
+``` python
+from instagrapi import Client
+
+cl = Client()
+
+# The context comes from Instagram's login challenge response.
+context = "<two_step_verification_context>"
+
+cl.bloks_two_step_verification_entrypoint(context)
+cl.bloks_two_step_verification_method_picker(context)
+cl.bloks_two_step_verification_select_method(context, selected_method="totp")
+
+code = cl.totp_generate_code("<totp seed>")
+result = cl.bloks_two_step_verification_verify_code(context, code, challenge="totp")
+login_payload = cl.bloks_extract_login_response(result)
+cl.bloks_apply_login_response(login_payload)
+```
+
+For SMS, select and verify the `sms` challenge instead:
+
+``` python
+cl.bloks_two_step_verification_select_method(context, selected_method="sms")
+result = cl.bloks_two_step_verification_verify_code(context, "123456", challenge="sms")
+```
+
+`bloks_extract_login_response(...)` returns decoded `login_response`, response `headers`, cookie values, raw cookie header text, and the raw embedded object when Instagram returns a successful Bloks login payload. It returns `{}` when the response is an intermediate UI state or an error. `bloks_apply_login_response(...)` can then copy the returned authorization data and cookies into the current client session.
+
+This is intentionally low-level. The full CAA login flow that produces `two_step_verification_context` is not wired into `Client.login()` yet, because it depends on newer login response state and account-specific verification behavior.

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -1,3 +1,6 @@
+import json
+from http.cookies import SimpleCookie
+from json import JSONDecodeError
 from typing import Any, Dict, List, Optional
 
 from instagrapi.utils.serialization import dumps
@@ -5,6 +8,16 @@ from instagrapi.utils.serialization import dumps
 
 class BloksMixin:
     bloks_versioning_id = ""
+
+    def _bloks_payload(self, params: Dict, bloks_versioning_id: str = "") -> Dict[str, str]:
+        versioning_id = bloks_versioning_id or self.bloks_versioning_id
+        assert versioning_id, "Client.bloks_versioning_id is empty (hash is expected)"
+        return {
+            "params": dumps(params),
+            "_uuid": self.uuid,
+            "bk_client_context": dumps({"bloks_version": versioning_id, "styles_id": "instagram"}),
+            "bloks_versioning_id": versioning_id,
+        }
 
     def bloks_async_action(self, action: str, params: Dict, bloks_versioning_id: str = "") -> Dict:
         """
@@ -24,15 +37,29 @@ class BloksMixin:
         Dict
             Raw Instagram response.
         """
-        versioning_id = bloks_versioning_id or self.bloks_versioning_id
-        assert versioning_id, "Client.bloks_versioning_id is empty (hash is expected)"
-        data = {
-            "params": dumps(params),
-            "_uuid": self.uuid,
-            "bk_client_context": dumps({"bloks_version": versioning_id, "styles_id": "instagram"}),
-            "bloks_versioning_id": versioning_id,
-        }
+        data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
         return self.private_request(f"bloks/async_action/{action}/", data=data, with_signature=False)
+
+    def bloks_app(self, app: str, params: Dict, bloks_versioning_id: str = "") -> Dict:
+        """
+        Perform a raw Bloks app request.
+
+        Parameters
+        ----------
+        app: str
+            App name, for example ``com.bloks.www.two_step_verification.entrypoint``.
+        params: Dict
+            Bloks ``params`` payload.
+        bloks_versioning_id: str, optional
+            Bloks versioning id. Uses ``Client.bloks_versioning_id`` when omitted.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
+        return self.private_request(f"bloks/apps/{app}/", data=data, with_signature=False)
 
     def bloks_fxcal_link_reels_share(
         self,
@@ -71,6 +98,300 @@ class BloksMixin:
             params,
             bloks_versioning_id=bloks_versioning_id,
         )
+
+    def bloks_two_step_verification_entrypoint(
+        self,
+        two_step_verification_context: str,
+        flow_source: str = "two_factor_login",
+        should_fallback_to_sms: bool = False,
+        screen_id: Optional[str] = None,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Open the current Bloks two-step verification entrypoint.
+
+        This is a low-level helper for accounts that require the newer
+        CAA/Bloks two-factor flow. It requires a ``two_step_verification_context``
+        returned by Instagram during login.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        server_params = {
+            "should_fallback_to_sms": int(should_fallback_to_sms),
+            "family_device_id": self.phone_id,
+            "device_id": self.android_device_id,
+            "two_step_verification_context": two_step_verification_context,
+            "flow_source": flow_source,
+        }
+        if screen_id:
+            server_params["INTERNAL_INFRA_screen_id"] = screen_id
+        params = {
+            "client_input_params": {
+                "device_id": self.android_device_id,
+                "is_whatsapp_installed": 0,
+                "machine_id": self.mid,
+            },
+            "server_params": server_params,
+        }
+        return self.bloks_app(
+            "com.bloks.www.two_step_verification.entrypoint",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
+
+    def bloks_two_step_verification_method_picker(
+        self,
+        two_step_verification_context: str,
+        flow_source: str = "two_factor_login",
+        should_fallback_to_sms: bool = False,
+        screen_id: Optional[str] = None,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Open the Bloks two-step verification method picker.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        server_params = {
+            "should_fallback_to_sms": int(should_fallback_to_sms),
+            "device_id": self.android_device_id,
+            "two_step_verification_context": two_step_verification_context,
+            "flow_source": flow_source,
+        }
+        if screen_id:
+            server_params["INTERNAL_INFRA_screen_id"] = screen_id
+        params = {
+            "client_input_params": {"is_whatsapp_installed": 0},
+            "server_params": server_params,
+        }
+        return self.bloks_app(
+            "com.bloks.www.two_step_verification.method_picker",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
+
+    def bloks_two_step_verification_select_method(
+        self,
+        two_step_verification_context: str,
+        selected_method: str,
+        flow_source: str = "two_factor_login",
+        should_fallback_to_sms: bool = False,
+        latency_qpl_marker_id: Optional[int] = None,
+        latency_qpl_instance_id: Optional[int] = None,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Select a two-step verification method such as ``totp`` or ``sms``.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        server_params = {
+            "should_fallback_to_sms": int(should_fallback_to_sms),
+            "device_id": self.android_device_id,
+            "spectra_reg_login_data": None,
+            "two_step_verification_context": two_step_verification_context,
+            "flow_source": flow_source,
+        }
+        if latency_qpl_marker_id is not None:
+            server_params["INTERNAL__latency_qpl_marker_id"] = latency_qpl_marker_id
+        if latency_qpl_instance_id is not None:
+            server_params["INTERNAL__latency_qpl_instance_id"] = latency_qpl_instance_id
+        params = {
+            "client_input_params": {
+                "selected_method": selected_method,
+                "cloud_trust_token": None,
+                "network_bssid": None,
+            },
+            "server_params": server_params,
+        }
+        return self.bloks_async_action(
+            "com.bloks.www.two_step_verification.method_picker.navigation.async",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
+
+    def bloks_two_step_verification_enter_totp_code(
+        self,
+        two_step_verification_context: str,
+        flow_source: str = "two_factor_login",
+        screen_id: Optional[str] = None,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Open the Bloks TOTP code entry app.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        server_params = {
+            "device_id": self.android_device_id,
+            "two_step_verification_context": two_step_verification_context,
+            "flow_source": flow_source,
+        }
+        if screen_id:
+            server_params["INTERNAL_INFRA_screen_id"] = screen_id
+        params = {"server_params": server_params}
+        return self.bloks_app(
+            "com.bloks.www.two_factor_login.enter_totp_code",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
+
+    def bloks_two_step_verification_verify_code(
+        self,
+        two_step_verification_context: str,
+        code: str,
+        challenge: str = "totp",
+        flow_source: str = "two_factor_login",
+        should_trust_device: bool = True,
+        should_fallback_to_sms: bool = False,
+        auth_secure_device_id: str = "",
+        block_store_machine_id: str = "",
+        latency_qpl_marker_id: Optional[int] = None,
+        latency_qpl_instance_id: Optional[int] = None,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Verify a Bloks two-step verification code.
+
+        ``challenge`` is the selected method name, for example ``totp`` or
+        ``sms``. The raw response may contain an embedded login payload; parse it
+        with :meth:`bloks_extract_login_response`.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        server_params = {
+            "should_fallback_to_sms": int(should_fallback_to_sms),
+            "device_id": self.android_device_id,
+            "spectra_reg_login_data": None,
+            "challenge": challenge,
+            "two_step_verification_context": two_step_verification_context,
+            "flow_source": flow_source,
+        }
+        if latency_qpl_marker_id is not None:
+            server_params["INTERNAL__latency_qpl_marker_id"] = latency_qpl_marker_id
+        if latency_qpl_instance_id is not None:
+            server_params["INTERNAL__latency_qpl_instance_id"] = latency_qpl_instance_id
+        params = {
+            "client_input_params": {
+                "auth_secure_device_id": auth_secure_device_id,
+                "block_store_machine_id": block_store_machine_id,
+                "code": code,
+                "should_trust_device": int(should_trust_device),
+                "family_device_id": self.phone_id,
+                "device_id": self.android_device_id,
+                "cloud_trust_token": None,
+                "network_bssid": None,
+                "machine_id": self.mid,
+            },
+            "server_params": server_params,
+        }
+        return self.bloks_async_action(
+            "com.bloks.www.two_step_verification.verify_code.async",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
+
+    def bloks_extract_login_response(self, result: Dict) -> Dict[str, Any]:
+        """
+        Extract an embedded login response from a Bloks action payload.
+
+        Successful CAA/Bloks two-factor responses can place a JSON object inside
+        ``layout.bloks_payload.action``. This helper returns the decoded
+        ``login_response``, response ``headers``, cookie values, raw cookie
+        header text, and raw embedded object. If no payload is found, an empty
+        dictionary is returned.
+
+        Returns
+        -------
+        Dict
+            Parsed login payload or ``{}``.
+        """
+        action = result.get("layout", {}).get("bloks_payload", {}).get("action", "")
+        if not isinstance(action, str):
+            return {}
+        decoder = json.JSONDecoder()
+        index = 0
+        while index < len(action):
+            if action[index] != '"':
+                index += 1
+                continue
+            try:
+                value, end = decoder.raw_decode(action[index:])
+            except JSONDecodeError:
+                index += 1
+                continue
+            index += max(end, 1)
+            if not isinstance(value, str) or "login_response" not in value:
+                continue
+            try:
+                raw = json.loads(value)
+                login_response = json.loads(raw["login_response"])
+                headers = json.loads(raw.get("headers") or "{}")
+            except (KeyError, TypeError, ValueError):
+                continue
+            raw_cookies = raw.get("cookies") or ""
+            cookies = SimpleCookie()
+            cookies.load(raw_cookies.replace("Set-Cookie: ", ""))
+            return {
+                "login_response": login_response,
+                "headers": headers,
+                "cookies": {name: morsel.value for name, morsel in cookies.items()},
+                "raw_cookies": raw_cookies,
+                "raw": raw,
+            }
+        return {}
+
+    def bloks_apply_login_response(self, result: Dict) -> bool:
+        """
+        Apply a parsed Bloks login response to the client session.
+
+        ``result`` may be either the raw Bloks response returned by
+        ``bloks_two_step_verification_verify_code(...)`` or the dictionary
+        returned by :meth:`bloks_extract_login_response`.
+
+        Returns
+        -------
+        bool
+            ``True`` when authorization or session cookies were applied.
+        """
+        parsed = result if "headers" in result or "cookies" in result else self.bloks_extract_login_response(result)
+        if not parsed:
+            return False
+        headers = parsed.get("headers") or {}
+        cookies = parsed.get("cookies") or {}
+        authorization = headers.get("IG-Set-Authorization") or headers.get("ig-set-authorization")
+        if authorization:
+            self.authorization_data = self.parse_authorization(authorization)
+            if self.authorization:
+                self.private.headers["Authorization"] = self.authorization
+        for name, value in cookies.items():
+            self.private.cookies.set(name, value)
+        if cookies.get("sessionid"):
+            self.public.cookies.set("sessionid", cookies["sessionid"])
+        ig_u_rur = headers.get("ig-set-ig-u-rur") or headers.get("IG-Set-IG-U-RUR")
+        if ig_u_rur:
+            self.set_ig_u_rur(ig_u_rur)
+            self.private.headers["IG-U-RUR"] = ig_u_rur
+        ig_www_claim = headers.get("x-ig-set-www-claim") or headers.get("X-IG-Set-WWW-Claim")
+        if ig_www_claim:
+            self.set_ig_www_claim(ig_www_claim)
+            self.private.headers["X-IG-WWW-Claim"] = ig_www_claim
+        return bool(authorization or cookies.get("sessionid"))
 
     def bloks_action(self, action: str, data: dict) -> bool:
         """Performing actions for bloks

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -208,7 +208,8 @@ class BloksMixin:
         params = {
             "client_input_params": {
                 "selected_method": selected_method,
-                "cloud_trust_token": None,
+                # Instagram payload field name, not a secret value.
+                "cloud_trust_token": None,  # nosec B105
                 "network_bssid": None,
             },
             "server_params": server_params,
@@ -294,7 +295,8 @@ class BloksMixin:
                 "should_trust_device": int(should_trust_device),
                 "family_device_id": self.phone_id,
                 "device_id": self.android_device_id,
-                "cloud_trust_token": None,
+                # Instagram payload field name, not a secret value.
+                "cloud_trust_token": None,  # nosec B105
                 "network_bssid": None,
                 "machine_id": self.mid,
             },

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -1,3 +1,5 @@
+import base64
+
 from tests.helpers import *
 
 
@@ -19,6 +21,26 @@ class BloksRegressionTestCase(unittest.TestCase):
         self.assertEqual(result, expected)
         private_request.assert_called_once_with(
             "bloks/async_action/com.example.action/",
+            data={
+                "params": dumps(params),
+                "_uuid": "uuid-1",
+                "bk_client_context": dumps({"bloks_version": "bloks-version", "styles_id": "instagram"}),
+                "bloks_versioning_id": "bloks-version",
+            },
+            with_signature=False,
+        )
+
+    def test_bloks_app_posts_unsigned_bloks_payload(self):
+        client = self.build_client()
+        params = {"server_params": {"flow": "example_flow"}}
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.bloks_app("com.example.app", params)
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "bloks/apps/com.example.app/",
             data={
                 "params": dumps(params),
                 "_uuid": "uuid-1",
@@ -50,3 +72,206 @@ class BloksRegressionTestCase(unittest.TestCase):
             },
             bloks_versioning_id="",
         )
+
+    def test_bloks_two_step_verification_entrypoint_uses_current_payload(self):
+        client = self.build_client()
+        client.android_device_id = "android-1"
+        client.phone_id = "family-device-1"
+        client.mid = "machine-1"
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "bloks_app", return_value=expected) as bloks_app:
+            result = client.bloks_two_step_verification_entrypoint(
+                "context-1",
+                screen_id="screen-1",
+                should_fallback_to_sms=True,
+            )
+
+        self.assertEqual(result, expected)
+        bloks_app.assert_called_once_with(
+            "com.bloks.www.two_step_verification.entrypoint",
+            {
+                "client_input_params": {
+                    "device_id": "android-1",
+                    "is_whatsapp_installed": 0,
+                    "machine_id": "machine-1",
+                },
+                "server_params": {
+                    "should_fallback_to_sms": 1,
+                    "family_device_id": "family-device-1",
+                    "device_id": "android-1",
+                    "INTERNAL_INFRA_screen_id": "screen-1",
+                    "two_step_verification_context": "context-1",
+                    "flow_source": "two_factor_login",
+                },
+            },
+            bloks_versioning_id="",
+        )
+
+    def test_bloks_two_step_verification_method_picker_uses_current_payload(self):
+        client = self.build_client()
+        client.android_device_id = "android-1"
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "bloks_app", return_value=expected) as bloks_app:
+            result = client.bloks_two_step_verification_method_picker("context-1")
+
+        self.assertEqual(result, expected)
+        bloks_app.assert_called_once_with(
+            "com.bloks.www.two_step_verification.method_picker",
+            {
+                "client_input_params": {"is_whatsapp_installed": 0},
+                "server_params": {
+                    "should_fallback_to_sms": 0,
+                    "device_id": "android-1",
+                    "two_step_verification_context": "context-1",
+                    "flow_source": "two_factor_login",
+                },
+            },
+            bloks_versioning_id="",
+        )
+
+    def test_bloks_two_step_verification_select_method_uses_current_payload(self):
+        client = self.build_client()
+        client.android_device_id = "android-1"
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "bloks_async_action", return_value=expected) as bloks_async_action:
+            result = client.bloks_two_step_verification_select_method(
+                "context-1",
+                selected_method="sms",
+                latency_qpl_marker_id=36707139,
+                latency_qpl_instance_id=123,
+            )
+
+        self.assertEqual(result, expected)
+        bloks_async_action.assert_called_once_with(
+            "com.bloks.www.two_step_verification.method_picker.navigation.async",
+            {
+                "client_input_params": {
+                    "selected_method": "sms",
+                    "cloud_trust_token": None,
+                    "network_bssid": None,
+                },
+                "server_params": {
+                    "should_fallback_to_sms": 0,
+                    "INTERNAL__latency_qpl_marker_id": 36707139,
+                    "device_id": "android-1",
+                    "spectra_reg_login_data": None,
+                    "INTERNAL__latency_qpl_instance_id": 123,
+                    "two_step_verification_context": "context-1",
+                    "flow_source": "two_factor_login",
+                },
+            },
+            bloks_versioning_id="",
+        )
+
+    def test_bloks_two_step_verification_verify_code_uses_current_payload(self):
+        client = self.build_client()
+        client.android_device_id = "android-1"
+        client.phone_id = "family-device-1"
+        client.mid = "machine-1"
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "bloks_async_action", return_value=expected) as bloks_async_action:
+            result = client.bloks_two_step_verification_verify_code(
+                "context-1",
+                "123456",
+                challenge="sms",
+                should_trust_device=False,
+            )
+
+        self.assertEqual(result, expected)
+        bloks_async_action.assert_called_once_with(
+            "com.bloks.www.two_step_verification.verify_code.async",
+            {
+                "client_input_params": {
+                    "auth_secure_device_id": "",
+                    "block_store_machine_id": "",
+                    "code": "123456",
+                    "should_trust_device": 0,
+                    "family_device_id": "family-device-1",
+                    "device_id": "android-1",
+                    "cloud_trust_token": None,
+                    "network_bssid": None,
+                    "machine_id": "machine-1",
+                },
+                "server_params": {
+                    "should_fallback_to_sms": 0,
+                    "device_id": "android-1",
+                    "spectra_reg_login_data": None,
+                    "challenge": "sms",
+                    "two_step_verification_context": "context-1",
+                    "flow_source": "two_factor_login",
+                },
+            },
+            bloks_versioning_id="",
+        )
+
+    def test_bloks_extract_login_response_parses_embedded_action_payload(self):
+        client = self.build_client()
+        login_payload = {
+            "login_response": dumps(
+                {
+                    "logged_in_user": {"pk": 123, "username": "example"},
+                    "trusted_device_nonce": "nonce-1",
+                    "credential_type": "password",
+                }
+            ),
+            "headers": dumps({"IG-Set-Authorization": "Bearer IGT:2:encoded"}),
+            "cookies": (
+                "Set-Cookie: csrftoken=token-1; Domain=.instagram.com; Path=/; Secure\r\n"
+                "Set-Cookie: ds_user_id=123; Domain=.instagram.com; Path=/; Secure\r\n"
+                "Set-Cookie: sessionid=123%3Aabc; Domain=.instagram.com; Path=/; Secure"
+            ),
+            "exact_profile_identified": "1",
+        }
+        result = {
+            "layout": {
+                "bloks_payload": {
+                    "action": f"BK.action({dumps('ignored')}, {dumps(dumps(login_payload))})",
+                }
+            }
+        }
+
+        parsed = client.bloks_extract_login_response(result)
+
+        self.assertEqual(parsed["login_response"]["logged_in_user"]["username"], "example")
+        self.assertEqual(parsed["headers"]["IG-Set-Authorization"], "Bearer IGT:2:encoded")
+        self.assertEqual(parsed["cookies"]["sessionid"], "123%3Aabc")
+        self.assertEqual(parsed["raw_cookies"], login_payload["cookies"])
+        self.assertEqual(parsed["raw"]["exact_profile_identified"], "1")
+
+    def test_bloks_apply_login_response_updates_client_session(self):
+        client = self.build_client()
+        authorization_data = {
+            "ds_user_id": "123",
+            "sessionid": "123%3Aabc",
+            "should_use_header_over_cookies": True,
+        }
+        authorization = "Bearer IGT:2:" + base64.b64encode(dumps(authorization_data).encode()).decode()
+
+        result = client.bloks_apply_login_response(
+            {
+                "headers": {
+                    "IG-Set-Authorization": authorization,
+                    "ig-set-ig-u-rur": "RUR,123,1:token",
+                    "x-ig-set-www-claim": "hmac.claim",
+                },
+                "cookies": {
+                    "csrftoken": "token-1",
+                    "ds_user_id": "123",
+                    "sessionid": "123%3Aabc",
+                },
+            }
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(client.authorization_data, authorization_data)
+        self.assertEqual(client.private.cookies.get("csrftoken"), "token-1")
+        self.assertEqual(client.private.cookies.get("ds_user_id"), "123")
+        self.assertEqual(client.private.cookies.get("sessionid"), "123%3Aabc")
+        self.assertEqual(client.public.cookies.get("sessionid"), "123%3Aabc")
+        self.assertEqual(client.private.headers["Authorization"], client.authorization)
+        self.assertEqual(client.ig_u_rur, "RUR,123,1:token")
+        self.assertEqual(client.ig_www_claim, "hmac.claim")


### PR DESCRIPTION
## Summary
- add unsigned `bloks/apps/...` helper alongside existing async-action helper
- add low-level Bloks two-step verification helpers for entrypoint, method picker, method selection, code verification, and TOTP code entry
- add parsing/application helpers for embedded Bloks login payloads
- document the newer Bloks 2FA helper flow in TOTP docs and README/index

## Notes
This does not wire full CAA login into `Client.login()` yet. The new helpers require a `two_step_verification_context` from Instagram's login challenge response and expose the verified request shapes as a safer low-level surface.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_bloks.py tests/regression/test_auth_story.py -q`
- `.venv/bin/python -m ruff check instagrapi tests/regression/test_bloks.py tests/regression/test_auth_story.py`
- `.venv/bin/python -m ruff format --check instagrapi tests/regression/test_bloks.py tests/regression/test_auth_story.py`
- `.venv/bin/python -m mkdocs build --strict`

Refs #2219