### PR TITLE
Add experimental realtime MQTT client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2023-2026 Mark Subzeroid and instagrapi contributors
+Portions of the realtime MQTT implementation are derived from instagram_mqtt:
+Copyright (c) 2019 Nerixyz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -173,6 +173,42 @@ note = cl.create_note("Hello from instagrapi", audience=0)
 cl.delete_note(note.id)
 ```
 
+### Receive Direct messages with Realtime MQTT
+
+Realtime MQTT support is experimental and receive-oriented. It opens Instagram's
+private MQTToT connection after login, emits live callbacks, and uses the same
+`Client.proxy` settings as HTTP requests. Use the regular `direct_*` methods for
+replies, reactions, media, and other actions.
+
+```python
+import json
+
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+
+def handle_direct_message(payload):
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+cl.realtime_on("message", handle_direct_message)
+
+rt = cl.realtime_connect()
+rt.direct_subscribe()
+
+try:
+    rt.ping()
+    while True:
+        rt.read_once()
+finally:
+    cl.realtime_disconnect()
+```
+
+See the full [Realtime MQTT guide](docs/usage-guide/realtime.md) for lower-level
+subscriptions and event details.
+
 ## Features
 
 * Uses [Web API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) and [Mobile API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) flows where available
@@ -186,6 +222,7 @@ cl.delete_note(note.id)
 * App-side discovery surfaces: `chaining`, `fetch_suggestion_details`, `discover_recommended_accounts_for_category_v1`, `user_stream_*`, `user_web_profile_info_v1`
 * v2 search SERPs: `fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`
 * Alternative media-info path (`media_info_v2`) for ad-tagged / sponsored media that the canonical endpoint refuses
+* Experimental Realtime MQTT receive helpers for live events and Direct message sync
 
 Anonymous/public web paths are best treated as opportunistic rather than guaranteed. Instagram can change or restrict them independently of the library, so production-grade workflows should prefer authenticated sessions.
 

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -46,12 +46,48 @@ while True:
     cl.realtime_read_once()
 ```
 
+Receive Direct message sync payloads:
+
+``` python
+import json
+
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+
+def handle_direct_message(payload):
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+cl.realtime_on("message", handle_direct_message)
+rt = cl.realtime_connect()
+
+try:
+    # Optional keepalive check for smoke tests or long-running workers.
+    rt.ping()
+
+    while True:
+        cl.realtime_read_once()
+except KeyboardInterrupt:
+    pass
+finally:
+    cl.realtime_disconnect()
+```
+
+Direct message sync is receive-only. Use the normal `direct_*` methods for replies, reactions, media, and other actions.
+The payload shape is private and can change server-side, so inspect the received dictionary before depending on nested keys.
+
 Subscribe to raw realtime topics:
 
 ``` python
 rt.graph_ql_subscribe(["<graphql-subscription>"])
 rt.skywalker_subscribe(["<skywalker-subscription>"])
 ```
+
+Raw GraphQL and Skywalker subscription strings are advanced and unstable. Message sync is subscribed by the default
+connection topics, so the Direct message example above does not need an extra raw subscription.
 
 Events:
 

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -1,0 +1,58 @@
+# Realtime MQTT
+
+!!! warning
+    Realtime MQTT support is experimental. Instagram can change this private transport without notice.
+
+The realtime client opens Instagram's MQTToT connection for receiving live events after login.
+It is useful when you need callbacks for realtime payloads instead of polling HTTP endpoints.
+Use the Direct methods for sending messages, reactions, and media.
+
+| Method | Return | Description |
+| --- | --- | --- |
+| `realtime_connect(transport=None)` | `RealtimeClient` | Create and connect the stateful realtime client |
+| `realtime_disconnect()` | `None` | Disconnect the active realtime client |
+| `realtime_on(event, handler)` | `None` | Register an event handler on the active realtime client |
+| `realtime_read_once()` | `Any` | Read one packet from the active realtime client |
+
+`RealtimeClient` also exposes lower-level helpers:
+
+| Method | Description |
+| --- | --- |
+| `on(event, handler)` | Register a handler for `receive`, `message`, or `realtime_sub` |
+| `graph_ql_subscribe(subscriptions)` | Publish raw GraphQL realtime subscriptions |
+| `skywalker_subscribe(subscriptions)` | Publish raw Skywalker subscriptions |
+| `publish_json(topic, data)` | Publish a JSON payload to a raw MQTToT topic |
+| `read_once()` | Read and dispatch one packet |
+
+Basic receive loop:
+
+``` python
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+
+def handle_receive(event):
+    print(event["topic"], event["payload"])
+
+
+cl.realtime_on("receive", handle_receive)
+rt = cl.realtime_connect()
+
+while True:
+    cl.realtime_read_once()
+```
+
+Subscribe to raw realtime topics:
+
+``` python
+rt.graph_ql_subscribe(["<graphql-subscription>"])
+rt.skywalker_subscribe(["<skywalker-subscription>"])
+```
+
+Events:
+
+* `receive` is emitted for every decoded publish packet as `{"topic": topic, "payload": payload}`.
+* `message` is emitted for message-sync payloads.
+* `realtime_sub` is emitted for realtime subscription payloads.

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -64,14 +64,8 @@ def handle_direct_message(payload):
 
 cl.realtime_on("message", handle_direct_message)
 
-# Fetch the Direct inbox snapshot before subscribing to message-sync events.
-# Instagram uses these values as the Iris cursor for realtime Direct patches.
-cl.direct_threads(amount=1)
-seq_id = cl.last_json["seq_id"]
-snapshot_at_ms = cl.last_json["snapshot_at_ms"]
-
 rt = cl.realtime_connect()
-rt.iris_subscribe(seq_id=seq_id, snapshot_at_ms=snapshot_at_ms)
+rt.direct_subscribe()
 
 try:
     # Optional keepalive check for smoke tests or long-running workers.

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -12,6 +12,7 @@ Use the Direct methods for sending messages, reactions, and media.
 | `realtime_connect(transport=None)` | `RealtimeClient` | Create and connect the stateful realtime client |
 | `realtime_disconnect()` | `None` | Disconnect the active realtime client |
 | `realtime_on(event, handler)` | `None` | Register an event handler on the active realtime client |
+| `realtime_ping()` | `bool` | Send a keepalive ping and wait for `PINGRESP` |
 | `realtime_read_once()` | `Any` | Read one packet from the active realtime client |
 
 `RealtimeClient` also exposes lower-level helpers:
@@ -22,6 +23,7 @@ Use the Direct methods for sending messages, reactions, and media.
 | `graph_ql_subscribe(subscriptions)` | Publish raw GraphQL realtime subscriptions |
 | `skywalker_subscribe(subscriptions)` | Publish raw Skywalker subscriptions |
 | `publish_json(topic, data)` | Publish a JSON payload to a raw MQTToT topic |
+| `ping()` | Send a keepalive ping and wait for `PINGRESP` |
 | `read_once()` | Read and dispatch one packet |
 
 Basic receive loop:

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -22,6 +22,7 @@ Use the Direct methods for sending messages, reactions, and media.
 | `on(event, handler)` | Register a handler for `receive`, `message`, or `realtime_sub` |
 | `graph_ql_subscribe(subscriptions)` | Publish raw GraphQL realtime subscriptions |
 | `skywalker_subscribe(subscriptions)` | Publish raw Skywalker subscriptions |
+| `iris_subscribe(seq_id, snapshot_at_ms)` | Publish Direct inbox sync state for message-sync events |
 | `publish_json(topic, data)` | Publish a JSON payload to a raw MQTToT topic |
 | `ping()` | Send a keepalive ping and wait for `PINGRESP` |
 | `read_once()` | Read and dispatch one packet |
@@ -62,7 +63,15 @@ def handle_direct_message(payload):
 
 
 cl.realtime_on("message", handle_direct_message)
+
+# Fetch the Direct inbox snapshot before subscribing to message-sync events.
+# Instagram uses these values as the Iris cursor for realtime Direct patches.
+cl.direct_threads(amount=1)
+seq_id = cl.last_json["seq_id"]
+snapshot_at_ms = cl.last_json["snapshot_at_ms"]
+
 rt = cl.realtime_connect()
+rt.iris_subscribe(seq_id=seq_id, snapshot_at_ms=snapshot_at_ms)
 
 try:
     # Optional keepalive check for smoke tests or long-running workers.

