### PR TITLE
feat: add private GraphQL followers helper

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -68,6 +68,8 @@ Low level methods:
 | user_followers_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's followers information by Public Graphql API                     |
 | user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "", order: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor). Supports `date_followed_latest` and `date_followed_earliest` |
 | user_followers_v1(user_id: str, amount: int = 0, order: str = None)                 | List[UserShort]             | Get user's followers information by Private Mobile API. Supports `date_followed_latest` and `date_followed_earliest` |
+| user_followers_private_gql_chunk(user_id: str, max_amount: int = 0, max_id: str = None, rank_token: str = None, order: str = None) | Tuple[List[UserShort], str] | Get user's followers through the private mobile GraphQL `FollowersList` surface and max_id cursor |
+| user_followers_private_gql(user_id: str, amount: int = 0, rank_token: str = None, order: str = None) | List[UserShort] | Get user's followers through the private mobile GraphQL `FollowersList` surface |
 | user_following_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's following users information by Private Mobile API               |
 | user_follow_requests_chunk(max_amount: int = 0, max_id: str = "")                   | Tuple[List[UserShort], str] | Get pending incoming follow requests by Private Mobile API and max_id      |
 | user_following_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
@@ -143,6 +145,12 @@ Raw private GraphQL helpers expose the same mobile `order` variable for callers 
 
 ``` python
 payload = cl.private_graphql_followers_list(cl.user_id, cl.rank_token, order="date_followed_latest")
+```
+
+Use `user_followers_private_gql()` when you want the current mobile GraphQL followers list parsed into `UserShort` objects:
+
+``` python
+followers = cl.user_followers_private_gql(cl.user_id, amount=50, order="date_followed_latest")
 ```
 
 Example: We go around the list of our followers and unfollow from them:

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -8,6 +8,7 @@ from requests.exceptions import RequestException
 
 from instagrapi.exceptions import (
     ClientError,
+    ClientGraphqlError,
     ClientJSONDecodeError,
     ClientLoginRequired,
     ClientNotFoundError,
@@ -969,6 +970,119 @@ class UserMixin:
             List of objects of User type
         """
         users, _ = self.user_followers_v1_chunk(str(user_id), amount, order=order)
+        if amount:
+            users = users[:amount]
+        return users
+
+    @staticmethod
+    def _private_graphql_root(data: Dict, root_field_name: str) -> Dict:
+        payload = data.get("data") or data
+        if not isinstance(payload, dict):
+            return {}
+        root = payload.get(root_field_name)
+        if isinstance(root, dict):
+            return root
+        for key, value in payload.items():
+            if root_field_name in str(key) and isinstance(value, dict):
+                return value
+        return {}
+
+    def user_followers_private_gql_chunk(
+        self,
+        user_id: str,
+        max_amount: int = 0,
+        max_id: str = None,
+        rank_token: str = None,
+        order: FOLLOWERS_ORDER = None,
+        priority: str = "u=3, i",
+    ) -> Tuple[List[UserShort], str]:
+        """
+        Get user's followers information by Private GraphQL API and max_id.
+
+        Parameters
+        ----------
+        user_id: str
+            User id of an instagram account
+        max_amount: int, optional
+            Maximum number of users to return from the fetched chunk, default is 0 - full chunk
+        max_id: str, optional
+            The cursor from which it is worth continuing to receive the list of followers
+        rank_token: str, optional
+            Rank token for the follow list request. Defaults to client rank_token
+        order: str, optional
+            Followers sort order: date_followed_latest or date_followed_earliest
+        priority: str, optional
+            GraphQL request priority header captured from the Android app
+
+        Returns
+        -------
+        Tuple[List[UserShort], str]
+            List of users and next max_id cursor
+        """
+        user_id = str(user_id)
+        result = self.private_graphql_followers_list(
+            user_id,
+            rank_token or self.rank_token,
+            max_id=max_id,
+            order=order,
+            priority=priority,
+        )
+        followers = self._private_graphql_root(result, "xdt_api__v1__friendships__followers")
+        if not followers:
+            raise ClientGraphqlError("Missing private GraphQL followers payload")
+        users = []
+        for user in followers.get("users") or []:
+            users.append(extract_user_short(user))
+            if max_amount and len(users) >= max_amount:
+                break
+        return users, followers.get("next_max_id")
+
+    def user_followers_private_gql(
+        self,
+        user_id: str,
+        amount: int = 0,
+        rank_token: str = None,
+        order: FOLLOWERS_ORDER = None,
+        priority: str = "u=3, i",
+    ) -> List[UserShort]:
+        """
+        Get user's followers information by Private GraphQL API.
+
+        Parameters
+        ----------
+        user_id: str
+            User id of an instagram account
+        amount: int, optional
+            Maximum number of users to return, default is 0 - Inf
+        rank_token: str, optional
+            Rank token for the follow list request. Defaults to client rank_token
+        order: str, optional
+            Followers sort order: date_followed_latest or date_followed_earliest
+        priority: str, optional
+            GraphQL request priority header captured from the Android app
+
+        Returns
+        -------
+        List[UserShort]
+            List of objects of UserShort type
+        """
+        users = []
+        max_id = None
+        while True:
+            chunk_amount = max(amount - len(users), 0) if amount else 0
+            chunk, max_id = self.user_followers_private_gql_chunk(
+                user_id,
+                max_amount=chunk_amount,
+                max_id=max_id,
+                rank_token=rank_token,
+                order=order,
+                priority=priority,
+            )
+            users.extend(chunk)
+            if amount and len(users) >= amount:
+                break
+            if not max_id or not chunk:
+                break
         if amount:
             users = users[:amount]
         return users

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -43,6 +43,12 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(followers, dict)
         self.assertGreater(len(followers.get("users", [])), 0)
 
+    def test_user_followers_private_gql(self):
+        user_id = self.user_id_from_username("instagram")
+        followers = self.cl.user_followers_private_gql(user_id, amount=5, order="date_followed_latest")
+        self.assertEqual(len(followers), 5)
+        self.assertIsInstance(followers[0], UserShort)
+
 
 class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
     def test_user_short_gql(self):

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -753,6 +753,84 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(query.call_args.kwargs["priority"], "u=3, i")
         self.assertEqual(query.call_args.kwargs["extra_headers"]["X-FB-RMD"], "state=URL_ELIGIBLE")
 
+    def test_user_followers_private_gql_chunk_extracts_users_and_cursor(self):
+        client = Client()
+        response = {
+            "data": {
+                "1$xdt_api__v1__friendships__followers(_request_data:$request_data,user_id:$user_id)": {
+                    "users": [
+                        {
+                            "id": "1",
+                            "username": "one",
+                            "full_name": "One",
+                            "profile_pic_url": "https://example.com/one.jpg",
+                            "is_private": False,
+                        },
+                        {
+                            "pk": "2",
+                            "username": "two",
+                            "full_name": "Two",
+                            "profile_pic_url": "https://example.com/two.jpg",
+                            "is_private": True,
+                        },
+                    ],
+                    "next_max_id": "25",
+                }
+            }
+        }
+        with mock.patch.object(client, "private_graphql_followers_list", return_value=response) as followers_list:
+            users, next_max_id = client.user_followers_private_gql_chunk(
+                "123",
+                max_amount=2,
+                max_id="10",
+                rank_token="rank",
+                order="date_followed_latest",
+            )
+
+        self.assertEqual([user.pk for user in users], ["1", "2"])
+        self.assertEqual([user.username for user in users], ["one", "two"])
+        self.assertEqual(next_max_id, "25")
+        followers_list.assert_called_once_with(
+            "123",
+            "rank",
+            max_id="10",
+            order="date_followed_latest",
+            priority="u=3, i",
+        )
+
+    def test_user_followers_private_gql_paginates_until_amount(self):
+        client = Client()
+        pages = [
+            {
+                "data": {
+                    "xdt_api__v1__friendships__followers": {
+                        "users": [
+                            {"id": "1", "username": "one"},
+                            {"id": "2", "username": "two"},
+                        ],
+                        "next_max_id": "25",
+                    }
+                }
+            },
+            {
+                "data": {
+                    "xdt_api__v1__friendships__followers": {
+                        "users": [
+                            {"id": "3", "username": "three"},
+                            {"id": "4", "username": "four"},
+                        ],
+                        "next_max_id": "50",
+                    }
+                }
+            },
+        ]
+        with mock.patch.object(client, "private_graphql_followers_list", side_effect=pages) as followers_list:
+            users = client.user_followers_private_gql("123", amount=3, rank_token="rank")
+
+        self.assertEqual([user.pk for user in users], ["1", "2", "3"])
+        self.assertEqual(followers_list.call_args_list[0].kwargs["max_id"], None)
+        self.assertEqual(followers_list.call_args_list[1].kwargs["max_id"], "25")
+
     def test_private_graphql_following_list_builds_query_wrapper(self):
         client = Client()
         with mock.patch.object(client, "private_graphql_query_request", return_value={"data": {}}) as query:


### PR DESCRIPTION
## Summary
- add `user_followers_private_gql_chunk()` and `user_followers_private_gql()` wrappers around the private mobile GraphQL `FollowersList` surface
- parse CHAPI GraphQL follower payloads into `UserShort` objects with max_id pagination
- document the private GraphQL alternative next to the legacy public `user_followers_gql()` path

Refs #1796

## Tests
- `.venv/bin/python -m pytest tests/regression/test_user.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`

Live coverage was added for the new wrapper, but not run locally because it requires Instagram credentials/session state.