### PR TITLE
Add password reset request helper

### DIFF
--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -13,7 +13,8 @@ Viewing and managing your profile
 | account_security_info() | dict | Return account security settings, backup codes, trusted devices, and 2FA state |
 | set_external_url(external_url: str) | dict | Replace bio links with a single external URL |
 | remove_bio_links(link_ids: List[int]) | dict | Remove one or more bio links by link ID |
-| reset_password(username: str) | dict | Trigger Instagram account recovery flow |
+| send_password_reset(identifier: str, recaptcha_challenge_field: str = "") | dict | Send an Instagram password reset link or code to the account email or phone |
+| reset_password(username: str) | dict | Backward-compatible alias for `send_password_reset()` |
 | change_password(old_password: str, new_password: str) | bool | Change account password |
 | send_confirm_email(email: str) | dict | Send a confirmation code to a new email address |
 | confirm_email(email: str, code: str) | dict | Confirm a new email address with the received code |
@@ -81,6 +82,7 @@ Notes:
 
 * `account_edit(**data)` only applies supported fields and preserves missing required profile fields from `account_info()`.
 * Use `account_set_biography()` when you want Instagram to re-process biography entities/markup explicitly.
+* `send_password_reset()` starts Instagram's recovery flow by requesting a reset link or code. It does not set a new password by itself; continue with the link/code flow that Instagram sends to the account email or phone.
 * `account_security_info()` and `insights_*` style methods require an authenticated session and may depend on the account type or enabled security features.
 
 Low level methods:

--- a/instagrapi/mixins/account.py
+++ b/instagrapi/mixins/account.py
@@ -1,11 +1,7 @@
 import json
-from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Dict
 
-import requests
-
-from instagrapi.exceptions import ClientError, ClientLoginRequired
 from instagrapi.extractors import extract_account, extract_user_short
 from instagrapi.types import Account, UserShort
 from instagrapi.utils.auth import gen_token, generate_signature
@@ -17,40 +13,42 @@ class AccountMixin:
     Helper class to manage your account
     """
 
-    def reset_password(self, username: str) -> Dict:
+    def send_password_reset(self, identifier: str, recaptcha_challenge_field: str = "") -> Dict:
         """
-        Reset your password
+        Send a password reset link or code to the account email or phone.
+
+        Parameters
+        ----------
+        identifier: str
+            Username, email address, or phone number for the account.
+        recaptcha_challenge_field: str, default ""
+            Recaptcha challenge token when Instagram asks for one.
 
         Returns
         -------
         Dict
             Jsonified response from Instagram
         """
-        response = requests.post(
+        csrf_token = self.public.cookies.get("csrftoken") or gen_token()
+        return self.public_request(
             "https://www.instagram.com/accounts/account_recovery_send_ajax/",
-            data={"email_or_username": username, "recaptcha_challenge_field": ""},
+            data={"email_or_username": identifier, "recaptcha_challenge_field": recaptcha_challenge_field},
             headers={
                 "x-requested-with": "XMLHttpRequest",
-                "x-csrftoken": gen_token(),
-                "Connection": "Keep-Alive",
-                "Accept": "*/*",
-                "Accept-Encoding": "gzip,deflate",
-                "Accept-Language": "en-US",
-                "User-Agent": (
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) "
-                    "AppleWebKit/605.1.15 (KHTML, like Gecko) "
-                    "Version/11.1.2 Safari/605.1.15"
-                ),
+                "x-csrftoken": csrf_token,
             },
-            proxies=self.public.proxies,
-            timeout=self.request_timeout,
+            return_json=True,
+            update_headers=False,
         )
-        try:
-            return response.json()
-        except JSONDecodeError as e:
-            if "/login/" in response.url:
-                raise ClientLoginRequired(e, response=response)
-            raise ClientError(e, response=response)
+
+    def reset_password(self, username: str) -> Dict:
+        """
+        Send a password reset link or code.
+
+        This method is kept for backward compatibility. Use
+        :meth:`send_password_reset` in new code.
+        """
+        return self.send_password_reset(username)
 
     def account_info(self) -> Account:
         """

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -2,6 +2,45 @@ from tests.helpers import *
 
 
 class AccountRegressionTestCase(unittest.TestCase):
+    def test_send_password_reset_posts_recovery_payload(self):
+        client = Client()
+
+        with mock.patch.object(client, "public_request", return_value={"status": "ok"}) as public_request:
+            result = client.send_password_reset("user@example.com")
+
+        self.assertEqual(result, {"status": "ok"})
+        public_request.assert_called_once()
+        args, kwargs = public_request.call_args
+        self.assertEqual(args, ("https://www.instagram.com/accounts/account_recovery_send_ajax/",))
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "email_or_username": "user@example.com",
+                "recaptcha_challenge_field": "",
+            },
+        )
+        self.assertEqual(kwargs["headers"]["x-requested-with"], "XMLHttpRequest")
+        self.assertIn("x-csrftoken", kwargs["headers"])
+        self.assertTrue(kwargs["return_json"])
+        self.assertFalse(kwargs["update_headers"])
+
+    def test_send_password_reset_accepts_recaptcha_challenge_field(self):
+        client = Client()
+
+        with mock.patch.object(client, "public_request", return_value={"status": "ok"}) as public_request:
+            client.send_password_reset("user@example.com", recaptcha_challenge_field="challenge")
+
+        self.assertEqual(public_request.call_args.kwargs["data"]["recaptcha_challenge_field"], "challenge")
+
+    def test_reset_password_delegates_to_send_password_reset(self):
+        client = Client()
+
+        with mock.patch.object(client, "send_password_reset", return_value={"status": "ok"}) as send_password_reset:
+            result = client.reset_password("username")
+
+        self.assertEqual(result, {"status": "ok"})
+        send_password_reset.assert_called_once_with("username")
+
     def test_confirm_email_posts_verify_email_code_payload(self):
         client = Client()
         client.phone_id = "phone-id"


### PR DESCRIPTION
## Summary
- add `send_password_reset()` for requesting an Instagram password reset link or code by username, email, or phone
- keep `reset_password()` as a backward-compatible alias
- route the request through `public_request()` so it uses the configured public session, proxy, TLS verification, retry, and logging behavior
- document the limitation: this starts Instagram's recovery flow but does not set a new password without the reset link/code flow

Addresses #2066.

## Tests
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_account.py tests/regression/test_public.py -q`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/ruff check instagrapi/mixins/account.py tests/regression/test_account.py`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/mkdocs build --strict`