--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -36,6 +36,7 @@ from instagrapi.mixins.public import (
     PublicRequestMixin,
     TopSearchesPublicMixin,
 )
+from instagrapi.mixins.realtime import RealtimeMixin
 from instagrapi.mixins.share import ShareMixin
 from instagrapi.mixins.signup import SignUpMixin
 from instagrapi.mixins.story import StoryMixin
@@ -94,6 +95,7 @@ class Client(
     MultipleAccountsMixin,
     NoteMixin,
     FundraiserMixin,
+    RealtimeMixin,
 ):
     proxy = None
 

--- a/instagrapi/mixins/realtime.py
+++ b/instagrapi/mixins/realtime.py
@@ -1,0 +1,31 @@
+from instagrapi.realtime import RealtimeClient
+
+
+class RealtimeMixin:
+    realtime = None
+
+    def realtime_client(self, transport=None) -> RealtimeClient:
+        return RealtimeClient(self, transport=transport)
+
+    def realtime_connect(self, transport=None) -> RealtimeClient:
+        if not self.realtime:
+            self.realtime = self.realtime_client(transport=transport)
+        elif transport is not None:
+            self.realtime.transport = transport
+        self.realtime.connect()
+        return self.realtime
+
+    def realtime_disconnect(self) -> None:
+        if self.realtime:
+            self.realtime.disconnect()
+            self.realtime = None
+
+    def realtime_on(self, event: str, handler) -> None:
+        if not self.realtime:
+            self.realtime = self.realtime_client()
+        self.realtime.on(event, handler)
+
+    def realtime_read_once(self):
+        if not self.realtime:
+            raise RuntimeError("Realtime client is not connected")
+        return self.realtime.read_once()

--- a/instagrapi/mixins/realtime.py
+++ b/instagrapi/mixins/realtime.py
@@ -29,3 +29,8 @@ class RealtimeMixin:
         if not self.realtime:
             raise RuntimeError("Realtime client is not connected")
         return self.realtime.read_once()
+
+    def realtime_ping(self) -> bool:
+        if not self.realtime:
+            raise RuntimeError("Realtime client is not connected")
+        return self.realtime.ping()

--- a/instagrapi/realtime/__init__.py
+++ b/instagrapi/realtime/__init__.py
@@ -1,0 +1,3 @@
+from instagrapi.realtime.client import RealtimeClient
+
+__all__ = ["RealtimeClient"]

--- a/instagrapi/realtime/client.py
+++ b/instagrapi/realtime/client.py
@@ -1,0 +1,158 @@
+import json
+import time
+from collections import defaultdict
+from typing import Any, Callable, Dict, Iterable, List
+
+from instagrapi.realtime.mqttot import (
+    MQTToTConnection,
+    MQTToTTopics,
+    SocketMQTToTTransport,
+    compress_payload,
+    decode_packet,
+    parse_json_payload,
+    try_decompress_payload,
+    write_connect_packet,
+    write_disconnect_packet,
+    write_publish_packet,
+)
+
+REALTIME_HOST = "edge-mqtt.facebook.com"
+IG_REALTIME_APP_ID = 567067343352427
+REALTIME_SUBSCRIBE_TOPICS = [88, 135, 149, 150, 133, 146]
+
+
+class RealtimeClient:
+    def __init__(self, client, transport=None):
+        self.client = client
+        self.transport = transport or SocketMQTToTTransport(REALTIME_HOST)
+        self.connected = False
+        self._handlers: Dict[str, List[Callable[[Any], None]]] = defaultdict(list)
+        self._packet_id = 0
+
+    def on(self, event: str, handler: Callable[[Any], None]) -> None:
+        self._handlers[event].append(handler)
+
+    def connect(self) -> None:
+        self.transport.connect()
+        if isinstance(self.transport, SocketMQTToTTransport):
+            self.transport.send(write_connect_packet(self.build_connection()))
+            packet = decode_packet(self.transport.recv_packet())
+            if packet.packet_type != "connack" or packet.return_code != 0:
+                raise ConnectionError(f"Realtime MQTT connect failed: {packet.return_code}")
+        self.connected = True
+
+    def disconnect(self) -> None:
+        if isinstance(self.transport, SocketMQTToTTransport) and self.connected:
+            self.transport.send(write_disconnect_packet())
+        self.transport.disconnect()
+        self.connected = False
+
+    def build_connection(self) -> MQTToTConnection:
+        sessionid = self.client.sessionid
+        assert sessionid, "Login required"
+        device_id = self.client.phone_id
+        assert device_id, "Client phone_id is required"
+        user_agent = self.client.user_agent
+        app_version = getattr(self.client, "app_version", "")
+        capabilities = getattr(self.client, "capabilities", "3brTv10=")
+        locale = getattr(self.client, "locale", "en_US")
+        return MQTToTConnection(
+            client_identifier=device_id[:20],
+            client_info={
+                "userId": int(self.client.user_id),
+                "userAgent": user_agent,
+                "clientCapabilities": 183,
+                "endpointCapabilities": 0,
+                "publishFormat": 1,
+                "noAutomaticForeground": False,
+                "makeUserAvailableInForeground": True,
+                "deviceId": device_id,
+                "isInitiallyForeground": True,
+                "networkType": 1,
+                "networkSubtype": 0,
+                "clientMqttSessionId": int(time.time() * 1000) & 0xFFFFFFFF,
+                "subscribeTopics": REALTIME_SUBSCRIBE_TOPICS,
+                "clientType": "cookie_auth",
+                "appId": IG_REALTIME_APP_ID,
+                "deviceSecret": "",
+                "clientStack": 3,
+            },
+            password=f"sessionid={sessionid}",
+            app_specific_info={
+                "app_version": app_version,
+                "X-IG-Capabilities": capabilities,
+                "everclear_subscriptions": json.dumps(
+                    {
+                        "inapp_notification_subscribe_comment": "17899377895239777",
+                        "inapp_notification_subscribe_comment_mention_and_reply": "17899377895239777",
+                        "video_call_participant_state_delivery": "17977239895057311",
+                        "presence_subscribe": "17846944882223835",
+                    },
+                    separators=(",", ":"),
+                ),
+                "User-Agent": user_agent,
+                "Accept-Language": locale.replace("_", "-"),
+                "platform": "android",
+                "ig_mqtt_route": "django",
+                "pubsub_msg_type_blacklist": "direct, typing_type",
+                "auth_cache_enabled": "0",
+            },
+        )
+
+    def graph_ql_subscribe(self, subscriptions: str | Iterable[str]) -> None:
+        if isinstance(subscriptions, str):
+            subscriptions = [subscriptions]
+        self.publish_json(MQTToTTopics.REALTIME_SUB, {"sub": list(subscriptions)})
+
+    def skywalker_subscribe(self, subscriptions: str | Iterable[str]) -> None:
+        if isinstance(subscriptions, str):
+            subscriptions = [subscriptions]
+        self.publish_json(MQTToTTopics.PUBSUB, {"sub": list(subscriptions)})
+
+    def publish_json(self, topic: str, data: Dict[str, Any]) -> None:
+        self._packet_id += 1
+        packet = write_publish_packet(
+            topic,
+            compress_payload(json.dumps(data, separators=(",", ":")).encode()),
+            qos=1,
+            packet_id=self._packet_id,
+        )
+        self.transport.send(packet)
+
+    def read_once(self) -> Any:
+        packet = decode_packet(self.transport.recv_packet())
+        if packet.packet_type != "publish":
+            return packet
+        payload = self.dispatch_packet(packet.topic, packet.payload)
+        if packet.qos == 1 and packet.packet_id is not None:
+            self.transport.send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
+        return payload
+
+    def dispatch_packet(self, topic: str, payload: bytes) -> Any:
+        body = try_decompress_payload(payload)
+        parsed = None
+        if topic in {
+            MQTToTTopics.SEND_MESSAGE_RESPONSE,
+            MQTToTTopics.IRIS_SUB_RESPONSE,
+            MQTToTTopics.REALTIME_SUB,
+            MQTToTTopics.MESSAGE_SYNC,
+        }:
+            try:
+                parsed = json.loads(body.decode())
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                parsed = body
+        else:
+            try:
+                parsed = parse_json_payload(payload)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                parsed = body
+        self.emit("receive", {"topic": topic, "payload": parsed})
+        if topic == MQTToTTopics.MESSAGE_SYNC:
+            self.emit("message", parsed)
+        if topic == MQTToTTopics.REALTIME_SUB:
+            self.emit("realtime_sub", parsed)
+        return parsed
+
+    def emit(self, event: str, payload: Any) -> None:
+        for handler in self._handlers.get(event, []):
+            handler(payload)

