### PR TITLE
Fix username normalization for lookup helpers

### DIFF
--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -55,6 +55,10 @@ class UserMixin:
     _users_followers = {}  # user_pk -> dict(user_pk -> "short user object")
     _fb_dtsg = None
 
+    @staticmethod
+    def _normalize_username(username: str) -> str:
+        return str(username).strip().lstrip("@").strip().lower()
+
     def user_id_from_username(self, username: str) -> str:
         """
         Get full media id
@@ -73,7 +77,7 @@ class UserMixin:
         -------
         'example' -> 1903424587
         """
-        username = str(username).lower()
+        username = self._normalize_username(username)
         return str(self.user_info_by_username(username).pk)
 
     def user_short_gql(self, user_id: str, use_cache: bool = True) -> UserShort:
@@ -206,7 +210,7 @@ class UserMixin:
         User
             An object of User type
         """
-        username = str(username).lower()
+        username = self._normalize_username(username)
         temporary_public_headers = {
             "Host": "www.instagram.com",
             "X-Requested-With": "XMLHttpRequest",
@@ -267,7 +271,7 @@ class UserMixin:
         """
         Resolve username via doc_id search, then fetch profile by user id.
         """
-        username = str(username).lower()
+        username = self._normalize_username(username)
         self._inject_sessionid_for_v2_gql()
         data = self.public_doc_id_graphql_request("26347858941511777", {"hasQuery": True, "query": username})
         users = ((data or {}).get("xdt_api__v1__fbsearch__non_profiled_serp") or {}).get("users") or []
@@ -304,7 +308,7 @@ class UserMixin:
         User
             An object of User type
         """
-        username = str(username).lower()
+        username = self._normalize_username(username)
         try:
             result = self.private_request(f"users/{username}/usernameinfo/")
         except ClientNotFoundError as e:
@@ -331,7 +335,7 @@ class UserMixin:
         User
             An object of User type
         """
-        username = str(username).lower()
+        username = self._normalize_username(username)
         if not use_cache or username not in self._usernames_cache:
             try:
                 try:
@@ -1711,7 +1715,7 @@ class UserMixin:
         UserNotFound
             On 404 / unknown ClientError.
         """
