### PR TITLE
Clarify legacy signup spam rejection

### DIFF
--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -50,6 +50,7 @@ Notes:
 * `challenge_code_handler(username, choice)` should return the received code as a string. Returning a falsey value means no code is available yet.
 * Login `submit_phone` challenges use `client.phone_number`, then call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
 * Signup SMS challenges use the `phone_number` passed to `signup(...)` and call `challenge_code_handler(username, ChallengeChoice.SMS)` for the received code.
+* `signup(...)` uses Instagram's legacy account-create flow. On modern Instagram app versions this flow is often rejected with `SignupSpamError` / `feedback_required` because the official app uses additional signup checks that instagrapi does not currently generate. Treat this as a platform rejection, not as a malformed SMS/email code.
 * Current `master` raises a clearer `ChallengeRequired` for `/auth_platform/?apc=...` flows. That path is not yet supported automatically and still requires manual verification.
 * For long-running automation, persist client settings around challenge handling so you can retry without rebuilding the entire device/session state.
 

--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -103,6 +103,10 @@ class FeedbackRequired(PrivateError):
     pass
 
 
+class SignupSpamError(FeedbackRequired):
+    """Raised when Instagram rejects the legacy signup flow as spam."""
+
+
 class ChallengeError(PrivateError):
     pass
 

--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -13,6 +13,8 @@ from instagrapi.exceptions import (
     EmailInvalidError,
     EmailNotAvailableError,
     EmailVerificationSendError,
+    FeedbackRequired,
+    SignupSpamError,
 )
 from instagrapi.extractors import extract_user_short
 from instagrapi.mixins.challenge import ChallengeChoice
@@ -184,7 +186,6 @@ class SignUpMixin:
     ) -> dict:
         # timestamp = datetime.now().strftime("%s")  # Unused variable
         data = {
-            "is_secondary_account_creation": "true",
             "jazoest": str(int(random.randint(22300, 22399))),  # "22341",
             "tos_version": "row",
             "suggestedUsername": "",
@@ -209,7 +210,18 @@ class SignUpMixin:
             "one_tap_opt_in": "true",
             **kwargs,
         }
-        return self.private_request("accounts/create/", data, domain="www.instagram.com")
+        try:
+            return self.private_request("accounts/create/", data, domain="www.instagram.com")
+        except FeedbackRequired as exc:
+            if getattr(exc, "spam", False):
+                details = vars(exc).copy()
+                details.pop("message", None)
+                raise SignupSpamError(
+                    "Instagram rejected the legacy signup flow as spam. "
+                    "Modern app signup uses additional device trust checks that instagrapi does not currently generate.",
+                    **details,
+                ) from exc
+            raise
 
     def challenge_flow(
         self,

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import FeedbackRequired, SignupSpamError
 from instagrapi.mixins.challenge import ChallengeChoice
 from tests.helpers import *
 
@@ -46,6 +47,63 @@ class SignupHelperRegressionTestCase(unittest.TestCase):
                 "prefill_shown": "False",
             },
         )
+
+    def test_accounts_create_primary_signup_omits_secondary_account_flag(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.adid = "adid"
+        client.waterfall_id = "waterfall-id"
+        client.password_encrypt = mock.Mock(return_value="enc-password")
+
+        with mock.patch.object(
+            client, "private_request", return_value={"created_user": {"pk": "1"}}
+        ) as private_request:
+            result = client.accounts_create(
+                username="example",
+                password="password",
+                email="addr@example.com",
+                signup_code="signup-code",
+                full_name="Example User",
+                year=2000,
+                month=5,
+                day=12,
+            )
+
+        self.assertEqual(result, {"created_user": {"pk": "1"}})
+        data = private_request.call_args.args[1]
+        self.assertNotIn("is_secondary_account_creation", data)
+        self.assertEqual(data["username"], "example")
+        self.assertEqual(data["force_sign_up_code"], "signup-code")
+        private_request.assert_called_once()
+
+    def test_accounts_create_spam_feedback_raises_signup_specific_error(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+        client.adid = "adid"
+        client.waterfall_id = "waterfall-id"
+        client.password_encrypt = mock.Mock(return_value="enc-password")
+        feedback = FeedbackRequired(
+            message="feedback_required: Try Again Later",
+            feedback_message="We limit how often you can do certain things on Instagram.",
+            spam=True,
+        )
+
+        with mock.patch.object(client, "private_request", side_effect=feedback):
+            with self.assertRaises(SignupSpamError) as ctx:
+                client.accounts_create(
+                    username="example",
+                    password="password",
+                    email="addr@example.com",
+                    signup_code="signup-code",
+                )
+
+        self.assertIn("legacy signup flow", str(ctx.exception))
+        self.assertTrue(ctx.exception.spam)
+        self.assertEqual(ctx.exception.feedback_message, "We limit how often you can do certain things on Instagram.")
 
     def test_challenge_api_rejects_external_api_path(self):
         client = Client()


### PR DESCRIPTION
## Summary
- remove the secondary-account flag from primary legacy signup payloads
- raise SignupSpamError when Instagram rejects legacy signup with feedback_required/spam:true
- document that signup(...) is a legacy flow and modern app signup may be rejected by device trust checks

## Tests
- .venv/bin/python -m pytest tests/regression/test_signup.py -q
- .venv/bin/python -m ruff check instagrapi/mixins/signup.py instagrapi/exceptions.py tests/regression/test_signup.py
- .venv/bin/python -m ruff format --check instagrapi/mixins/signup.py instagrapi/exceptions.py tests/regression/test_signup.py
- git diff --check