--- a/instagrapi/realtime/client.py
+++ b/instagrapi/realtime/client.py
@@ -25,7 +25,7 @@ REALTIME_SUBSCRIBE_TOPICS = [88, 135, 149, 150, 133, 146]
 class RealtimeClient:
     def __init__(self, client, transport=None):
         self.client = client
-        self.transport = transport or SocketMQTToTTransport(REALTIME_HOST)
+        self.transport = transport or SocketMQTToTTransport(REALTIME_HOST, proxy=getattr(client, "proxy", None))
         self.connected = False
         self._handlers: Dict[str, List[Callable[[Any], None]]] = defaultdict(list)
         self._packet_id = 0
@@ -54,7 +54,7 @@ class RealtimeClient:
         device_id = self.client.phone_id
         assert device_id, "Client phone_id is required"
         user_agent = self.client.user_agent
-        app_version = getattr(self.client, "app_version", "")
+        app_version = self.client_app_version()
         capabilities = getattr(self.client, "capabilities", "3brTv10=")
         locale = getattr(self.client, "locale", "en_US")
         return MQTToTConnection(
@@ -116,9 +116,19 @@ class RealtimeClient:
             {
                 "seq_id": seq_id,
                 "snapshot_at_ms": snapshot_at_ms,
-                "snapshot_app_version": snapshot_app_version or self.client.app_version,
+                "snapshot_app_version": snapshot_app_version or self.client_app_version(),
             },
         )
+
+    def direct_subscribe(self, amount: int = 1) -> Dict[str, Any]:
+        self.client.direct_threads(amount=amount)
+        seq_id = self.client.last_json.get("seq_id")
+        snapshot_at_ms = self.client.last_json.get("snapshot_at_ms")
+        if seq_id is None or snapshot_at_ms is None:
+            raise RuntimeError("Direct inbox did not return realtime sync state")
+        state = {"seq_id": seq_id, "snapshot_at_ms": snapshot_at_ms}
+        self.iris_subscribe(**state)
+        return state
 
     def publish_json(self, topic: str, data: Dict[str, Any]) -> None:
         self._packet_id += 1
@@ -230,6 +240,10 @@ class RealtimeClient:
         if path.startswith(prefix):
             return path[len(prefix) :].split("/", 1)[0]
         return None
+
+    def client_app_version(self) -> str:
+        device_settings = getattr(self.client, "device_settings", None) or {}
+        return getattr(self.client, "app_version", None) or device_settings.get("app_version", "")
 
     def emit(self, event: str, payload: Any) -> None:
         for handler in self._handlers.get(event, []):

--- a/instagrapi/realtime/client.py
+++ b/instagrapi/realtime/client.py
@@ -13,6 +13,7 @@ from instagrapi.realtime.mqttot import (
     try_decompress_payload,
     write_connect_packet,
     write_disconnect_packet,
+    write_pingreq_packet,
     write_publish_packet,
 )
 
@@ -129,6 +130,21 @@ class RealtimeClient:
         if packet.qos == 1 and packet.packet_id is not None:
             self.transport.send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
         return payload
+
+    def ping(self, max_packets: int = 5) -> bool:
+        if not self.connected:
+            raise RuntimeError("Realtime client is not connected")
+        self.transport.send(write_pingreq_packet())
+        for _ in range(max_packets):
+            packet = decode_packet(self.transport.recv_packet())
+            if packet.packet_type == "pingresp":
+                return True
+            if packet.packet_type != "publish" or packet.topic is None:
+                return False
+            self.dispatch_packet(packet.topic, packet.payload)
+            if packet.qos == 1 and packet.packet_id is not None:
+                self.transport.send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
+        return False
 
     def dispatch_packet(self, topic: str, payload: bytes) -> Any:
         body = try_decompress_payload(payload)

--- a/instagrapi/realtime/client.py
+++ b/instagrapi/realtime/client.py
@@ -110,6 +110,16 @@ class RealtimeClient:
             subscriptions = [subscriptions]
         self.publish_json(MQTToTTopics.PUBSUB, {"sub": list(subscriptions)})
 
+    def iris_subscribe(self, seq_id: int, snapshot_at_ms: int, snapshot_app_version: str | None = None) -> None:
+        self.publish_json(
+            MQTToTTopics.IRIS_SUB,
+            {
+                "seq_id": seq_id,
+                "snapshot_at_ms": snapshot_at_ms,
+                "snapshot_app_version": snapshot_app_version or self.client.app_version,
+            },
+        )
+
     def publish_json(self, topic: str, data: Dict[str, Any]) -> None:
         self._packet_id += 1
         packet = write_publish_packet(
@@ -166,10 +176,60 @@ class RealtimeClient:
                 parsed = body
         self.emit("receive", {"topic": topic, "payload": parsed})
         if topic == MQTToTTopics.MESSAGE_SYNC:
-            self.emit("message", parsed)
+            self.dispatch_message_sync(parsed)
         if topic == MQTToTTopics.REALTIME_SUB:
             self.emit("realtime_sub", parsed)
         return parsed
+
+    def dispatch_message_sync(self, payload: Any) -> None:
+        if not isinstance(payload, list):
+            self.emit("message", payload)
+            return
+        for item in payload:
+            if not isinstance(item, dict):
+                self.emit("iris", item)
+                continue
+            patches = item.get("data")
+            if not isinstance(patches, list):
+                self.emit("iris", item)
+                continue
+            meta = {key: value for key, value in item.items() if key != "data"}
+            for patch in patches:
+                if not isinstance(patch, dict):
+                    self.emit("iris", {**meta, "data": patch})
+                    continue
+                path = patch.get("path")
+                raw_value = patch.get("value")
+                if not path or raw_value is None:
+                    self.emit("iris", {**meta, **patch})
+                    continue
+                try:
+                    value = json.loads(raw_value) if isinstance(raw_value, str) else raw_value
+                except json.JSONDecodeError:
+                    value = {"value": raw_value}
+                wrapper = {
+                    **meta,
+                    "message": {
+                        "path": path,
+                        "op": patch.get("op"),
+                        "thread_id": self.thread_id_from_message_sync_path(path),
+                        **(value if isinstance(value, dict) else {"value": value}),
+                    },
+                }
+                if path.startswith("/direct_v2/threads/"):
+                    self.emit("message", wrapper)
+                else:
+                    self.emit("thread_update", wrapper)
+
+    @staticmethod
+    def thread_id_from_message_sync_path(path: str) -> str | None:
+        prefix = "/direct_v2/threads/"
+        if path.startswith(prefix):
+            return path[len(prefix) :].split("/", 1)[0]
+        prefix = "/direct_v2/inbox/threads/"
+        if path.startswith(prefix):
+            return path[len(prefix) :].split("/", 1)[0]
+        return None
 
     def emit(self, event: str, payload: Any) -> None:
         for handler in self._handlers.get(event, []):

--- a/instagrapi/realtime/client.py
+++ b/instagrapi/realtime/client.py
@@ -123,6 +123,8 @@ class RealtimeClient:
         packet = decode_packet(self.transport.recv_packet())
         if packet.packet_type != "publish":
             return packet
+        if packet.topic is None:
+            return packet
         payload = self.dispatch_packet(packet.topic, packet.payload)
         if packet.qos == 1 and packet.packet_id is not None:
             self.transport.send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))

