### PR TITLE
Validate downloaded media content length

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -295,6 +295,8 @@ PosixPath('/tmp/45588546_367538213983456_6830188946193737023_n.mp4')
 
 ```
 
+If Instagram returns a `Content-Length` header and the downloaded file is shorter, download helpers remove the partial file and raise `ClientIncompleteReadError`.
+
 ``` python
 
 >>> cl.media_pk_from_url("http://www.instagram.com/p/BjNLpA1AhXM/")

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -1,6 +1,5 @@
 import json
 import random
-import shutil
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -105,10 +104,7 @@ class DownloadPhotoMixin:
             return path.resolve()
         response = requests.get(url, stream=True, timeout=self.request_timeout)
         response.raise_for_status()
-        with open(path, "wb") as f:
-            response.raw.decode_content = True
-            shutil.copyfileobj(response.raw, f)
-        return path.resolve()
+        return self._download_response_to_path(response, path)
 
     def photo_download_by_url_origin(self, url: str) -> bytes:
         """
@@ -126,8 +122,7 @@ class DownloadPhotoMixin:
         url = str(url)
         response = requests.get(url, stream=True, timeout=self.request_timeout)
         response.raise_for_status()
-        response.raw.decode_content = True
-        return response.content
+        return self._download_response_bytes(response, url)
 
 
 class UploadPhotoMixin:

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import shutil
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 try:
@@ -347,6 +349,47 @@ class PublicRequestMixin:
             raise ClientConnectionError("{} {}".format(e.__class__.__name__, str(e)))
         finally:
             self.last_response_ts = time.time()
+
+    def _expected_content_length(self, response) -> Optional[int]:
+        content_length = response.headers.get("Content-Length")
+        if not content_length:
+            return None
+        try:
+            return int(content_length)
+        except (TypeError, ValueError):
+            return None
+
+    def _raise_for_incomplete_download(self, actual_length: int, expected_length: Optional[int], source: str) -> None:
+        if expected_length is None or actual_length == expected_length:
+            return
+        raise ClientIncompleteReadError(
+            f"Broken file {source} (Content-length={expected_length}, but file length={actual_length})"
+        )
+
+    def _download_response_to_path(self, response, path: Path) -> Path:
+        path = Path(path)
+        try:
+            with open(path, "wb") as f:
+                response.raw.decode_content = True
+                shutil.copyfileobj(response.raw, f)
+            self._raise_for_incomplete_download(
+                path.stat().st_size,
+                self._expected_content_length(response),
+                f'"{path}"',
+            )
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+        return path.resolve()
+
+    def _download_response_bytes(self, response, url: str) -> bytes:
+        content = response.content
+        self._raise_for_incomplete_download(
+            len(content),
+            self._expected_content_length(response),
+            f'from url "{url}"',
+        )
+        return content
 
     def public_graphql_request(
         self,

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -1,5 +1,4 @@
 import json
-import shutil
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Tuple
@@ -454,11 +453,7 @@ class StoryMixin:
 
         response = self._send_public_request(url, stream=True, timeout=self.request_timeout)
         response.raise_for_status()
-
-        with open(path, "wb") as f:
-            response.raw.decode_content = True
-            shutil.copyfileobj(response.raw, f)
-        return path.resolve()
+        return self._download_response_to_path(response, path)
 
     def story_viewers_chunk(self, story_pk: int, max_amount: int = 0, max_id: str = "") -> tuple[list[Viewer], str]:
         unique_set: set[str] = set()

--- a/instagrapi/mixins/track.py
+++ b/instagrapi/mixins/track.py
@@ -1,4 +1,3 @@
-import shutil
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 from urllib.parse import urlparse
@@ -49,10 +48,7 @@ class TrackMixin:
         path = Path(folder) / filename
         response = requests.get(url, stream=True, timeout=self.request_timeout)
         response.raise_for_status()
-        with open(path, "wb") as f:
-            response.raw.decode_content = True
-            shutil.copyfileobj(response.raw, f)
-        return path.resolve()
+        return self._download_response_to_path(response, path)
 
     def _track_request(self, data: Dict[str, Any], path: str = "clips/music/") -> Dict:
         try:

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -11,7 +11,6 @@ from instagrapi import config
 from instagrapi.exceptions import (
     VideoConfigureError,
     VideoConfigureStoryError,
-    VideoNotDownload,
     VideoNotUpload,
 )
 from instagrapi.types import (
@@ -98,29 +97,7 @@ class DownloadVideoMixin:
             return path.resolve()
         response = requests.get(url, stream=True, timeout=self.request_timeout)
         response.raise_for_status()
-        try:
-            content_length = int(response.headers.get("Content-Length"))
-        except TypeError:
-            print(
-                """
-                The program detected an mis-formatted link, and hence can't download it.
-                This problem occurs when the URL is passed into
-                    'video_download_by_url()' or the 'clip_download_by_url()'.
-                The raw URL needs to be re-formatted into one that is recognizable by the methods.
-                Use this code: url=self.cl.media_info(self.cl.media_pk_from_url('insert the url here')).video_url
-                You can remove the 'self' from the code above if needed.
-                """
-            )
-            raise Exception("The program detected an mis-formatted link.")
-        file_length = len(response.content)
-        if content_length != file_length:
-            raise VideoNotDownload(
-                f'Broken file "{path}" (Content-length={content_length}, but file length={file_length})'
-            )
-        with open(path, "wb") as f:
-            f.write(response.content)
-            f.close()
-        return path.resolve()
+        return self._download_response_to_path(response, path)
 
     def video_download_by_url_origin(self, url: str) -> bytes:
         """
