### PR TITLE
Add CAA Bloks login fallback

### DIFF
--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -40,7 +40,7 @@ Notes:
 
 Some accounts are moved by Instagram to a newer CAA/Bloks two-factor flow. In that case the legacy `accounts/two_factor_login/` endpoint can reject a valid code with `Invalid Parameters`.
 
-`Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, instagrapi automatically retries through the Bloks two-factor flow. When the context is not present, the exception explains that the account still needs manual app verification or a fresh current-app login response.
+`Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, instagrapi automatically retries through the Bloks two-factor flow. If the legacy login response does not expose that context, instagrapi can make a current CAA/Bloks login request to recover the context and continue the same Bloks verification path. When Instagram still does not return enough state, the exception explains that the account needs manual app verification or a fresh current-app login response.
 
 The low-level helpers remain available when you need to inspect or drive the flow manually:
 
@@ -69,6 +69,8 @@ cl.bloks_two_step_verification_select_method(context, selected_method="sms")
 result = cl.bloks_two_step_verification_verify_code(context, "123456", challenge="sms")
 ```
 
+`bloks_caa_login_send_request(...)` is also available as a low-level helper for inspecting the CAA/Bloks login response manually. `bloks_extract_two_step_verification_context(...)` extracts the context from that response when Instagram returns the current Bloks redirect action.
+
 `bloks_extract_login_response(...)` returns decoded `login_response`, response `headers`, cookie values, raw cookie header text, and the raw embedded object when Instagram returns a successful Bloks login payload. It returns `{}` when the response is an intermediate UI state or an error. `bloks_apply_login_response(...)` can then copy the returned authorization data and cookies into the current client session.
 
-Automatic fallback can only run after Instagram exposes `two_step_verification_context` to the client. A `BadPassword` response with a known-good password can still be account-risk handling before Instagram exposes that context, so treat it as a signal to inspect proxy/IP, device consistency, and the raw login response.
+Automatic fallback can only run after Instagram exposes `two_step_verification_context` to the client or to the CAA/Bloks login response. A `BadPassword` response with a known-good password can still be account-risk handling before Instagram exposes that context, so treat it as a signal to inspect proxy/IP, device consistency, and the raw login response.

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -507,6 +507,13 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         value = self._find_login_response_value(data, "two_step_verification_context")
         return value.strip() if isinstance(value, str) else ""
 
+    def _exception_context(self, data: Dict) -> Dict:
+        context = deepcopy(data)
+        message = context.pop("message", None)
+        if message is not None:
+            context["instagram_message"] = message
+        return context
+
     def _login_response_bool(self, data: Dict, key: str) -> bool:
         value = self._find_login_response_value(data, key)
         if isinstance(value, bool):
@@ -535,7 +542,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 "verification in the Instagram app or capture a fresh login "
                 "response with the current app flow.",
                 response=getattr(exc, "response", None),
-                **login_json,
+                **self._exception_context(login_json),
             ) from exc
 
         challenge = self._infer_bloks_two_factor_challenge(login_json)
@@ -555,8 +562,25 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "the raw Bloks response and retry with the selected verification "
             "method required by the account.",
             response=getattr(exc, "response", None),
-            **login_json,
+            **self._exception_context(login_json),
         ) from exc
+
+    def _login_with_caa_bloks_two_factor(self, verification_code: str, password: str, exc: Exception) -> bool:
+        caa_result = self.bloks_caa_login_send_request(password, login_attempt_count=1)
+        context = self.bloks_extract_two_step_verification_context(caa_result)
+        login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
+        if not context:
+            raise TwoFactorRequired(
+                "Instagram rejected the legacy login endpoint and may require "
+                "a newer CAA/Bloks login flow, but the CAA response did not "
+                "include two_step_verification_context required for automatic "
+                "Bloks two-factor verification. Complete verification in the "
+                "Instagram app or inspect the current login response.",
+                response=getattr(exc, "response", None),
+                **self._exception_context(login_json),
+            ) from exc
+        login_json["two_step_verification_context"] = context
+        return self._login_with_bloks_two_factor(verification_code, login_json, exc)
 
     def init(self) -> bool:
         """
@@ -726,15 +750,19 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             self.authorization_data = self.parse_authorization(self.last_response.headers.get("ig-set-authorization"))
         except BadPassword as exc:
             login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
-            if not self._extract_two_step_verification_context(login_json):
+            context = self._extract_two_step_verification_context(login_json)
+            if not context and not verification_code.strip():
                 raise
             if not verification_code.strip():
                 raise TwoFactorRequired(
                     f"{exc} (Instagram returned a Bloks two-factor context; provide verification_code for login)",
                     response=getattr(exc, "response", None),
-                    **login_json,
+                    **self._exception_context(login_json),
                 ) from exc
-            logged = self._login_with_bloks_two_factor(verification_code, login_json, exc)
+            if context:
+                logged = self._login_with_bloks_two_factor(verification_code, login_json, exc)
+            else:
+                logged = self._login_with_caa_bloks_two_factor(verification_code, self.password, exc)
         except TwoFactorRequired as e:
             if not verification_code.strip():
                 raise TwoFactorRequired(f"{e} (you did not provide verification_code for login method)")

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -1,7 +1,10 @@
 import json
+import re
+import time
 from http.cookies import SimpleCookie
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 from instagrapi.utils.serialization import dumps
 
@@ -307,6 +310,187 @@ class BloksMixin:
             params,
             bloks_versioning_id=bloks_versioning_id,
         )
+
+    def bloks_caa_login_send_request(
+        self,
+        password: str,
+        username: str = "",
+        login_attempt_count: int = 1,
+        try_num: int = 1,
+        waterfall_id: str = "",
+        offline_experiment_group: str = "caa_iteration_v3_perf_ig_4",
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Send the current CAA/Bloks login request used before Bloks 2FA.
+
+        This low-level helper is intentionally conservative: it uses ordinary
+        device/session identifiers already available on the client and leaves
+        attestation-like fields empty instead of inventing fake values.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        contact_point = username or self.username
+        encrypted_password = password if password.startswith("#PWD_") else self.password_encrypt(password)
+        flow_id = waterfall_id or str(uuid4())
+        text_input_id = flow_id[:8]
+        params = {
+            "client_input_params": {
+                "blocked_uids": [],
+                "aac": dumps(
+                    {
+                        "aac_init_timestamp": int(time.time()),
+                        "aaccs": "",
+                        "aacjid": str(uuid4()),
+                    }
+                ),
+                "sim_phones": [],
+                "aymh_accounts": [],
+                "network_bssid": None,
+                "secure_family_device_id": "",
+                "has_granted_read_contacts_permissions": 0,
+                "auth_secure_device_id": "",
+                "has_whatsapp_installed": 0,
+                "password": encrypted_password,
+                "sso_token_map_json_string": "",
+                "block_store_machine_id": "",
+                "ig_vetted_device_nonces": None,
+                "cloud_trust_token": None,
+                "event_flow": "login_manual",
+                "password_contains_non_ascii": str(not password.isascii()).lower(),
+                "client_known_key_hash": "",
+                "sso_accounts_auth_data": [],
+                "encrypted_msisdn": "",
+                "has_granted_read_phone_permissions": 0,
+                "app_manager_id": "",
+                "should_show_nested_nta_from_aymh": 0,
+                "device_id": self.android_device_id,
+                "zero_balance_state": "",
+                "login_attempt_count": login_attempt_count,
+                "machine_id": self.mid,
+                "flash_call_permission_status": {
+                    "READ_PHONE_STATE": "DENIED",
+                    "READ_CALL_LOG": "DENIED",
+                    "ANSWER_PHONE_CALLS": "DENIED",
+                },
+                "accounts_list": [],
+                "gms_incoming_call_retriever_eligibility": "not_eligible",
+                "family_device_id": self.phone_id,
+                "fb_ig_device_id": [],
+                "device_emails": [],
+                "try_num": try_num,
+                "lois_settings": {"lois_token": ""},
+                "event_step": "home_page",
+                "headers_infra_flow_id": "",
+                "openid_tokens": {},
+                "contact_point": contact_point,
+            },
+            "server_params": {
+                "should_trigger_override_login_2fa_action": 0,
+                "is_from_logged_out": 0,
+                "should_trigger_override_login_success_action": 0,
+                "login_credential_type": "none",
+                "server_login_source": "login",
+                "waterfall_id": flow_id,
+                "two_step_login_type": "one_step_login",
+                "login_source": "Login",
+                "is_platform_login": 0,
+                "login_entry_point": "logged_out",
+                "INTERNAL__latency_qpl_marker_id": 36707139,
+                "is_from_aymh": 0,
+                "offline_experiment_group": offline_experiment_group,
+                "is_from_landing_page": 0,
+                "left_nav_button_action": "NONE",
+                "password_text_input_id": f"{text_input_id}:105",
+                "is_from_empty_password": 0,
+                "is_from_msplit_fallback": 0,
+                "ar_event_source": "login_home_page",
+                "qe_device_id": self.uuid,
+                "username_text_input_id": f"{text_input_id}:104",
+                "layered_homepage_experiment_group": "Deploy: Not in Experiment",
+                "device_id": self.android_device_id,
+                "login_surface": "login_home",
+                "INTERNAL__latency_qpl_instance_id": int(time.time() * 1000),
+                "reg_flow_source": "login_home_native_integration_point",
+                "is_caa_perf_enabled": 1,
+                "credential_type": "password",
+                "is_from_password_entry_page": 0,
+                "caller": "gslr",
+                "family_device_id": self.phone_id,
+                "is_from_assistive_id": 0,
+                "access_flow_version": "pre_mt_behavior",
+                "is_from_logged_in_switcher": 0,
+            },
+        }
+        return self.bloks_async_action(
+            "com.bloks.www.bloks.caa.login.async.send_login_request",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
+
+    def _find_bloks_value(self, data: Any, key: str) -> Any:
+        if isinstance(data, dict):
+            value = data.get(key)
+            if value:
+                return value
+            for child in data.values():
+                value = self._find_bloks_value(child, key)
+                if value:
+                    return value
+        elif isinstance(data, list):
+            for child in data:
+                value = self._find_bloks_value(child, key)
+                if value:
+                    return value
+        elif isinstance(data, str) and len(data) < 10000 and key in data:
+            try:
+                value = self._find_bloks_value(json.loads(data), key)
+            except (TypeError, ValueError):
+                value = None
+            if value:
+                return value
+        return None
+
+    @staticmethod
+    def _extract_first_json_string(value: str, start: int) -> str:
+        quote_index = value.find('"', start)
+        if quote_index < 0:
+            return ""
+        try:
+            decoded, _ = json.JSONDecoder().raw_decode(value[quote_index:])
+        except JSONDecodeError:
+            return ""
+        return decoded if isinstance(decoded, str) else ""
+
+    def bloks_extract_two_step_verification_context(self, result: Dict) -> str:
+        """
+        Extract ``two_step_verification_context`` from a CAA/Bloks login result.
+
+        Current app responses can place this context inside the Bloks action
+        program that redirects to ``two_step_verification.entrypoint``. This
+        helper first checks normal JSON containers, then parses that action
+        parameter map without logging or returning any other sensitive fields.
+        """
+        value = self._find_bloks_value(result, "two_step_verification_context")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        action = result.get("layout", {}).get("bloks_payload", {}).get("action", "")
+        if not isinstance(action, str) or "two_step_verification.entrypoint" not in action:
+            return ""
+        marker = '"two_step_verification_context"'
+        marker_index = action.find(marker)
+        if marker_index < 0:
+            return ""
+        key_list_end = action.find(")", marker_index)
+        if key_list_end < 0:
+            return ""
+        value_group = re.search(r"\(dkc\s+", action[key_list_end:])
+        if not value_group:
+            return ""
+        return self._extract_first_json_string(action, key_list_end + value_group.start()).strip()
 
     def bloks_extract_login_response(self, result: Dict) -> Dict[str, Any]:
         """

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -355,10 +355,10 @@ class BloksMixin:
                 "auth_secure_device_id": "",
                 "has_whatsapp_installed": 0,
                 "password": encrypted_password,
-                "sso_token_map_json_string": "",
+                "sso_token_map_json_string": "",  # nosec B105
                 "block_store_machine_id": "",
                 "ig_vetted_device_nonces": None,
-                "cloud_trust_token": None,
+                "cloud_trust_token": None,  # nosec B105
                 "event_flow": "login_manual",
                 "password_contains_non_ascii": str(not password.isascii()).lower(),
                 "client_known_key_hash": "",
@@ -382,7 +382,7 @@ class BloksMixin:
                 "fb_ig_device_id": [],
                 "device_emails": [],
                 "try_num": try_num,
-                "lois_settings": {"lois_token": ""},
+                "lois_settings": {"lois_token": ""},  # nosec B105
                 "event_step": "home_page",
                 "headers_infra_flow_id": "",
                 "openid_tokens": {},
@@ -405,7 +405,7 @@ class BloksMixin:
                 "is_from_landing_page": 0,
                 "left_nav_button_action": "NONE",
                 "password_text_input_id": f"{text_input_id}:105",
-                "is_from_empty_password": 0,
+                "is_from_empty_password": 0,  # nosec B105
                 "is_from_msplit_fallback": 0,
                 "ar_event_source": "login_home_page",
                 "qe_device_id": self.uuid,
@@ -417,7 +417,7 @@ class BloksMixin:
                 "reg_flow_source": "login_home_native_integration_point",
                 "is_caa_perf_enabled": 1,
                 "credential_type": "password",
-                "is_from_password_entry_page": 0,
+                "is_from_password_entry_page": 0,  # nosec B105
                 "caller": "gslr",
                 "family_device_id": self.phone_id,
                 "is_from_assistive_id": 0,

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -271,6 +271,58 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
         client.login_flow.assert_called_once_with()
 
+    def test_login_bad_password_without_context_tries_caa_bloks_context_when_code_provided(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {"message": "The password you entered is incorrect.", "error_type": "bad_password"}
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.login_flow = Mock()
+        client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        caa_result = {"layout": {"bloks_payload": {"action": "action-with-context"}}}
+        client.bloks_caa_login_send_request = Mock(return_value=caa_result)
+        client.bloks_extract_two_step_verification_context = Mock(return_value="context-1")
+        client.bloks_two_step_verification_entrypoint = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_method_picker = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_select_method = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
+        client.bloks_apply_login_response = Mock(return_value=True)
+
+        result = client.login(verification_code="654321")
+
+        self.assertTrue(result)
+        client.bloks_caa_login_send_request.assert_called_once_with("password", login_attempt_count=1)
+        client.bloks_extract_two_step_verification_context.assert_called_once_with(caa_result)
+        client.bloks_two_step_verification_select_method.assert_called_once_with("context-1", selected_method="totp")
+        client.bloks_two_step_verification_verify_code.assert_called_once_with(
+            "context-1",
+            "654321",
+            challenge="totp",
+        )
+        client.login_flow.assert_called_once_with()
+
+    def test_login_bad_password_without_context_raises_clear_error_when_caa_has_no_context(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {"message": "The password you entered is incorrect.", "error_type": "bad_password"}
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        client.bloks_caa_login_send_request = Mock(return_value={"layout": {"bloks_payload": {"action": ""}}})
+        client.bloks_extract_two_step_verification_context = Mock(return_value="")
+        client.bloks_two_step_verification_verify_code = Mock()
+
+        with self.assertRaises(TwoFactorRequired) as cm:
+            client.login(verification_code="654321")
+
+        self.assertIn("CAA response did not include two_step_verification_context", str(cm.exception))
+        client.bloks_caa_login_send_request.assert_called_once_with("password", login_attempt_count=1)
+        client.bloks_two_step_verification_verify_code.assert_not_called()
+
     def test_login_by_sessionid_falls_back_to_user_short_gql(self):
         client = Client()
         sessionid = "1234567890123456789012345678901%3Atoken"

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -208,6 +208,56 @@ class BloksRegressionTestCase(unittest.TestCase):
             bloks_versioning_id="",
         )
 
+    def test_bloks_caa_login_send_request_uses_current_payload(self):
+        client = self.build_client()
+        client.username = "example"
+        client.android_device_id = "android-1"
+        client.phone_id = "family-device-1"
+        client.uuid = "uuid-1"
+        client.mid = "machine-1"
+        client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "bloks_async_action", return_value=expected) as bloks_async_action:
+            result = client.bloks_caa_login_send_request("password", login_attempt_count=1)
+
+        self.assertEqual(result, expected)
+        bloks_async_action.assert_called_once()
+        action, params = bloks_async_action.call_args.args[:2]
+        self.assertEqual(action, "com.bloks.www.bloks.caa.login.async.send_login_request")
+        self.assertEqual(params["client_input_params"]["contact_point"], "example")
+        self.assertEqual(params["client_input_params"]["password"], "#PWD_INSTAGRAM:4:1:encrypted")
+        self.assertEqual(params["client_input_params"]["device_id"], "android-1")
+        self.assertEqual(params["client_input_params"]["family_device_id"], "family-device-1")
+        self.assertEqual(params["client_input_params"]["machine_id"], "machine-1")
+        self.assertEqual(params["client_input_params"]["login_attempt_count"], 1)
+        self.assertEqual(params["client_input_params"]["try_num"], 1)
+        self.assertEqual(params["server_params"]["login_credential_type"], "none")
+        self.assertEqual(params["server_params"]["credential_type"], "password")
+        self.assertEqual(params["server_params"]["family_device_id"], "family-device-1")
+        self.assertEqual(params["server_params"]["device_id"], "android-1")
+        self.assertIn("waterfall_id", params["server_params"])
+
+    def test_bloks_extract_two_step_verification_context_from_caa_action(self):
+        client = self.build_client()
+        result = {
+            "layout": {
+                "bloks_payload": {
+                    "action": (
+                        '(... "com.bloks.www.two_step_verification.entrypoint" '
+                        '(dkc "server_params" "client_input_params") '
+                        '(dkc (f4i (dkc "two_step_verification_context" "flow_source" '
+                        '"device_id" "should_fallback_to_sms" "family_device_id" '
+                        '"INTERNAL_INFRA_screen_id") '
+                        '(dkc "context-1" "two_factor_login" "android-1" 0 '
+                        '"family-device-1" "screen-1"))))'
+                    )
+                }
+            }
+        }
+
+        self.assertEqual(client.bloks_extract_two_step_verification_context(result), "context-1")
+
     def test_bloks_extract_login_response_parses_embedded_action_payload(self):
         client = self.build_client()
         login_payload = {


### PR DESCRIPTION
## Summary
- add a CAA/Bloks login request helper for modern login flows that need a Bloks two-step context
- extract `two_step_verification_context` from current Bloks redirect actions
- make `Client.login(..., verification_code=...)` fall back through CAA when legacy login returns `BadPassword` without a context
- document the updated automatic and low-level Bloks 2FA behavior

Closes #2543.

## Tests
- `ruff check . && ruff format --check .`
- `pytest -q tests/regression/test_extractors.py::ExtractorsRegressionTestCase tests/regression/test_public.py::PublicRegressionTestCase tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase tests/regression/test_direct.py::DirectMixinRegressionTestCase tests/regression/test_challenge.py::ChallengeRegressionTestCase tests/regression/test_comments.py::CommentRepliesRegressionTestCase tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase tests/regression/test_download.py::DownloadRegressionTestCase tests/regression/test_notes.py::NoteMixinRegressionTestCase tests/regression/test_location.py::LocationMixinRegressionTestCase tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase tests/regression/test_user.py::UserMixinRegressionTestCase tests/regression/test_timeline.py::TimelineRegressionTestCase tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase tests/regression/test_upload.py::UploadRegressionTestCase tests/regression/test_bloks.py::BloksRegressionTestCase`
- `mkdocs build --strict`
