### PR TITLE
Fix comment pin endpoint slash

### DIFF
--- a/instagrapi/mixins/comment.py
+++ b/instagrapi/mixins/comment.py
@@ -591,7 +591,7 @@ class CommentMixin:
         data = self.with_action_data({"_uid": self.user_id, "_uuid": self.uuid})
         name = "unpin" if revert else "pin"
 
-        result = self.private_request(f"media/{media_id}/{name}_comment/{comment_pk}", data)
+        result = self.private_request(f"media/{media_id}/{name}_comment/{comment_pk}/", data)
         return result["status"] == "ok"
 
     def comment_unpin(self, media_id: str, comment_pk: int):

--- a/tests/live/test_comments.py
+++ b/tests/live/test_comments.py
@@ -105,6 +105,20 @@ class ClientCommentExtendTestCase(_helpers.ClientPrivateTestCase):
         for field in ["pk", "username", "full_name", "profile_pic_url"]:
             self.assertIn(field, user_fields)
 
+    def test_comment_pin_and_unpin(self):
+        text = "Pin live fixture [%s]" % datetime.now().strftime("%s")
+        caption_text = "Comment pin media fixture [%s]" % datetime.now().strftime("%s")
+        path = self.copy_media_fixture("examples/kanada.jpg")
+        media = self.cl.photo_upload(path, caption_text)
+        self.addCleanup(self.cleanup_media, media.id)
+        self.assertUploadedMediaAccessible(media, media_type=1, caption_text=caption_text)
+        comment = self.cl.media_comment(media.id, text)
+        self.addCleanup(self.cleanup_comment, media.id, comment.pk)
+        self.assertCommentAccessible(media.id, comment.pk, text)
+
+        self.assertTrue(self.cl.comment_pin(media.id, comment.pk))
+        self.assertTrue(self.cl.comment_unpin(media.id, comment.pk))
+
     def test_comment_like_and_unlike(self):
         media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")
         comment = self.cl.media_comments_v1(media_pk)[0]

--- a/tests/regression/test_comments.py
+++ b/tests/regression/test_comments.py
@@ -202,6 +202,28 @@ class CommentRepliesRegressionTestCase(unittest.TestCase):
             query_hash="5f0b1f6281e72053cbc07909c8d154ae",
         )
 
+    def test_comment_pin_posts_to_slash_terminated_endpoint(self):
+        client = self._build_logged_in_client()
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.comment_pin("123_456", 789)
+
+        self.assertTrue(result)
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/123_456/pin_comment/789/")
+        self.assertEqual(data["_uid"], client.user_id)
+        self.assertEqual(data["_uuid"], client.uuid)
+
+    def test_comment_unpin_posts_to_slash_terminated_endpoint(self):
+        client = self._build_logged_in_client()
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.comment_unpin("123_456", 789)
+
+        self.assertTrue(result)
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/123_456/unpin_comment/789/")
+        self.assertEqual(data["_uid"], client.user_id)
+        self.assertEqual(data["_uuid"], client.uuid)
+
     def test_media_comment_replies_chunk_returns_child_cursor(self):
         client = Client()
         with mock.patch.object(


### PR DESCRIPTION
## Summary
- keep comment pin/unpin requests on the slash-terminated mobile endpoints
- add regression coverage for pin/unpin request paths
- add a live upload/comment/pin/unpin smoke test

## Verification
- `.venv/bin/python -m pytest tests/regression/test_comments.py tests/live/test_comments.py::ClientCommentExtendTestCase::test_comment_pin_and_unpin`
- `.venv/bin/python -m ruff check instagrapi/mixins/comment.py tests/regression/test_comments.py tests/live/test_comments.py`

Fixes #1899