### PR TITLE
Add per-slide album usertags

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -473,6 +473,16 @@ Now let's mention users (Usertag) and location:
     location=Location(name='Russia, Saint-Petersburg', lat=59.96, lng=30.29)
 )
 
+>>> other = cl.user_info_by_username('other')
+>>> album = cl.album_upload(
+    ["/app/image.jpg", "/app/image2.jpg"],
+    "Album with per-slide tags",
+    usertags=[
+        [Usertag(user=example, x=0.5, y=0.5)],
+        [Usertag(user=other, x=0.25, y=0.75)],
+    ],
+)
+
 >>> media.dict()
 {'pk': 2573355619819242434,
  'id': '2573355619819242434_1903424587',
@@ -510,6 +520,10 @@ Now let's mention users (Usertag) and location:
  'title': '',
  'resources': []}
 ```
+
+For `album_upload`, nested `usertags` are matched by index with `paths`: `usertags[0]` applies to `paths[0]`, `usertags[1]` applies to `paths[1]`, and so on. A flat `List[Usertag]` is still accepted for backward compatibility and tags only the first carousel item.
+
+When reading an album, the same index rule applies to resources: tags for the first carousel item are in `media.resources[0].usertags`, tags for the second item are in `media.resources[1].usertags`, etc.
 
 Reels:
 

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -178,6 +178,7 @@ def extract_media_gql(data):
 
 
 def extract_resource_v1(data):
+    data = deepcopy(data)
     if "video_versions" in data:
         data["video_url"] = sorted(data["video_versions"], key=lambda o: o["height"] * o["width"])[-1]["url"]
     candidates = data.get("image_versions2", {}).get("candidates", [])
@@ -188,6 +189,11 @@ def extract_resource_v1(data):
         )[-1]["url"]
         if candidates
         else None
+    )
+    usertags = data.get("usertags") or {}
+    data["usertags"] = sorted(
+        [extract_usertag(usertag) for usertag in usertags.get("in", [])],
+        key=lambda tag: tag.user.pk,
     )
     return Resource(**data)
 

--- a/instagrapi/mixins/album.py
+++ b/instagrapi/mixins/album.py
@@ -125,7 +125,7 @@ class UploadAlbumMixin:
         self,
         paths: List[Path],
         caption: str,
-        usertags: List[Usertag] = [],
+        usertags: Union[List[Usertag], List[List[Usertag]]] = [],
         location: Location = None,
         configure_timeout: int = 3,
         configure_handler=None,
@@ -142,8 +142,9 @@ class UploadAlbumMixin:
             List of paths for media to upload
         caption: str
             Media caption
-        usertags: List[Usertag], optional
-            List of users to be tagged on this upload, default is empty list.
+        usertags: List[Usertag] or List[List[Usertag]], optional
+            List of users to tag. A flat list tags the first carousel item for backward compatibility.
+            Use a nested list to tag each carousel item by index: ``usertags[0]`` applies to ``paths[0]``.
         location: Location, optional
             Location tag for this upload, default is none
         configure_timeout: int
@@ -234,7 +235,7 @@ class UploadAlbumMixin:
         paths: List[Path],
         caption: str,
         track: Union[Track, Dict],
-        usertags: List[Usertag] = [],
+        usertags: Union[List[Usertag], List[List[Usertag]]] = [],
         location: Location = None,
         configure_timeout: int = 3,
         configure_handler=None,
@@ -257,8 +258,9 @@ class UploadAlbumMixin:
             Media caption.
         track: Track or dict
             Track from music search/browser response or a compatible dict.
-        usertags: List[Usertag], optional
-            List of users to be tagged on this upload.
+        usertags: List[Usertag] or List[List[Usertag]], optional
+            List of users to tag. A flat list tags the first carousel item for backward compatibility.
+            Use a nested list to tag each carousel item by index: ``usertags[0]`` applies to ``paths[0]``.
         location: Location, optional
             Location tag for this upload.
         configure_timeout: int
@@ -311,7 +313,7 @@ class UploadAlbumMixin:
         self,
         childs: List,
         caption: str,
-        usertags: List[Usertag] = [],
+        usertags: Union[List[Usertag], List[List[Usertag]]] = [],
         location: Location = None,
         extra_data: Dict[str, str] = {},
     ) -> Dict:
@@ -324,8 +326,9 @@ class UploadAlbumMixin:
             List of media/resources of an album
         caption: str
             Media caption
-        usertags: List[Usertag], optional
-            List of users to be tagged on this upload, default is empty list.
+        usertags: List[Usertag] or List[List[Usertag]], optional
+            List of users to tag. A flat list tags the first carousel item for backward compatibility.
+            Use a nested list to tag each carousel item by index: ``usertags[0]`` applies to ``childs[0]``.
         location: Location, optional
             Location tag for this upload, default is None
         extra_data: Dict[str, str], optional
@@ -338,8 +341,16 @@ class UploadAlbumMixin:
         """
         upload_id = str(int(time.time() * 1000))
         if usertags:
-            usertags = [{"user_id": tag.user.pk, "position": [tag.x, tag.y]} for tag in usertags]
-            childs[0]["usertags"] = dumps({"in": usertags})
+            if isinstance(usertags[0], list):
+                for child, child_usertags in zip(childs, usertags):
+                    if not child_usertags:
+                        continue
+                    child["usertags"] = dumps(
+                        {"in": [{"user_id": tag.user.pk, "position": [tag.x, tag.y]} for tag in child_usertags]}
+                    )
+            else:
+                child_usertags = [{"user_id": tag.user.pk, "position": [tag.x, tag.y]} for tag in usertags]
+                childs[0]["usertags"] = dumps({"in": child_usertags})
         data = {
             "timezone_offset": str(self.timezone_offset),
             "source_type": "4",

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -26,6 +26,7 @@ class Resource(TypesBaseModel):
     video_url: Optional[HttpUrl] = None  # for Video and IGTV
     thumbnail_url: Optional[HttpUrl] = None
     media_type: int
+    usertags: List["Usertag"] = []
 
 
 class BioLink(TypesBaseModel):

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -1,5 +1,6 @@
 import json
 
+from instagrapi.extractors import extract_media_v1
 from tests.helpers import *
 
 
@@ -59,6 +60,59 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         with mock.patch.object(client, "private_request", return_value={}):
             with self.assertRaises(MediaNotFound):
                 client.media_info_v2("9_8")
+
+    def test_extract_media_v1_preserves_album_resource_usertags(self):
+        payload = self._media_or_ad_payload()
+        payload["media_type"] = 8
+        payload["carousel_media"] = [
+            {
+                "pk": "10",
+                "id": "10_2",
+                "media_type": 1,
+                "image_versions2": {
+                    "candidates": [{"url": "https://example.com/one.jpg", "width": 100, "height": 100}],
+                },
+                "usertags": {
+                    "in": [
+                        {
+                            "user": {
+                                "pk": "100",
+                                "username": "first",
+                                "profile_pic_url": "https://example.com/first.jpg",
+                            },
+                            "position": [0.25, 0.75],
+                        }
+                    ]
+                },
+            },
+            {
+                "pk": "20",
+                "id": "20_2",
+                "media_type": 1,
+                "image_versions2": {
+                    "candidates": [{"url": "https://example.com/two.jpg", "width": 100, "height": 100}],
+                },
+                "usertags": {
+                    "in": [
+                        {
+                            "user": {
+                                "pk": "200",
+                                "username": "second",
+                                "profile_pic_url": "https://example.com/second.jpg",
+                            },
+                            "position": [0.5, 0.5],
+                        }
+                    ]
+                },
+            },
+        ]
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(media.resources[0].usertags[0].user.pk, "100")
+        self.assertEqual(media.resources[0].usertags[0].x, 0.25)
+        self.assertEqual(media.resources[1].usertags[0].user.pk, "200")
+        self.assertEqual(media.resources[1].usertags[0].y, 0.5)
 
 
 class CheckOffensiveCommentV2RegressionTestCase(unittest.TestCase):

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -339,6 +339,41 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertIsInstance(media, Media)
         photo_rupload.assert_called_once_with(Path("slide.png"), to_album=True)
 
+    def test_album_configure_assigns_nested_usertags_by_carousel_index(self):
+        client = self.build_client()
+        first_user = UserShort(pk="10", username="first")
+        second_user = UserShort(pk="20", username="second")
+        children = [{"upload_id": "1"}, {"upload_id": "2"}]
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            client.album_configure(
+                children,
+                "caption",
+                usertags=[
+                    [Usertag(user=first_user, x=0.25, y=0.75)],
+                    [Usertag(user=second_user, x=0.5, y=0.5)],
+                ],
+            )
+
+        metadata = private_request.call_args.args[1]["children_metadata"]
+        first_tags = json.loads(metadata[0]["usertags"])
+        second_tags = json.loads(metadata[1]["usertags"])
+        self.assertEqual(first_tags, {"in": [{"user_id": "10", "position": [0.25, 0.75]}]})
+        self.assertEqual(second_tags, {"in": [{"user_id": "20", "position": [0.5, 0.5]}]})
+
+    def test_album_configure_keeps_flat_usertags_on_first_carousel_item(self):
+        client = self.build_client()
+        user = UserShort(pk="10", username="first")
+        children = [{"upload_id": "1"}, {"upload_id": "2"}]
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            client.album_configure(children, "caption", usertags=[Usertag(user=user, x=0.25, y=0.75)])
+
+        metadata = private_request.call_args.args[1]["children_metadata"]
+        first_tags = json.loads(metadata[0]["usertags"])
+        self.assertEqual(first_tags, {"in": [{"user_id": "10", "position": [0.25, 0.75]}]})
+        self.assertNotIn("usertags", metadata[1])
+
     def test_music_in_feed_audio_browser_requests_feed_music_product(self):
         client = self.build_client()
         expected = {"status": "ok", "alacorn_session_id": "alacorn-1"}


### PR DESCRIPTION
## Summary
- preserve `carousel_media[*].usertags` on extracted album resources so callers can read per-slide tags via `media.resources[index].usertags`
- support nested `album_upload(..., usertags=[...])` lists so tags can be assigned to matching `paths[index]` carousel items
- keep the old flat `List[Usertag]` behavior as a backward-compatible first-slide tag shortcut
- document the read/write index mapping for album usertags

Fixes #2094.

## Tests
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_upload.py tests/regression/test_media.py -q`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/ruff check instagrapi/mixins/album.py instagrapi/extractors.py instagrapi/types.py tests/regression/test_upload.py tests/regression/test_media.py`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/mkdocs build --strict`
