### PR TITLE
Support backup codes in Bloks 2FA

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cl.delete_note(note.id)
 ## Features
 
 * Uses [Web API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) and [Mobile API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) flows where available
-* Supports login by password, 2FA, `sessionid`, and [Bloks 2FA](https://subzeroid.github.io/instagrapi/usage-guide/totp.html#bloks-two-factor-flow) fallback/helpers for newer verification flows
+* Supports login by password, 2FA, 8-digit backup codes, `sessionid`, and [Bloks 2FA](https://subzeroid.github.io/instagrapi/usage-guide/totp.html#bloks-two-factor-flow) fallback/helpers for newer verification flows
 * Includes email/SMS-based [challenge resolver](https://subzeroid.github.io/instagrapi/usage-guide/challenge_resolver.html) hooks
 * Uploads and downloads photos, videos, albums, IGTV, reels, and stories
 * Works with users, media, comments, locations, hashtags, collections, notes, direct messages, and insights

--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -42,6 +42,14 @@ Some accounts are moved by Instagram to a newer CAA/Bloks two-factor flow. In th
 
 `Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, instagrapi automatically retries through the Bloks two-factor flow. If the legacy login response does not expose that context, instagrapi can make a current CAA/Bloks login request to recover the context and continue the same Bloks verification path. When Instagram still does not return enough state, the exception explains that the account needs manual app verification or a fresh current-app login response.
 
+8-digit backup codes can be passed through the same `verification_code` parameter:
+
+``` python
+cl.login(USERNAME, PASSWORD, verification_code="12345678")
+```
+
+When the code is 8 digits and Instagram exposes `two_step_verification_context`, instagrapi selects the Bloks `backup_codes` challenge instead of sending the code to the legacy TOTP/SMS endpoint.
+
 The low-level helpers remain available when you need to inspect or drive the flow manually:
 
 ``` python
@@ -67,6 +75,14 @@ For SMS, select and verify the `sms` challenge instead:
 ``` python
 cl.bloks_two_step_verification_select_method(context, selected_method="sms")
 result = cl.bloks_two_step_verification_verify_code(context, "123456", challenge="sms")
+```
+
+For backup codes, select `backup_codes`, open the backup-code entry screen, then verify the 8-digit code:
+
+``` python
+cl.bloks_two_step_verification_select_method(context, selected_method="backup_codes")
+cl.bloks_two_step_verification_enter_backup_code(context)
+result = cl.bloks_two_step_verification_verify_code(context, "12345678", challenge="backup_codes")
 ```
 
 `bloks_caa_login_send_request(...)` is also available as a low-level helper for inspecting the CAA/Bloks login response manually. `bloks_extract_two_step_verification_context(...)` extracts the context from that response when Instagram returns the current Bloks redirect action.

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -524,7 +524,15 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             return value.strip().lower() in {"1", "true", "yes"}
         return False
 
-    def _infer_bloks_two_factor_challenge(self, data: Dict) -> str:
+    def _normalize_backup_code(self, code: str) -> str:
+        return re.sub(r"[\s-]+", "", str(code).strip())
+
+    def _looks_like_backup_code(self, code: str) -> bool:
+        return bool(re.fullmatch(r"\d{8}", self._normalize_backup_code(code)))
+
+    def _infer_bloks_two_factor_challenge(self, data: Dict, verification_code: str = "") -> str:
+        if self._looks_like_backup_code(verification_code):
+            return "backup_codes"
         sms_enabled = self._login_response_bool(data, "sms_two_factor_on")
         totp_enabled = self._login_response_bool(data, "totp_two_factor_on")
         if sms_enabled and not totp_enabled:
@@ -545,13 +553,16 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 **self._exception_context(login_json),
             ) from exc
 
-        challenge = self._infer_bloks_two_factor_challenge(login_json)
+        challenge = self._infer_bloks_two_factor_challenge(login_json, verification_code)
         self.bloks_two_step_verification_entrypoint(context)
         self.bloks_two_step_verification_method_picker(context)
         self.bloks_two_step_verification_select_method(context, selected_method=challenge)
+        if challenge == "backup_codes":
+            self.bloks_two_step_verification_enter_backup_code(context)
+        code = self._normalize_backup_code(verification_code) if challenge == "backup_codes" else verification_code
         result = self.bloks_two_step_verification_verify_code(
             context,
-            verification_code,
+            code,
             challenge=challenge,
         )
         if self.bloks_apply_login_response(result):
@@ -767,31 +778,36 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             if not verification_code.strip():
                 raise TwoFactorRequired(f"{e} (you did not provide verification_code for login method)")
             two_factor_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
-            two_factor_identifier = self.last_json.get("two_factor_info", {}).get("two_factor_identifier")
-            data = {
-                "verification_code": verification_code,
-                "phone_id": self.phone_id,
-                "_csrftoken": self.token,
-                "two_factor_identifier": two_factor_identifier,
-                "username": self.username,
-                "trust_this_device": "0",
-                "guid": self.uuid,
-                "device_id": self.android_device_id,
-                "waterfall_id": str(uuid4()),
-                "verification_method": "3",
-            }
-            try:
-                logged = self.private_request("accounts/two_factor_login/", data, login=True)
-            except UnknownError as exc:
-                message = getattr(exc, "message", "") or ""
-                if message.strip().lower() == "invalid parameters":
-                    logged = self._login_with_bloks_two_factor(verification_code, two_factor_json, exc)
-                else:
-                    raise
+            if self._looks_like_backup_code(verification_code) and self._extract_two_step_verification_context(
+                two_factor_json
+            ):
+                logged = self._login_with_bloks_two_factor(verification_code, two_factor_json, e)
             else:
-                self.authorization_data = self.parse_authorization(
-                    self.last_response.headers.get("ig-set-authorization")
-                )
+                two_factor_identifier = self.last_json.get("two_factor_info", {}).get("two_factor_identifier")
+                data = {
+                    "verification_code": verification_code,
+                    "phone_id": self.phone_id,
+                    "_csrftoken": self.token,
+                    "two_factor_identifier": two_factor_identifier,
+                    "username": self.username,
+                    "trust_this_device": "0",
+                    "guid": self.uuid,
+                    "device_id": self.android_device_id,
+                    "waterfall_id": str(uuid4()),
+                    "verification_method": "3",
+                }
+                try:
+                    logged = self.private_request("accounts/two_factor_login/", data, login=True)
+                except UnknownError as exc:
+                    message = getattr(exc, "message", "") or ""
+                    if message.strip().lower() == "invalid parameters":
+                        logged = self._login_with_bloks_two_factor(verification_code, two_factor_json, exc)
+                    else:
+                        raise
+                else:
+                    self.authorization_data = self.parse_authorization(
+                        self.last_response.headers.get("ig-set-authorization")
+                    )
         if logged:
             self.login_flow()
             self.last_login = time.time()

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -252,6 +252,35 @@ class BloksMixin:
             bloks_versioning_id=bloks_versioning_id,
         )
 
+    def bloks_two_step_verification_enter_backup_code(
+        self,
+        two_step_verification_context: str,
+        flow_source: str = "two_factor_login",
+        screen_id: Optional[str] = None,
+        bloks_versioning_id: str = "",
+    ) -> Dict:
+        """
+        Open the Bloks backup-code entry app.
+
+        Returns
+        -------
+        Dict
+            Raw Instagram response.
+        """
+        server_params = {
+            "device_id": self.android_device_id,
+            "two_step_verification_context": two_step_verification_context,
+            "flow_source": flow_source,
+        }
+        if screen_id:
+            server_params["INTERNAL_INFRA_screen_id"] = screen_id
+        params = {"server_params": server_params}
+        return self.bloks_app(
+            "com.bloks.www.two_factor_login.enter_backup_code",
+            params,
+            bloks_versioning_id=bloks_versioning_id,
+        )
+
     def bloks_two_step_verification_verify_code(
         self,
         two_step_verification_context: str,

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -214,6 +214,50 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_apply_login_response.assert_called_once_with({"layout": {}})
         client.login_flow.assert_called_once_with()
 
+    def test_login_two_factor_backup_code_with_context_uses_bloks_without_legacy_two_factor_request(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.uuid = "uuid-1"
+        client.phone_id = "phone-1"
+        client.android_device_id = "android-1"
+        client._token = "csrftoken"
+        client.last_json = {
+            "two_factor_info": {
+                "two_factor_identifier": "two-factor-id",
+                "two_step_verification_context": "context-1",
+                "totp_two_factor_on": True,
+                "sms_two_factor_on": False,
+            }
+        }
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.login_flow = Mock()
+        client.private_request = Mock(side_effect=[TwoFactorRequired("Two-factor authentication required")])
+        client.bloks_two_step_verification_entrypoint = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_method_picker = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_select_method = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_enter_backup_code = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
+        client.bloks_apply_login_response = Mock(return_value=True)
+
+        result = client.login(verification_code="1234 5678")
+
+        self.assertTrue(result)
+        self.assertEqual(client.private_request.call_count, 1)
+        client.bloks_two_step_verification_select_method.assert_called_once_with(
+            "context-1",
+            selected_method="backup_codes",
+        )
+        client.bloks_two_step_verification_enter_backup_code.assert_called_once_with("context-1")
+        client.bloks_two_step_verification_verify_code.assert_called_once_with(
+            "context-1",
+            "12345678",
+            challenge="backup_codes",
+        )
+        client.login_flow.assert_called_once_with()
+
     def test_login_two_factor_invalid_parameters_without_context_keeps_clear_error(self):
         client = Client()
         client.username = "example"
@@ -300,6 +344,42 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
             "context-1",
             "654321",
             challenge="totp",
+        )
+        client.login_flow.assert_called_once_with()
+
+    def test_login_with_eight_digit_backup_code_selects_backup_code_bloks_challenge(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {
+            "two_step_verification_context": "context-1",
+            "sms_two_factor_on": False,
+            "totp_two_factor_on": True,
+        }
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.login_flow = Mock()
+        client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        client.bloks_two_step_verification_entrypoint = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_method_picker = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_select_method = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_enter_backup_code = Mock(return_value={"status": "ok"})
+        client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
+        client.bloks_apply_login_response = Mock(return_value=True)
+
+        result = client.login(verification_code="1234 5678")
+
+        self.assertTrue(result)
+        client.bloks_two_step_verification_select_method.assert_called_once_with(
+            "context-1",
+            selected_method="backup_codes",
+        )
+        client.bloks_two_step_verification_enter_backup_code.assert_called_once_with("context-1")
+        client.bloks_two_step_verification_verify_code.assert_called_once_with(
+            "context-1",
+            "12345678",
+            challenge="backup_codes",
         )
         client.login_flow.assert_called_once_with()
 

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -208,6 +208,31 @@ class BloksRegressionTestCase(unittest.TestCase):
             bloks_versioning_id="",
         )
 
+    def test_bloks_two_step_verification_enter_backup_code_uses_current_payload(self):
+        client = self.build_client()
+        client.android_device_id = "android-1"
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "bloks_app", return_value=expected) as bloks_app:
+            result = client.bloks_two_step_verification_enter_backup_code(
+                "context-1",
+                screen_id="screen-1",
+            )
+
+        self.assertEqual(result, expected)
+        bloks_app.assert_called_once_with(
+            "com.bloks.www.two_factor_login.enter_backup_code",
+            {
+                "server_params": {
+                    "device_id": "android-1",
+                    "INTERNAL_INFRA_screen_id": "screen-1",
+                    "two_step_verification_context": "context-1",
+                    "flow_source": "two_factor_login",
+                },
+            },
+            bloks_versioning_id="",
+        )
+
     def test_bloks_caa_login_send_request_uses_current_payload(self):
         client = self.build_client()
         client.username = "example"


### PR DESCRIPTION
## Summary
- detect 8-digit Instagram backup codes and route them through the Bloks backup-code challenge
- add a low-level `bloks_two_step_verification_enter_backup_code` helper
- document backup-code login and manual Bloks backup-code flow

Closes #2035.

## Tests
- `.venv/bin/pytest tests/regression/test_auth_story.py tests/regression/test_bloks.py -q`
- `.venv/bin/ruff check instagrapi/mixins/auth.py instagrapi/mixins/bloks.py tests/regression/test_auth_story.py tests/regression/test_bloks.py`