### PR TITLE
Bump version to 2.7.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.7.6"
+version = "2.7.7"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]


### PR DESCRIPTION
## Summary
- bump package version to 2.7.7 for the backup-code 2FA release

## Tests
- `.venv/bin/pytest tests/regression/test_auth_story.py tests/regression/test_bloks.py -q`
- `.venv/bin/ruff check pyproject.toml instagrapi/mixins/auth.py instagrapi/mixins/bloks.py tests/regression/test_auth_story.py tests/regression/test_bloks.py`