--- a/instagrapi/realtime/mqttot.py
+++ b/instagrapi/realtime/mqttot.py
@@ -1,0 +1,557 @@
+import json
+import socket
+import ssl
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+
+class MQTToTTopics:
+    PUBSUB = "88"
+    FOREGROUND_STATE = "102"
+    SEND_MESSAGE = "132"
+    SEND_MESSAGE_RESPONSE = "133"
+    IRIS_SUB = "134"
+    IRIS_SUB_RESPONSE = "135"
+    MESSAGE_SYNC = "146"
+    REALTIME_SUB = "149"
+    REGION_HINT = "150"
+
+
+class ThriftTypes:
+    STOP = 0x00
+    TRUE = 0x01
+    FALSE = 0x02
+    BYTE = 0x03
+    INT_16 = 0x04
+    INT_32 = 0x05
+    INT_64 = 0x06
+    BINARY = 0x08
+    LIST = 0x09
+    MAP = 0x0B
+    STRUCT = 0x0C
+    BOOLEAN = 0xA1
+    LIST_INT_32 = (INT_32 << 8) | LIST
+    LIST_BINARY = (BINARY << 8) | LIST
+    MAP_BINARY_BINARY = (0x88 << 8) | MAP
+
+
+@dataclass(frozen=True)
+class ThriftDescriptor:
+    name: str
+    field: int
+    type: int
+    children: tuple["ThriftDescriptor", ...] = ()
+
+
+@dataclass
+class DecodedMQTToTPacket:
+    packet_type: str
+    payload: bytes
+    protocol_name: Optional[str] = None
+    protocol_level: Optional[int] = None
+    connect_flags: Optional[int] = None
+    keep_alive: Optional[int] = None
+    topic: Optional[str] = None
+    qos: int = 0
+    packet_id: Optional[int] = None
+    return_code: Optional[int] = None
+
+
+@dataclass
+class MQTToTConnection:
+    client_identifier: str
+    client_info: Dict[str, Any]
+    password: str
+    app_specific_info: Optional[Dict[str, str]] = None
+
+    @staticmethod
+    def thrift_descriptors() -> List[ThriftDescriptor]:
+        return [
+            ThriftDescriptor("clientIdentifier", 1, ThriftTypes.BINARY),
+            ThriftDescriptor("willTopic", 2, ThriftTypes.BINARY),
+            ThriftDescriptor("willMessage", 3, ThriftTypes.BINARY),
+            ThriftDescriptor(
+                "clientInfo",
+                4,
+                ThriftTypes.STRUCT,
+                (
+                    ThriftDescriptor("userId", 1, ThriftTypes.INT_64),
+                    ThriftDescriptor("userAgent", 2, ThriftTypes.BINARY),
+                    ThriftDescriptor("clientCapabilities", 3, ThriftTypes.INT_64),
+                    ThriftDescriptor("endpointCapabilities", 4, ThriftTypes.INT_64),
+                    ThriftDescriptor("publishFormat", 5, ThriftTypes.INT_32),
+                    ThriftDescriptor("noAutomaticForeground", 6, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("makeUserAvailableInForeground", 7, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("deviceId", 8, ThriftTypes.BINARY),
+                    ThriftDescriptor("isInitiallyForeground", 9, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("networkType", 10, ThriftTypes.INT_32),
+                    ThriftDescriptor("networkSubtype", 11, ThriftTypes.INT_32),
+                    ThriftDescriptor("clientMqttSessionId", 12, ThriftTypes.INT_64),
+                    ThriftDescriptor("clientIpAddress", 13, ThriftTypes.BINARY),
+                    ThriftDescriptor("subscribeTopics", 14, ThriftTypes.LIST_INT_32),
+                    ThriftDescriptor("clientType", 15, ThriftTypes.BINARY),
+                    ThriftDescriptor("appId", 16, ThriftTypes.INT_64),
+                    ThriftDescriptor("overrideNectarLogging", 17, ThriftTypes.BOOLEAN),
+                    ThriftDescriptor("connectTokenHash", 18, ThriftTypes.BINARY),
+                    ThriftDescriptor("regionPreference", 19, ThriftTypes.BINARY),
+                    ThriftDescriptor("deviceSecret", 20, ThriftTypes.BINARY),
+                    ThriftDescriptor("clientStack", 21, ThriftTypes.BYTE),
+                    ThriftDescriptor("fbnsConnectionKey", 22, ThriftTypes.INT_64),
+                    ThriftDescriptor("fbnsConnectionSecret", 23, ThriftTypes.BINARY),
+                    ThriftDescriptor("fbnsDeviceId", 24, ThriftTypes.BINARY),
+                    ThriftDescriptor("fbnsDeviceSecret", 25, ThriftTypes.BINARY),
+                    ThriftDescriptor("anotherUnknown", 26, ThriftTypes.INT_64),
+                ),
+            ),
+            ThriftDescriptor("password", 5, ThriftTypes.BINARY),
+            ThriftDescriptor("getDiffsRequests", 6, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("zeroRatingTokenHash", 9, ThriftTypes.BINARY),
+            ThriftDescriptor("appSpecificInfo", 10, ThriftTypes.MAP_BINARY_BINARY),
+        ]
+
+    def to_thrift(self) -> bytes:
+        payload: Dict[str, Any] = {
+            "clientIdentifier": self.client_identifier,
+            "clientInfo": self.client_info,
+            "password": self.password,
+        }
+        if self.app_specific_info:
+            payload["appSpecificInfo"] = self.app_specific_info
+        return write_thrift_object(payload, self.thrift_descriptors())
+
+
+def compress_payload(data: bytes) -> bytes:
+    return zlib.compress(data, level=9)
+
+
+def try_decompress_payload(data: bytes) -> bytes:
+    if not data or data[0] != 0x78:
+        return data
+    try:
+        return zlib.decompress(data)
+    except zlib.error:
+        return data
+
+
+def write_connect_packet(connection: MQTToTConnection, keep_alive: int = 20) -> bytes:
+    payload = compress_payload(connection.to_thrift())
+    variable_header = _write_utf8("MQTToT") + bytes([3, 0xC2]) + struct.pack("!H", keep_alive)
+    remaining = variable_header + payload
+    return bytes([0x10]) + _encode_remaining_length(len(remaining)) + remaining
+
+
+def write_publish_packet(topic: str, payload: bytes, qos: int = 1, packet_id: int = 1) -> bytes:
+    if qos not in (0, 1):
+        raise ValueError("Only QoS 0 and QoS 1 are supported")
+    variable_header = _write_utf8(str(topic))
+    if qos:
+        variable_header += struct.pack("!H", packet_id)
+    body = variable_header + payload
+    fixed_header = bytes([0x30 | (qos << 1)]) + _encode_remaining_length(len(body))
+    return fixed_header + body
+
+
+def write_subscribe_packet(topic: str, packet_id: int = 1, qos: int = 1) -> bytes:
+    body = struct.pack("!H", packet_id) + _write_utf8(str(topic)) + bytes([qos])
+    return bytes([0x82]) + _encode_remaining_length(len(body)) + body
+
+
+def write_pingreq_packet() -> bytes:
+    return b"\xc0\x00"
+
+
+def write_disconnect_packet() -> bytes:
+    return b"\xe0\x00"
+
+
+def decode_packet(packet: bytes) -> DecodedMQTToTPacket:
+    packet_type_id = packet[0] >> 4
+    flags = packet[0] & 0x0F
+    remaining_length, offset = _decode_remaining_length(packet, 1)
+    body = packet[offset : offset + remaining_length]
+    if packet_type_id == 1:
+        protocol_name, pos = _read_utf8(body, 0)
+        protocol_level = body[pos]
+        connect_flags = body[pos + 1]
+        keep_alive = struct.unpack("!H", body[pos + 2 : pos + 4])[0]
+        payload = body[pos + 4 :]
+        return DecodedMQTToTPacket(
+            packet_type="connect",
+            protocol_name=protocol_name,
+            protocol_level=protocol_level,
+            connect_flags=connect_flags,
+            keep_alive=keep_alive,
+            payload=payload,
+        )
+    if packet_type_id == 2:
+        return DecodedMQTToTPacket(
+            packet_type="connack",
+            return_code=body[1],
+            payload=body[2:],
+        )
+    if packet_type_id == 3:
+        topic, pos = _read_utf8(body, 0)
+        qos = (flags >> 1) & 0x03
+        packet_id = None
+        if qos:
+            packet_id = struct.unpack("!H", body[pos : pos + 2])[0]
+            pos += 2
+        return DecodedMQTToTPacket(
+            packet_type="publish",
+            topic=topic,
+            qos=qos,
+            packet_id=packet_id,
+            payload=body[pos:],
+        )
+    return DecodedMQTToTPacket(packet_type=str(packet_type_id), payload=body)
+
+
+def write_thrift_object(data: Dict[str, Any], descriptors: List[ThriftDescriptor]) -> bytes:
+    writer = _ThriftWriter()
+    _write_thrift_struct(writer, data, descriptors)
+    writer.write_stop()
+    return bytes(writer.buffer)
+
+
+def read_thrift_object(data: bytes, descriptors: List[ThriftDescriptor]) -> Dict[str, Any]:
+    return _ThriftReader(data).read_struct(descriptors)
+
+
+class SocketMQTToTTransport:
+    def __init__(self, host: str, port: int = 443, timeout: float = 30.0, tls_context: Optional[ssl.SSLContext] = None):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.tls_context = tls_context or ssl.create_default_context()
+        self.sock = None
+
+    def connect(self) -> None:
+        raw = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        self.sock = self.tls_context.wrap_socket(raw, server_hostname=self.host)
+        self.sock.settimeout(self.timeout)
+
+    def send(self, packet: bytes) -> None:
+        if self.sock is None:
+            raise RuntimeError("Transport is not connected")
+        self.sock.sendall(packet)
+
+    def recv_packet(self) -> bytes:
+        if self.sock is None:
+            raise RuntimeError("Transport is not connected")
+        first = _recv_exact(self.sock, 1)
+        remaining = bytearray()
+        while True:
+            byte = _recv_exact(self.sock, 1)
+            remaining.extend(byte)
+            if byte[0] & 0x80 == 0:
+                break
+        size, _ = _decode_remaining_length(bytes(remaining), 0)
+        return first + bytes(remaining) + _recv_exact(self.sock, size)
+
+    def disconnect(self) -> None:
+        if self.sock is None:
+            return
+        try:
+            self.sock.close()
+        finally:
+            self.sock = None
+
+
+class _ThriftWriter:
+    def __init__(self):
+        self.buffer = bytearray()
+        self._field_stack: List[int] = []
+        self._field = 0
+
+    def write_stop(self) -> None:
+        self.buffer.append(ThriftTypes.STOP)
+        if self._field_stack:
+            self._field = self._field_stack.pop()
+
+    def write_field(self, field: int, field_type: int) -> None:
+        delta = field - self._field
+        thrift_type = field_type & 0x0F
+        if 0 < delta <= 15:
+            self.buffer.append((delta << 4) | thrift_type)
+        else:
+            self.buffer.append(thrift_type)
+            self.write_varint(_zigzag(field, 16))
+        self._field = field
+
+    def write_varint(self, value: int) -> None:
+        while True:
+            if value & ~0x7F == 0:
+                self.buffer.append(value)
+                return
+            self.buffer.append((value & 0x7F) | 0x80)
+            value >>= 7
+
+    def write_varbigint(self, value: int) -> None:
+        self.write_varint(value)
+
+    def write_string_direct(self, value: str) -> None:
+        raw = value.encode()
+        self.write_varint(len(raw))
+        self.buffer.extend(raw)
+
+    def write_string(self, field: int, value: str) -> None:
+        self.write_field(field, ThriftTypes.BINARY)
+        self.write_string_direct(value)
+
+    def write_bool(self, field: int, value: bool) -> None:
+        self.write_field(field, ThriftTypes.TRUE if value else ThriftTypes.FALSE)
+
+    def write_int(self, field: int, value: int, bits: int) -> None:
+        field_type = {8: ThriftTypes.BYTE, 16: ThriftTypes.INT_16, 32: ThriftTypes.INT_32, 64: ThriftTypes.INT_64}[bits]
+        self.write_field(field, field_type)
+        if bits == 8:
+            self.buffer.extend(struct.pack("b", value))
+        elif bits == 64:
+            self.write_varbigint(_zigzag(value, 64))
+        else:
+            self.write_varint(_zigzag(value, bits))
+
+    def push_struct(self, field: int) -> None:
+        self.write_field(field, ThriftTypes.STRUCT)
+        self._field_stack.append(self._field)
+        self._field = 0
+
+
+class _ThriftReader:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.pos = 0
+        self._field_stack: List[int] = []
+        self._field = 0
+
+    def read_struct(self, descriptors: List[ThriftDescriptor]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        while self.pos < len(self.data):
+            field_type = self.read_field()
+            if field_type == ThriftTypes.STOP:
+                if self._field_stack:
+                    self._field = self._field_stack.pop()
+                break
+            descriptor = _find_descriptor(descriptors, self._field, field_type)
+            value = self.read_value(field_type, descriptor)
+            if descriptor:
+                result[descriptor.name] = value
+        return result
+
+    def read_field(self) -> int:
+        byte = self.read_byte()
+        if byte == ThriftTypes.STOP:
+            return ThriftTypes.STOP
+        delta = (byte & 0xF0) >> 4
+        if delta:
+            self._field += delta
+        else:
+            self._field = _unzigzag(self.read_varint())
+        return byte & 0x0F
+
+    def read_value(self, field_type: int, descriptor: Optional[ThriftDescriptor]) -> Any:
+        if field_type == ThriftTypes.TRUE:
+            return True
+        if field_type == ThriftTypes.FALSE:
+            return False
+        if field_type == ThriftTypes.BYTE:
+            return struct.unpack("b", self.read_bytes(1))[0]
+        if field_type in (ThriftTypes.INT_16, ThriftTypes.INT_32):
+            return _unzigzag(self.read_varint())
+        if field_type == ThriftTypes.INT_64:
+            return _unzigzag(self.read_varint())
+        if field_type == ThriftTypes.BINARY:
+            return self.read_bytes(self.read_varint()).decode()
+        if field_type == ThriftTypes.LIST:
+            return self.read_list()
+        if field_type == ThriftTypes.MAP:
+            return self.read_map()
+        if field_type == ThriftTypes.STRUCT:
+            self._field_stack.append(self._field)
+            self._field = 0
+            return self.read_struct(list(descriptor.children) if descriptor else [])
+        raise ValueError(f"Unsupported thrift type: {field_type}")
+
+    def read_list(self) -> List[Any]:
+        header = self.read_byte()
+        size = header >> 4
+        item_type = header & 0x0F
+        if size == 0x0F:
+            size = self.read_varint()
+        items = []
+        for _ in range(size):
+            items.append(self.read_value(item_type, None))
+        return items
+
+    def read_map(self) -> Dict[str, str]:
+        size = self.read_varint()
+        if not size:
+            return {}
+        item_types = self.read_byte()
+        key_type = (item_types & 0xF0) >> 4
+        value_type = item_types & 0x0F
+        result = {}
+        for _ in range(size):
+            key = self.read_value(key_type, None)
+            value = self.read_value(value_type, None)
+            result[key] = value
+        return result
+
+    def read_byte(self) -> int:
+        value = self.data[self.pos]
+        self.pos += 1
+        return value
+
+    def read_bytes(self, size: int) -> bytes:
+        value = self.data[self.pos : self.pos + size]
+        self.pos += size
+        return value
+
+    def read_varint(self) -> int:
+        shift = 0
+        result = 0
+        while self.pos < len(self.data):
+            byte = self.read_byte()
+            result |= (byte & 0x7F) << shift
+            if byte & 0x80 == 0:
+                break
+            shift += 7
+        return result
+
+
+def _write_thrift_struct(writer: _ThriftWriter, data: Dict[str, Any], descriptors: List[ThriftDescriptor]) -> None:
+    by_name = {descriptor.name: descriptor for descriptor in descriptors}
+    for name, value in data.items():
+        if value is None:
+            continue
+        descriptor = by_name[name]
+        thrift_type = descriptor.type & 0xFF
+        if thrift_type == ThriftTypes.BOOLEAN:
+            writer.write_bool(descriptor.field, bool(value))
+        elif thrift_type == ThriftTypes.BYTE:
+            writer.write_int(descriptor.field, int(value), 8)
+        elif thrift_type == ThriftTypes.INT_16:
+            writer.write_int(descriptor.field, int(value), 16)
+        elif thrift_type == ThriftTypes.INT_32:
+            writer.write_int(descriptor.field, int(value), 32)
+        elif thrift_type == ThriftTypes.INT_64:
+            writer.write_int(descriptor.field, int(value), 64)
+        elif thrift_type == ThriftTypes.BINARY:
+            writer.write_string(descriptor.field, str(value))
+        elif thrift_type == ThriftTypes.STRUCT:
+            writer.push_struct(descriptor.field)
+            _write_thrift_struct(writer, value, list(descriptor.children))
+            writer.write_stop()
+        elif thrift_type == ThriftTypes.LIST:
+            writer.write_field(descriptor.field, ThriftTypes.LIST)
+            item_type = descriptor.type >> 8
+            _write_thrift_list(writer, item_type, value)
+        elif thrift_type == ThriftTypes.MAP:
+            _write_thrift_map(writer, descriptor.field, value)
+        else:
+            raise ValueError(f"Unsupported thrift type: {descriptor.type}")
+
+
+def _write_thrift_list(writer: _ThriftWriter, item_type: int, values: List[Any]) -> None:
+    size = len(values)
+    if size < 0x0F:
+        writer.buffer.append((size << 4) | item_type)
+    else:
+        writer.buffer.append(0xF0 | item_type)
+        writer.write_varint(size)
+    for value in values:
+        if item_type == ThriftTypes.INT_32:
+            writer.write_varint(_zigzag(int(value), 32))
+        elif item_type == ThriftTypes.BINARY:
+            writer.write_string_direct(str(value))
+        else:
+            raise ValueError(f"Unsupported thrift list type: {item_type}")
+
+
+def _write_thrift_map(writer: _ThriftWriter, field: int, values: Dict[str, str]) -> None:
+    writer.write_field(field, ThriftTypes.MAP)
+    writer.write_varint(len(values))
+    if not values:
+        return
+    writer.buffer.append((ThriftTypes.BINARY << 4) | ThriftTypes.BINARY)
+    for key, value in values.items():
+        writer.write_string_direct(str(key))
+        writer.write_string_direct(str(value))
+
+
+def _find_descriptor(
+    descriptors: List[ThriftDescriptor],
+    field: int,
+    field_type: int,
+) -> Optional[ThriftDescriptor]:
+    for descriptor in descriptors:
+        descriptor_type = descriptor.type & 0x0F
+        if descriptor.field != field:
+            continue
+        if descriptor_type == field_type or (
+            descriptor.type == ThriftTypes.BOOLEAN and field_type in (ThriftTypes.TRUE, ThriftTypes.FALSE)
+        ):
+            return descriptor
+    return None
+
+
+def _write_utf8(value: str) -> bytes:
+    raw = value.encode()
+    return struct.pack("!H", len(raw)) + raw
+
+
+def _read_utf8(data: bytes, offset: int) -> tuple[str, int]:
+    size = struct.unpack("!H", data[offset : offset + 2])[0]
+    offset += 2
+    return data[offset : offset + size].decode(), offset + size
+
+
+def _encode_remaining_length(value: int) -> bytes:
+    encoded = bytearray()
+    while True:
+        byte = value % 128
+        value //= 128
+        if value:
+            byte |= 0x80
+        encoded.append(byte)
+        if not value:
+            return bytes(encoded)
+
+
+def _decode_remaining_length(data: bytes, offset: int) -> tuple[int, int]:
+    multiplier = 1
+    value = 0
+    while True:
+        encoded_byte = data[offset]
+        offset += 1
+        value += (encoded_byte & 127) * multiplier
+        if encoded_byte & 128 == 0:
+            return value, offset
+        multiplier *= 128
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            raise ConnectionError("Socket closed while reading MQTT packet")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _zigzag(value: int, bits: int) -> int:
+    return (value << 1) ^ (value >> (bits - 1))
+
+
+def _unzigzag(value: int) -> int:
+    return (value >> 1) ^ -(value & 1)
+
+
+def parse_json_payload(payload: bytes) -> Any:
+    return json.loads(try_decompress_payload(payload).decode())
+
+
+RealtimeHandler = Callable[[Any], None]

--- a/instagrapi/realtime/mqttot.py
+++ b/instagrapi/realtime/mqttot.py
@@ -5,6 +5,9 @@ import struct
 import zlib
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import unquote, urlsplit
+
+import socks
 
 
 class MQTToTTopics:
@@ -226,17 +229,58 @@ def read_thrift_object(data: bytes, descriptors: List[ThriftDescriptor]) -> Dict
 
 
 class SocketMQTToTTransport:
-    def __init__(self, host: str, port: int = 443, timeout: float = 30.0, tls_context: Optional[ssl.SSLContext] = None):
+    def __init__(
+        self,
+        host: str,
+        port: int = 443,
+        timeout: float = 30.0,
+        tls_context: Optional[ssl.SSLContext] = None,
+        proxy: Optional[str] = None,
+    ):
         self.host = host
         self.port = port
         self.timeout = timeout
         self.tls_context = tls_context or ssl.create_default_context()
+        self.proxy = proxy
         self.sock = None
 
     def connect(self) -> None:
-        raw = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        raw = (
+            self._create_proxy_connection()
+            if self.proxy
+            else socket.create_connection((self.host, self.port), timeout=self.timeout)
+        )
         self.sock = self.tls_context.wrap_socket(raw, server_hostname=self.host)
         self.sock.settimeout(self.timeout)
+
+    def _create_proxy_connection(self):
+        proxy = self.proxy or ""
+        if "://" not in proxy:
+            proxy = f"http://{proxy}"
+        parsed = urlsplit(proxy)
+        proxy_types = {
+            "http": socks.HTTP,
+            "https": socks.HTTP,
+            "socks4": socks.SOCKS4,
+            "socks4a": socks.SOCKS4,
+            "socks5": socks.SOCKS5,
+            "socks5h": socks.SOCKS5,
+        }
+        proxy_type = proxy_types.get(parsed.scheme)
+        if proxy_type is None or not parsed.hostname or parsed.port is None:
+            raise ValueError(f"Unsupported realtime proxy URL: {self.proxy}")
+        raw = socks.socksocket()
+        raw.settimeout(self.timeout)
+        raw.set_proxy(
+            proxy_type,
+            parsed.hostname,
+            parsed.port,
+            rdns=parsed.scheme in {"socks4a", "socks5h"},
+            username=unquote(parsed.username) if parsed.username else None,
+            password=unquote(parsed.password) if parsed.password else None,
+        )
+        raw.connect((self.host, self.port))
+        return raw
 
     def send(self, packet: bytes) -> None:
         if self.sock is None:

--- a/instagrapi/realtime/mqttot.py
+++ b/instagrapi/realtime/mqttot.py
@@ -205,6 +205,12 @@ def decode_packet(packet: bytes) -> DecodedMQTToTPacket:
             packet_id=packet_id,
             payload=body[pos:],
         )
+    if packet_type_id == 12:
+        return DecodedMQTToTPacket(packet_type="pingreq", payload=body)
+    if packet_type_id == 13:
+        return DecodedMQTToTPacket(packet_type="pingresp", payload=body)
+    if packet_type_id == 14:
+        return DecodedMQTToTPacket(packet_type="disconnect", payload=body)
     return DecodedMQTToTPacket(packet_type=str(packet_type_id), payload=body)
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - Collection: usage-guide/collection.md
     - Comment: usage-guide/comment.md
     - Direct: usage-guide/direct.md
+    - Realtime MQTT: usage-guide/realtime.md
     - Hashtag: usage-guide/hashtag.md
     - Highlight: usage-guide/highlight.md
     - Insight: usage-guide/insight.md

--- a/tests/live/test_realtime.py
+++ b/tests/live/test_realtime.py
@@ -36,7 +36,7 @@ class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
             return any(self.payload_contains(value, expected) for value in payload.values())
         if isinstance(payload, (list, tuple)):
             return any(self.payload_contains(value, expected) for value in payload)
-        return str(payload) == str(expected)
+        return str(expected) in str(payload)
 
     def payload_contains_message(self, payload, text, sender_id):
         return self.payload_contains(payload, text) and self.payload_contains(payload, sender_id)
@@ -55,8 +55,15 @@ class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
 
         receiver.realtime_on("message", received_payloads.append)
         try:
+            receiver.direct_threads(amount=1)
+            seq_id = receiver.last_json.get("seq_id")
+            snapshot_at_ms = receiver.last_json.get("snapshot_at_ms")
+            if seq_id is None or snapshot_at_ms is None:
+                self.skipTest("Direct inbox did not return realtime sync state")
+
             receiver.realtime_connect(transport=transport)
             self.assertTrue(receiver.realtime_ping())
+            receiver.realtime.iris_subscribe(seq_id=seq_id, snapshot_at_ms=snapshot_at_ms)
 
             message = sender.direct_send(text, user_ids=[receiver.user_id])
             self.assertIsInstance(message, DirectMessage)

--- a/tests/live/test_realtime.py
+++ b/tests/live/test_realtime.py
@@ -30,3 +30,60 @@ class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(self.cl.realtime_ping())
         finally:
             self.cl.realtime_disconnect()
+
+    def payload_contains(self, payload, expected):
+        if isinstance(payload, dict):
+            return any(self.payload_contains(value, expected) for value in payload.values())
+        if isinstance(payload, (list, tuple)):
+            return any(self.payload_contains(value, expected) for value in payload)
+        return str(payload) == str(expected)
+
+    def payload_contains_message(self, payload, text, sender_id):
+        return self.payload_contains(payload, text) and self.payload_contains(payload, sender_id)
+
+    def test_realtime_receives_direct_message_sync_live(self):
+        receiver = self.cl
+        try:
+            sender = self.fresh_accounts(1, exclude_user_ids={receiver.user_id})[0]
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        received_payloads = []
+        message = None
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=10)
+        text = f"instagrapi realtime live {int(time.time())}"
+
+        receiver.realtime_on("message", received_payloads.append)
+        try:
+            receiver.realtime_connect(transport=transport)
+            self.assertTrue(receiver.realtime_ping())
+
+            message = sender.direct_send(text, user_ids=[receiver.user_id])
+            self.assertIsInstance(message, DirectMessage)
+
+            deadline = time.time() + 45
+            while time.time() < deadline:
+                try:
+                    receiver.realtime_read_once()
+                except TimeoutError:
+                    continue
+                for payload in received_payloads:
+                    if self.payload_contains_message(payload, text, sender.user_id):
+                        return
+
+            self.fail("Realtime MQTT did not deliver the Direct message sync payload")
+        finally:
+            receiver.realtime_disconnect()
+            if message:
+                try:
+                    sender.direct_message_unsend(message.thread_id, message.id)
+                except Exception as exc:
+                    logger.warning("Realtime Direct message cleanup unsend failed: %s", exc)
+                try:
+                    sender.direct_thread_hide(message.thread_id)
+                except Exception as exc:
+                    logger.warning("Realtime Direct message cleanup sender hide failed: %s", exc)
+                try:
+                    receiver.direct_thread_hide(message.thread_id)
+                except Exception as exc:
+                    logger.warning("Realtime Direct message cleanup receiver hide failed: %s", exc)

--- a/tests/live/test_realtime.py
+++ b/tests/live/test_realtime.py
@@ -1,0 +1,32 @@
+from instagrapi.realtime.client import REALTIME_HOST
+from instagrapi.realtime.mqttot import SocketMQTToTTransport
+from tests import helpers as _helpers
+from tests.helpers import *
+
+
+class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for Realtime live tests")
+        try:
+            self.cl = self.fresh_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def test_realtime_connect_and_ping_live(self):
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=15)
+
+        try:
+            realtime = self.cl.realtime_connect(transport=transport)
+
+            self.assertTrue(realtime.connected)
+            self.assertTrue(self.cl.realtime_ping())
+        finally:
+            self.cl.realtime_disconnect()

--- a/tests/live/test_realtime.py
+++ b/tests/live/test_realtime.py
@@ -21,7 +21,7 @@ class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
             self.skipTest(str(exc))
 
     def test_realtime_connect_and_ping_live(self):
-        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=15)
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=15, proxy=self.cl.proxy)
 
         try:
             realtime = self.cl.realtime_connect(transport=transport)
