### PR TITLE
Bump version to 2.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.7.5"
+version = "2.7.6"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]


### PR DESCRIPTION
## Summary
- bump package version to 2.7.6

## Changes since 2.7.5
- CAA/Bloks login fallback can recover `two_step_verification_context` after legacy login returns `BadPassword` without that context.

## Tests
- git diff --check
- grep -E '^version[[:space:]]*=' pyproject.toml