@@ -138,13 +115,7 @@ class DownloadVideoMixin:
         """
         response = requests.get(url, stream=True, timeout=self.request_timeout)
         response.raise_for_status()
-        content_length = int(response.headers.get("Content-Length"))
-        file_length = len(response.content)
-        if content_length != file_length:
-            raise VideoNotDownload(
-                f'Broken file from url "{url}" (Content-length={content_length}, but file length={file_length})'
-            )
-        return response.content
+        return self._download_response_bytes(response, url)
 
 
 class UploadVideoMixin:

--- a/tests/regression/test_download.py
+++ b/tests/regression/test_download.py
@@ -1,4 +1,25 @@
+import io
+
+from instagrapi.exceptions import ClientIncompleteReadError
 from tests.helpers import *
+
+
+class _RawBytes(io.BytesIO):
+    decode_content = False
+
+
+class _DownloadResponse:
+    def __init__(self, content: bytes, content_length: int | str | None = None):
+        self.content = content
+        self.raw = _RawBytes(content)
+        self.headers = {}
+        if content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+        self.status_code = 200
+        self.url = "https://example.com/media.bin"
+
+    def raise_for_status(self):
+        return None
 
 
 class DownloadRegressionTestCase(unittest.TestCase):
@@ -61,3 +82,41 @@ class DownloadRegressionTestCase(unittest.TestCase):
             "/tmp",
             overwrite=False,
         )
+
+    def test_photo_download_by_url_rejects_incomplete_content_length(self):
+        client = Client()
+        response = _DownloadResponse(b"short", content_length=10)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "photo.jpg"
+
+            with mock.patch("instagrapi.mixins.photo.requests.get", return_value=response):
+                with self.assertRaises(ClientIncompleteReadError) as ctx:
+                    client.photo_download_by_url("https://example.com/photo.jpg", folder=tmpdir)
+
+            self.assertFalse(path.exists())
+            self.assertIn('Broken file "{}"'.format(path), str(ctx.exception))
+            self.assertIn("Content-length=10, but file length=5", str(ctx.exception))
+
+    def test_photo_download_by_url_origin_rejects_incomplete_content_length(self):
+        client = Client()
+        response = _DownloadResponse(b"short", content_length=10)
+
+        with mock.patch("instagrapi.mixins.photo.requests.get", return_value=response):
+            with self.assertRaises(ClientIncompleteReadError) as ctx:
+                client.photo_download_by_url_origin("https://example.com/photo.jpg")
+
+        self.assertIn('Broken file from url "https://example.com/photo.jpg"', str(ctx.exception))
+        self.assertIn("Content-length=10, but file length=5", str(ctx.exception))
+
+    def test_story_download_by_url_rejects_incomplete_content_length(self):
+        client = Client()
+        response = _DownloadResponse(b"short", content_length=10)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "story.mp4"
+
+            with mock.patch.object(client, "_send_public_request", return_value=response):
+                with self.assertRaises(ClientIncompleteReadError) as ctx:
+                    client.story_download_by_url("https://example.com/story.mp4", folder=tmpdir)
+
+            self.assertFalse(path.exists())
+            self.assertIn('Broken file "{}"'.format(path), str(ctx.exception))


### PR DESCRIPTION
## Summary
- add shared download helpers that validate Content-Length for streamed files and origin byte downloads
- apply the validation to photo, video, story, and track downloads; album, clip, and IGTV paths inherit it through their existing delegates
- document that incomplete downloads raise ClientIncompleteReadError and remove partial files

Fixes #1952

## Tests
- pytest tests/regression/test_download.py tests/regression/test_public.py -q
- ruff check instagrapi/mixins/public.py instagrapi/mixins/photo.py instagrapi/mixins/video.py instagrapi/mixins/story.py instagrapi/mixins/track.py tests/regression/test_download.py
- ruff format --check instagrapi/mixins/public.py instagrapi/mixins/photo.py instagrapi/mixins/video.py instagrapi/mixins/story.py instagrapi/mixins/track.py tests/regression/test_download.py && git diff --check
- mkdocs build --strict