### PR TITLE
Add email confirmation code helper

### DIFF
--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -15,6 +15,8 @@ Viewing and managing your profile
 | remove_bio_links(link_ids: List[int]) | dict | Remove one or more bio links by link ID |
 | reset_password(username: str) | dict | Trigger Instagram account recovery flow |
 | change_password(old_password: str, new_password: str) | bool | Change account password |
+| send_confirm_email(email: str) | dict | Send a confirmation code to a new email address |
+| confirm_email(email: str, code: str) | dict | Confirm a new email address with the received code |
 
 Example:
 
@@ -60,6 +62,9 @@ UserShort(pk=1903424587, username='example', ...)
     'error_type': 'email_unchanged',
     'status': 'ok'
 }
+
+>>> cl.confirm_email("addr@example.com", "123456")
+{'status': 'ok'}
 
 >>> cl.send_confirm_phone_number("+5599999999")
 {

--- a/instagrapi/mixins/account.py
+++ b/instagrapi/mixins/account.py
@@ -300,6 +300,26 @@ class AccountMixin:
             self.with_extra_data({"send_source": "personal_information", "email": email}),
         )
 
+    def confirm_email(self, email: str, code: str) -> dict:
+        """
+        Confirm new email address by code
+
+        Parameters
+        ----------
+        email: str
+            Email address
+        code: str
+            Confirmation code
+
+        Returns
+        -------
+        dict
+        """
+        return self.private_request(
+            "accounts/verify_email_code/",
+            self.with_extra_data({"email": email, "code": code}),
+        )
+
     def send_confirm_phone_number(self, phone_number: str) -> dict:
         """
         Send confirmation code to new phone number

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -1,0 +1,27 @@
+from tests.helpers import *
+
+
+class AccountRegressionTestCase(unittest.TestCase):
+    def test_confirm_email_posts_verify_email_code_payload(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.authorization_data = {"ds_user_id": "123"}
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.confirm_email("addr@example.com", "123456")
+
+        self.assertEqual(result, {"status": "ok"})
+        private_request.assert_called_once_with(
+            "accounts/verify_email_code/",
+            {
+                "_uuid": "uuid",
+                "device_id": "android-id",
+                "phone_id": "phone-id",
+                "_uid": "123",
+                "guid": "uuid",
+                "email": "addr@example.com",
+                "code": "123456",
+            },
+        )


### PR DESCRIPTION
## Summary
- add `confirm_email(email, code)` for profile email code verification
- use the Android 428 `accounts/verify_email_code/` endpoint with standard device payload
- document the new flow next to `send_confirm_email`

Fixes #2078.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_account.py -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/account.py tests/regression/test_account.py`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/account.py tests/regression/test_account.py`
- `git diff --check`