-        username = str(username).lower()
+        username = self._normalize_username(username)
         data = {
             "is_prefetch": False,
             "entry_point": "profile",
@@ -1829,6 +1833,7 @@ class UserMixin:
         dict
             Merged user dict.
         """
+        username = self._normalize_username(username)
         resp = self.user_stream_by_username_v1(username)
         return self._user_stream_collector(resp, username=username)
 
@@ -1857,6 +1862,7 @@ class UserMixin:
         UserNotFound
             ``data`` is missing from the response or the request 404'd.
         """
+        username = self._normalize_username(username)
         try:
             result = self.private_request(
                 "users/web_profile_info/",

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -133,6 +133,109 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(client.public_request_calls[0]["kwargs"], {})
         self.assertIn("web_profile_info/?username=example", client.public_request_calls[0]["url"])
 
+    def test_user_info_by_username_gql_normalizes_username(self):
+        class DummyClient(UserMixin):
+            response_body = None
+
+            def __init__(self):
+                self.public_request_calls = []
+
+            def public_request(self, url, headers=None, **kwargs):
+                self.public_request_calls.append({"url": url, "headers": headers, "kwargs": kwargs})
+                return json.dumps(self.response_body)
+
+        client = DummyClient()
+        client.response_body = self.build_web_profile_user()
+
+        user = client.user_info_by_username_gql(" @Example ")
+
+        self.assertEqual(user.username, "example")
+        self.assertIn("web_profile_info/?username=example", client.public_request_calls[0]["url"])
+
+    def test_user_info_by_username_v1_normalizes_username(self):
+        client = Client()
+        payload = {
+            "user": {
+                "pk": "123",
+                "username": "example",
+                "full_name": "Example",
+                "is_private": False,
+                "is_verified": False,
+                "profile_pic_url": "https://example.com/pic.jpg",
+                "media_count": 0,
+                "follower_count": 0,
+                "following_count": 0,
+                "is_business": False,
+            }
+        }
+
+        with mock.patch.object(client, "private_request", return_value=payload) as private_request:
+            user = client.user_info_by_username_v1(" @Example ")
+
+        self.assertEqual(user.username, "example")
+        private_request.assert_called_once_with("users/example/usernameinfo/")
+
+    def test_user_info_by_username_uses_normalized_cache_key(self):
+        client = Client()
+        client._usernames_cache = {}
+        client._users_cache = {}
+        user = User(
+            pk="123",
+            username="example",
+            full_name="Example",
+            is_private=False,
+            is_verified=False,
+            profile_pic_url="https://example.com/pic.jpg",
+            media_count=0,
+            follower_count=0,
+            following_count=0,
+            is_business=False,
+        )
+
+        with mock.patch.object(client, "user_info_by_username_gql", return_value=user) as gql:
+            with mock.patch.object(client, "user_info", return_value=user):
+                client.user_info_by_username("@Example")
+                client.user_info_by_username(" example ")
+
+        gql.assert_called_once_with("example")
+        self.assertEqual(client._usernames_cache, {"example": "123"})
+
+    def test_user_info_by_username_v2_gql_normalizes_search_query(self):
+        client = Client()
+        with mock.patch.object(client, "_inject_sessionid_for_v2_gql"):
+            with mock.patch.object(
+                client,
+                "public_doc_id_graphql_request",
+                return_value={
+                    "xdt_api__v1__fbsearch__non_profiled_serp": {"users": [{"username": "example", "pk": "123"}]}
+                },
+            ) as search:
+                with mock.patch.object(client, "user_info_v2_gql", return_value="user"):
+                    result = client.user_info_by_username_v2_gql(" @Example ")
+
+        self.assertEqual(result, "user")
+        search.assert_called_once_with("26347858941511777", {"hasQuery": True, "query": "example"})
+
+    def test_user_stream_by_username_v1_normalizes_endpoint(self):
+        client = Client()
+        with mock.patch.object(client, "private_request", return_value={"stream_rows": []}) as private_request:
+            client.user_stream_by_username_v1(" @Example ")
+
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "users/example/usernameinfo_stream/")
+
+    def test_user_web_profile_info_v1_normalizes_username_param(self):
+        client = Client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"data": {"pk": "9", "username": "example"}},
+        ) as private_request:
+            user = client.user_web_profile_info_v1(" @Example ")
+
+        private_request.assert_called_once_with("users/web_profile_info/", params={"username": "example"})
+        self.assertEqual(user, {"pk": "9", "username": "example"})
+
     def test_user_info_by_username_suppresses_traceback_for_public_retry_error(self):
         client = Client()
         client._usernames_cache = {}


### PR DESCRIPTION
## Summary
- Normalize username lookup inputs by trimming whitespace, removing leading `@` prefixes, and lowercasing before request URLs, query variables, and cache lookups.
- Apply the normalization across public, private, GraphQL, web-profile, and username stream profile lookup helpers.
- Add regression coverage for normalized URLs, private endpoints, GraphQL search variables, web profile params, and cache keys.

Fixes #1968

## Test Coverage
All new code paths have regression coverage.

## Pre-Landing Review
No issues found in manual diff review.

## Design Review
No frontend files changed - design review skipped.

## Eval Results
No prompt-related files changed - evals skipped.

## Plan Completion
Implemented the approved plan for defensive username input normalization. Profile URL parsing remains intentionally out of scope; callers should still pass usernames, not full profile URLs.

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/regression/test_user.py`
- [x] `.venv/bin/python -m pytest -q tests/regression`
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m ruff format --check .`
- [x] `.venv/bin/python -m bandit -c pyproject.toml -r instagrapi`
- [x] `.venv/bin/python -m mkdocs build --strict`
- [x] `.venv/bin/python -m pre_commit run --all-files`