@@ -50,20 +50,17 @@ class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
 
         received_payloads = []
         message = None
-        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=10)
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=10, proxy=receiver.proxy)
         text = f"instagrapi realtime live {int(time.time())}"
 
         receiver.realtime_on("message", received_payloads.append)
         try:
-            receiver.direct_threads(amount=1)
-            seq_id = receiver.last_json.get("seq_id")
-            snapshot_at_ms = receiver.last_json.get("snapshot_at_ms")
-            if seq_id is None or snapshot_at_ms is None:
-                self.skipTest("Direct inbox did not return realtime sync state")
-
-            receiver.realtime_connect(transport=transport)
+            realtime = receiver.realtime_connect(transport=transport)
             self.assertTrue(receiver.realtime_ping())
-            receiver.realtime.iris_subscribe(seq_id=seq_id, snapshot_at_ms=snapshot_at_ms)
+            try:
+                realtime.direct_subscribe()
+            except RuntimeError as exc:
+                self.skipTest(str(exc))
 
             message = sender.direct_send(text, user_ids=[receiver.user_id])
             self.assertIsInstance(message, DirectMessage)

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -10,6 +10,7 @@ from instagrapi.realtime.mqttot import (
     decode_packet,
     read_thrift_object,
     write_connect_packet,
+    write_pingreq_packet,
     write_publish_packet,
 )
 
