### PR TITLE
Add Bloks 2FA login fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cl.delete_note(note.id)
 ## Features
 
 * Uses [Web API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) and [Mobile API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) flows where available
-* Supports login by password, 2FA, `sessionid`, and low-level [Bloks 2FA](https://subzeroid.github.io/instagrapi/usage-guide/totp.html#bloks-two-factor-flow) helpers for newer verification flows
+* Supports login by password, 2FA, `sessionid`, and [Bloks 2FA](https://subzeroid.github.io/instagrapi/usage-guide/totp.html#bloks-two-factor-flow) fallback/helpers for newer verification flows
 * Includes email/SMS-based [challenge resolver](https://subzeroid.github.io/instagrapi/usage-guide/challenge_resolver.html) hooks
 * Uploads and downloads photos, videos, albums, IGTV, reels, and stories
 * Works with users, media, comments, locations, hashtags, collections, notes, direct messages, and insights

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Support chat in Telegram: [aiograpi_support](https://t.me/aiograpi_support)
 ## Features
 
 1. Uses [Public API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) (web, opportunistic) and [Private API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) (mobile app, authorized) flows depending on the situation
-2. [Login](https://subzeroid.github.io/instagrapi/usage-guide/interactions.html) by username and password, including 2FA, low-level [Bloks 2FA](usage-guide/totp.md#bloks-two-factor-flow) helpers, and by sessionid
+2. [Login](https://subzeroid.github.io/instagrapi/usage-guide/interactions.html) by username and password, including 2FA, [Bloks 2FA](usage-guide/totp.md#bloks-two-factor-flow) fallback/helpers, and by sessionid
 3. [Challenge Resolver](https://subzeroid.github.io/instagrapi/usage-guide/challenge_resolver.html) have Email and SMS handlers
 4. Support [upload](https://subzeroid.github.io/instagrapi/usage-guide/media.html) a Photo, Video, IGTV, Reels, Albums and Stories
 5. Support work with [User](https://subzeroid.github.io/instagrapi/usage-guide/user.html), [Media](https://subzeroid.github.io/instagrapi/usage-guide/media.html), [Comment](https://subzeroid.github.io/instagrapi/usage-guide/comment.html), [Insights](https://subzeroid.github.io/instagrapi/usage-guide/insight.html), [Collections](https://subzeroid.github.io/instagrapi/usage-guide/collection.html), [Location](https://subzeroid.github.io/instagrapi/usage-guide/location.html) (Place), [Hashtag](https://subzeroid.github.io/instagrapi/usage-guide/hashtag.html) and [Direct Message](https://subzeroid.github.io/instagrapi/usage-guide/direct.html) objects
@@ -115,7 +115,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`Resource`](usage-guide/media.md) - Part of Media (for albums)
   * [`MediaOembed`](usage-guide/media.md) - Short version of Media
   * [`Account`](usage-guide/account.md) - Full private info for your account (e.g. email, phone_number)
-  * [`TOTP`](usage-guide/totp.md) - 2FA TOTP helpers, code generation, and low-level Bloks verification helpers
+  * [`TOTP`](usage-guide/totp.md) - 2FA TOTP helpers, code generation, and Bloks verification fallback/helpers
   * [`User`](usage-guide/user.md) - Full public user data
   * [`UserShort`](usage-guide/user.md) - Short public user data (used in Usertag, Comment, Media, Direct Message)
   * [`Usertag`](usage-guide/user.md) - Tag user in Media (coordinates + UserShort)

--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -40,7 +40,9 @@ Notes:
 
 Some accounts are moved by Instagram to a newer CAA/Bloks two-factor flow. In that case the legacy `accounts/two_factor_login/` endpoint can reject a valid code with `Invalid Parameters`.
 
-`Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram requires the newer flow, use the low-level Bloks helpers with the `two_step_verification_context` returned by the login challenge response:
+`Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, instagrapi automatically retries through the Bloks two-factor flow. When the context is not present, the exception explains that the account still needs manual app verification or a fresh current-app login response.
+
+The low-level helpers remain available when you need to inspect or drive the flow manually:
 
 ``` python
 from instagrapi import Client
@@ -69,4 +71,4 @@ result = cl.bloks_two_step_verification_verify_code(context, "123456", challenge
 
 `bloks_extract_login_response(...)` returns decoded `login_response`, response `headers`, cookie values, raw cookie header text, and the raw embedded object when Instagram returns a successful Bloks login payload. It returns `{}` when the response is an intermediate UI state or an error. `bloks_apply_login_response(...)` can then copy the returned authorization data and cookies into the current client session.
 
-This is intentionally low-level. The full CAA login flow that produces `two_step_verification_context` is not wired into `Client.login()` yet, because it depends on newer login response state and account-specific verification behavior.
+Automatic fallback can only run after Instagram exposes `two_step_verification_context` to the client. A `BadPassword` response with a known-good password can still be account-risk handling before Instagram exposes that context, so treat it as a signal to inspect proxy/IP, device consistency, and the raw login response.

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 from instagrapi import config
 from instagrapi.exceptions import (
     BadCredentials,
+    BadPassword,
     ClientThrottledError,
     PleaseWaitFewMinutes,
     PrivateError,
@@ -486,6 +487,77 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         if clear_public_cookies:
             self.public.cookies.clear()
 
+    def _find_login_response_value(self, data: Any, key: str) -> Any:
+        if isinstance(data, dict):
+            value = data.get(key)
+            if value:
+                return value
+            for child in data.values():
+                value = self._find_login_response_value(child, key)
+                if value:
+                    return value
+        elif isinstance(data, list):
+            for child in data:
+                value = self._find_login_response_value(child, key)
+                if value:
+                    return value
+        return None
+
+    def _extract_two_step_verification_context(self, data: Dict) -> str:
+        value = self._find_login_response_value(data, "two_step_verification_context")
+        return value.strip() if isinstance(value, str) else ""
+
+    def _login_response_bool(self, data: Dict, key: str) -> bool:
+        value = self._find_login_response_value(data, key)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int):
+            return bool(value)
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes"}
+        return False
+
+    def _infer_bloks_two_factor_challenge(self, data: Dict) -> str:
+        sms_enabled = self._login_response_bool(data, "sms_two_factor_on")
+        totp_enabled = self._login_response_bool(data, "totp_two_factor_on")
+        if sms_enabled and not totp_enabled:
+            return "sms"
+        return "totp"
+
+    def _login_with_bloks_two_factor(self, verification_code: str, login_json: Dict, exc: Exception) -> bool:
+        context = self._extract_two_step_verification_context(login_json)
+        if not context:
+            raise TwoFactorRequired(
+                "Instagram rejected the legacy two-factor login endpoint and "
+                "may require a newer Bloks-based two-factor verification flow, "
+                "but the response did not include two_step_verification_context "
+                "required for the Bloks two-factor fallback. Complete "
+                "verification in the Instagram app or capture a fresh login "
+                "response with the current app flow.",
+                response=getattr(exc, "response", None),
+                **login_json,
+            ) from exc
+
+        challenge = self._infer_bloks_two_factor_challenge(login_json)
+        self.bloks_two_step_verification_entrypoint(context)
+        self.bloks_two_step_verification_method_picker(context)
+        self.bloks_two_step_verification_select_method(context, selected_method=challenge)
+        result = self.bloks_two_step_verification_verify_code(
+            context,
+            verification_code,
+            challenge=challenge,
+        )
+        if self.bloks_apply_login_response(result):
+            return True
+        raise TwoFactorRequired(
+            "Instagram accepted the Bloks two-factor verification request, but "
+            "the response did not include an embedded login payload. Inspect "
+            "the raw Bloks response and retry with the selected verification "
+            "method required by the account.",
+            response=getattr(exc, "response", None),
+            **login_json,
+        ) from exc
+
     def init(self) -> bool:
         """
         Initialize Login helpers
@@ -652,9 +724,21 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         try:
             logged = self.private_request("accounts/login/", data, login=True)
             self.authorization_data = self.parse_authorization(self.last_response.headers.get("ig-set-authorization"))
+        except BadPassword as exc:
+            login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
+            if not self._extract_two_step_verification_context(login_json):
+                raise
+            if not verification_code.strip():
+                raise TwoFactorRequired(
+                    f"{exc} (Instagram returned a Bloks two-factor context; provide verification_code for login)",
+                    response=getattr(exc, "response", None),
+                    **login_json,
+                ) from exc
+            logged = self._login_with_bloks_two_factor(verification_code, login_json, exc)
         except TwoFactorRequired as e:
             if not verification_code.strip():
                 raise TwoFactorRequired(f"{e} (you did not provide verification_code for login method)")
+            two_factor_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
             two_factor_identifier = self.last_json.get("two_factor_info", {}).get("two_factor_identifier")
             data = {
                 "verification_code": verification_code,
@@ -673,17 +757,13 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             except UnknownError as exc:
                 message = getattr(exc, "message", "") or ""
                 if message.strip().lower() == "invalid parameters":
-                    raise TwoFactorRequired(
-                        "Instagram rejected accounts/two_factor_login/ with "
-                        "'Invalid Parameters'. This account may require a newer "
-                        "Bloks-based two-factor verification flow that is not "
-                        "supported automatically yet. Complete verification in the "
-                        "Instagram app or refresh the session manually, then retry.",
-                        response=getattr(exc, "response", None),
-                        **(self.last_json if isinstance(self.last_json, dict) else {}),
-                    ) from exc
-                raise
-            self.authorization_data = self.parse_authorization(self.last_response.headers.get("ig-set-authorization"))
+                    logged = self._login_with_bloks_two_factor(verification_code, two_factor_json, exc)
+                else:
+                    raise
+            else:
+                self.authorization_data = self.parse_authorization(
+                    self.last_response.headers.get("ig-set-authorization")
+                )
         if logged:
             self.login_flow()
             self.last_login = time.time()

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import BadPassword
 from tests.helpers import *
 
 
@@ -165,6 +166,110 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
 
         self.assertIn("Bloks-based two-factor verification flow", str(cm.exception))
         self.assertEqual(client.private_request.call_count, 2)
+
+    def test_login_two_factor_invalid_parameters_falls_back_to_bloks_when_context_available(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.uuid = "uuid-1"
+        client.phone_id = "phone-1"
+        client.android_device_id = "android-1"
+        client._token = "csrftoken"
+        client.last_json = {
+            "two_factor_info": {
+                "two_factor_identifier": "two-factor-id",
+                "two_step_verification_context": "context-1",
+                "totp_two_factor_on": True,
+                "sms_two_factor_on": False,
+            }
+        }
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.login_flow = Mock()
+        client.private_request = Mock(
+            side_effect=[
+                TwoFactorRequired("Two-factor authentication required"),
+                UnknownError("Invalid Parameters", response=Mock(status_code=400)),
+            ]
+        )
+        client.bloks_two_step_verification_entrypoint = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_method_picker = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_select_method = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
+        client.bloks_apply_login_response = Mock(return_value=True)
+
+        result = client.login(verification_code="123456")
+
+        self.assertTrue(result)
+        self.assertEqual(client.private_request.call_count, 2)
+        client.bloks_two_step_verification_entrypoint.assert_called_once_with("context-1")
+        client.bloks_two_step_verification_method_picker.assert_called_once_with("context-1")
+        client.bloks_two_step_verification_select_method.assert_called_once_with("context-1", selected_method="totp")
+        client.bloks_two_step_verification_verify_code.assert_called_once_with(
+            "context-1",
+            "123456",
+            challenge="totp",
+        )
+        client.bloks_apply_login_response.assert_called_once_with({"layout": {}})
+        client.login_flow.assert_called_once_with()
+
+    def test_login_two_factor_invalid_parameters_without_context_keeps_clear_error(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.uuid = "uuid-1"
+        client.phone_id = "phone-1"
+        client.android_device_id = "android-1"
+        client._token = "csrftoken"
+        client.last_json = {"two_factor_info": {"two_factor_identifier": "two-factor-id"}}
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.private_request = Mock(
+            side_effect=[
+                TwoFactorRequired("Two-factor authentication required"),
+                UnknownError("Invalid Parameters", response=Mock(status_code=400)),
+            ]
+        )
+        client.bloks_two_step_verification_verify_code = Mock()
+
+        with self.assertRaises(TwoFactorRequired) as cm:
+            client.login(verification_code="123456")
+
+        self.assertIn("two_step_verification_context", str(cm.exception))
+        client.bloks_two_step_verification_verify_code.assert_not_called()
+
+    def test_login_bad_password_with_bloks_context_and_code_falls_back_to_bloks(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {
+            "two_step_verification_context": "context-1",
+            "sms_two_factor_on": True,
+            "totp_two_factor_on": False,
+        }
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.login_flow = Mock()
+        client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        client.bloks_two_step_verification_entrypoint = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_method_picker = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_select_method = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
+        client.bloks_apply_login_response = Mock(return_value=True)
+
+        result = client.login(verification_code="654321")
+
+        self.assertTrue(result)
+        client.bloks_two_step_verification_select_method.assert_called_once_with("context-1", selected_method="sms")
+        client.bloks_two_step_verification_verify_code.assert_called_once_with(
+            "context-1",
+            "654321",
+            challenge="sms",
+        )
+        client.login_flow.assert_called_once_with()
 
     def test_login_by_sessionid_falls_back_to_user_short_gql(self):
         client = Client()


### PR DESCRIPTION
## Summary
- add an automatic Bloks two-factor fallback inside `Client.login(..., verification_code=...)` when Instagram returns `two_step_verification_context`
- preserve the legacy `accounts/two_factor_login/` path as the first attempt and keep a clear error when the context is missing
- document the new automatic fallback plus the remaining low-level helper path

Closes #2219.

## Testing
- `.venv/bin/python -m pytest tests/regression/test_auth_story.py tests/regression/test_bloks.py -q`
- `.venv/bin/python -m pytest tests/regression/test_auth_story.py tests/regression/test_bloks.py tests/regression/test_challenge.py tests/regression/test_signup.py tests/regression/test_hardening.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/mkdocs build --strict`