@@ -82,6 +83,13 @@ def test_publish_packet_round_trips_topic_and_zipped_payload():
     assert json.loads(zlib.decompress(decoded.payload)) == {"sub": ["1/graphqlsubscriptions/test/{}"]}
 
 
+def test_ping_response_packet_decodes_as_pingresp():
+    decoded = decode_packet(b"\xd0\x00")
+
+    assert decoded.packet_type == "pingresp"
+    assert decoded.payload == b""
+
+
 def test_realtime_client_builds_cookie_auth_connection_from_instagram_session():
     client = _build_logged_in_client()
     realtime = RealtimeClient(client)
@@ -108,6 +116,28 @@ def test_client_exposes_stateful_realtime_helpers():
 
     client.realtime_disconnect()
     transport.disconnect.assert_called_once()
+
+
+def test_realtime_client_ping_sends_keepalive_and_reads_pingresp():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    transport.recv_packet.return_value = b"\xd0\x00"
+    realtime = RealtimeClient(client, transport=transport)
+    realtime.connected = True
+
+    assert realtime.ping()
+
+    transport.send.assert_called_once_with(write_pingreq_packet())
+    transport.recv_packet.assert_called_once()
+
+
+def test_client_exposes_stateful_realtime_ping_helper():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    transport.recv_packet.return_value = b"\xd0\x00"
+    client.realtime_connect(transport=transport)
+
+    assert client.realtime_ping()
 
 
 def test_realtime_connect_preserves_handlers_registered_before_connect():

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -1,0 +1,122 @@
+import json
+import zlib
+from unittest import mock
+
+from instagrapi import Client
+from instagrapi.realtime import RealtimeClient
+from instagrapi.realtime.mqttot import (
+    MQTToTConnection,
+    MQTToTTopics,
+    decode_packet,
+    read_thrift_object,
+    write_connect_packet,
+    write_publish_packet,
+)
+
+
+def _build_logged_in_client():
+    client = Client()
+    client.authorization_data = {"ds_user_id": "12345", "sessionid": "12345:session"}
+    client.phone_id = "phone-id-12345678901234567890"
+    client.uuid = "uuid-1"
+    client.user_agent = "Instagram 428.0.0.47.67 Android"
+    client.app_version = "428.0.0.47.67"
+    client.capabilities = "3brTvw=="
+    client.locale = "en_US"
+    return client
+
+
+def test_mqttot_connect_packet_uses_custom_protocol_and_zipped_thrift_payload():
+    connection = MQTToTConnection(
+        client_identifier="phone-id-123456789",
+        client_info={
+            "userId": 12345,
+            "userAgent": "Instagram 428",
+            "clientCapabilities": 183,
+            "endpointCapabilities": 0,
+            "publishFormat": 1,
+            "deviceId": "phone-id-12345678901234567890",
+            "isInitiallyForeground": True,
+            "subscribeTopics": [88, 135, 149, 150, 133, 146],
+            "clientType": "cookie_auth",
+            "appId": 567067343352427,
+            "clientStack": 3,
+        },
+        password="sessionid=12345:session",
+        app_specific_info={
+            "app_version": "428.0.0.47.67",
+            "platform": "android",
+            "ig_mqtt_route": "django",
+        },
+    )
+
+    packet = write_connect_packet(connection, keep_alive=20)
+
+    assert packet[0] == 0x10
+    decoded = decode_packet(packet)
+    assert decoded.packet_type == "connect"
+    assert decoded.protocol_name == "MQTToT"
+    assert decoded.protocol_level == 3
+    assert decoded.connect_flags == 0xC2
+    assert decoded.keep_alive == 20
+
+    thrift_payload = zlib.decompress(decoded.payload)
+    thrift = read_thrift_object(thrift_payload, MQTToTConnection.thrift_descriptors())
+    assert thrift["clientIdentifier"] == "phone-id-123456789"
+    assert thrift["password"] == "sessionid=12345:session"
+    assert thrift["clientInfo"]["clientType"] == "cookie_auth"
+    assert thrift["clientInfo"]["subscribeTopics"] == [88, 135, 149, 150, 133, 146]
+    assert thrift["appSpecificInfo"]["ig_mqtt_route"] == "django"
+
+
+def test_publish_packet_round_trips_topic_and_zipped_payload():
+    payload = zlib.compress(json.dumps({"sub": ["1/graphqlsubscriptions/test/{}"]}).encode())
+
+    packet = write_publish_packet(MQTToTTopics.REALTIME_SUB, payload, qos=1, packet_id=7)
+
+    decoded = decode_packet(packet)
+    assert decoded.packet_type == "publish"
+    assert decoded.topic == MQTToTTopics.REALTIME_SUB
+    assert decoded.qos == 1
+    assert decoded.packet_id == 7
+    assert json.loads(zlib.decompress(decoded.payload)) == {"sub": ["1/graphqlsubscriptions/test/{}"]}
+
+
+def test_realtime_client_builds_cookie_auth_connection_from_instagram_session():
+    client = _build_logged_in_client()
+    realtime = RealtimeClient(client)
+
+    connection = realtime.build_connection()
+
+    assert connection.client_identifier == "phone-id-12345678901"
+    assert connection.password == "sessionid=12345:session"
+    assert connection.client_info["userId"] == 12345
+    assert connection.client_info["clientType"] == "cookie_auth"
+    assert connection.client_info["appId"] == 567067343352427
+    assert connection.client_info["subscribeTopics"] == [88, 135, 149, 150, 133, 146]
+    assert connection.app_specific_info["app_version"] == "428.0.0.47.67"
+    assert connection.app_specific_info["platform"] == "android"
+
+
+def test_client_exposes_stateful_realtime_helpers():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    client.realtime_connect(transport=transport)
+
+    assert isinstance(client.realtime, RealtimeClient)
+    transport.connect.assert_called_once()
+
+    client.realtime_disconnect()
+    transport.disconnect.assert_called_once()
+
+
+def test_realtime_connect_preserves_handlers_registered_before_connect():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    handler = mock.Mock()
+
+    client.realtime_on("receive", handler)
+    client.realtime_connect(transport=transport)
+    client.realtime.emit("receive", {"topic": "146", "payload": {"ok": True}})
+
+    handler.assert_called_once_with({"topic": "146", "payload": {"ok": True}})

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -7,6 +7,7 @@ from instagrapi.realtime import RealtimeClient
 from instagrapi.realtime.mqttot import (
     MQTToTConnection,
     MQTToTTopics,
+    SocketMQTToTTransport,
     decode_packet,
     read_thrift_object,
     write_connect_packet,
@@ -106,6 +107,16 @@ def test_realtime_client_builds_cookie_auth_connection_from_instagram_session():
     assert connection.app_specific_info["platform"] == "android"
 
 
+def test_realtime_client_default_transport_uses_client_proxy():
+    client = _build_logged_in_client()
+    client.proxy = "socks5://127.0.0.1:8888"
+
+    realtime = RealtimeClient(client)
+
+    assert isinstance(realtime.transport, SocketMQTToTTransport)
+    assert realtime.transport.proxy == "socks5://127.0.0.1:8888"
+
+
 def test_client_exposes_stateful_realtime_helpers():
     client = _build_logged_in_client()
     transport = mock.Mock()
@@ -155,6 +166,32 @@ def test_realtime_client_iris_subscribe_publishes_inbox_sync_state():
             "snapshot_app_version": "428.0.0.47.67",
         },
     )
+
+
+def test_realtime_client_iris_subscribe_uses_device_settings_app_version():
+    client = _build_logged_in_client()
+    del client.app_version
+    client.device_settings = {"app_version": "428.0.0.47.67"}
+    realtime = RealtimeClient(client, transport=mock.Mock())
+
+    with mock.patch.object(realtime, "publish_json") as publish_json:
+        realtime.iris_subscribe(seq_id=123, snapshot_at_ms=456)
+
+    assert publish_json.call_args.args[1]["snapshot_app_version"] == "428.0.0.47.67"
+
+
+def test_realtime_client_direct_subscribe_fetches_inbox_and_subscribes_to_iris():
+    client = _build_logged_in_client()
+    client.last_json = {"seq_id": 123, "snapshot_at_ms": 456}
+    client.direct_threads = mock.Mock(return_value=[])
+    realtime = RealtimeClient(client, transport=mock.Mock())
+
+    with mock.patch.object(realtime, "iris_subscribe") as iris_subscribe:
+        state = realtime.direct_subscribe()
+
+    client.direct_threads.assert_called_once_with(amount=1)
+    iris_subscribe.assert_called_once_with(seq_id=123, snapshot_at_ms=456)
+    assert state == {"seq_id": 123, "snapshot_at_ms": 456}
 
 
 def test_message_sync_dispatch_emits_direct_message_wrapper():

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -140,6 +140,53 @@ def test_client_exposes_stateful_realtime_ping_helper():
     assert client.realtime_ping()
 
 
+def test_realtime_client_iris_subscribe_publishes_inbox_sync_state():
+    client = _build_logged_in_client()
+    realtime = RealtimeClient(client, transport=mock.Mock())
+
+    with mock.patch.object(realtime, "publish_json") as publish_json:
+        realtime.iris_subscribe(seq_id=123, snapshot_at_ms=456)
+
+    publish_json.assert_called_once_with(
+        MQTToTTopics.IRIS_SUB,
+        {
+            "seq_id": 123,
+            "snapshot_at_ms": 456,
+            "snapshot_app_version": "428.0.0.47.67",
+        },
+    )
+
+
+def test_message_sync_dispatch_emits_direct_message_wrapper():
+    client = _build_logged_in_client()
+    realtime = RealtimeClient(client, transport=mock.Mock())
+    handler = mock.Mock()
+    realtime.on("message", handler)
+    payload = [
+        {
+            "event": "patch",
+            "seq_id": 123,
+            "data": [
+                {
+                    "op": "add",
+                    "path": "/direct_v2/threads/987/items/item-1",
+                    "value": json.dumps({"item_id": "item-1", "text": "hello", "user_id": "55"}),
+                }
+            ],
+        }
+    ]
+
+    realtime.dispatch_packet(MQTToTTopics.MESSAGE_SYNC, zlib.compress(json.dumps(payload).encode()))
+
+    handler.assert_called_once()
+    message = handler.call_args.args[0]["message"]
+    assert message["thread_id"] == "987"
+    assert message["path"] == "/direct_v2/threads/987/items/item-1"
+    assert message["op"] == "add"
+    assert message["text"] == "hello"
+    assert message["user_id"] == "55"
+
+
 def test_realtime_connect_preserves_handlers_registered_before_connect():
     client = _build_logged_in_client()
     transport = mock.Mock()


### PR DESCRIPTION
## Summary
- add an experimental MQTToT packet/thrift codec and TLS socket transport
- add `RealtimeClient` plus stateful `Client.realtime_*` helpers, including keepalive `realtime_ping()` and high-level `rt.direct_subscribe()` for Direct message sync
- route realtime sockets through the configured `Client.proxy` by default
- document the receive-only realtime workflow and add MIT attribution for the public reference implementation

## Scope
This is a receive-only foundation for https://github.com/subzeroid/instagrapi/issues/2230. FBNS device auth, background worker management, and MQTT direct-send actions remain future work.

Reference: https://github.com/Nerixyz/instagram_mqtt

## Tests
- `.venv/bin/ruff check instagrapi/realtime instagrapi/mixins/realtime.py tests/regression/test_realtime.py tests/live/test_realtime.py`
- `.venv/bin/ruff format --check instagrapi/realtime instagrapi/mixins/realtime.py tests/regression/test_realtime.py tests/live/test_realtime.py`
- `.venv/bin/python -m pytest -q tests/regression/test_realtime.py tests/regression/test_direct.py`
- `.venv/bin/python -m pytest -q tests/live/test_realtime.py -s`
- `.venv/bin/mkdocs build --strict`