### PR TITLE
Add story music upload helpers

### DIFF
--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -74,6 +74,9 @@ Common arguments:
 | ------------------------------------ | -------- | -------------
 | photo_upload_to_story(path: Path, caption: str = "", upload_id: str = "", mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {})  | Story  | Upload photo to story
 | video_upload_to_story(path: Path, caption: str = "", thumbnail: Path = None, mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}) | Story  | Upload video to story
+| photo_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, duration: float = 15.0, extra_data: Dict = {}) | Story | Upload photo to story as a short video with the selected music track muxed into it
+| video_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Story | Upload video to story with the selected music track muxed into it
+| story_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Story music configure fields for manual story upload `extra_data`
 
 In `extra_data`, you can pass additional story settings, for example:
 
@@ -87,6 +90,8 @@ Notes:
 * Link stickers are supported through `StoryLink`; this is no longer the old Instagram "swipe up" flow.
 * For story uploads, use a 9:16 asset or build one with `StoryBuilder`.
 * Android users should pass `thumbnail=...` for video stories or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
+* Story music helpers require the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg because they render a local MP4 before upload.
+* Story music helpers add Story music metadata and bake the selected track into the uploaded media. They do not expose Instagram's native interactive lyrics/music sticker UI.
 * Anonymous public story fetch is not guaranteed. If the public/web story path fails, reliable story retrieval usually requires an authenticated session.
 
 
@@ -112,6 +117,35 @@ cl.video_upload_to_story(
     hashtags=[StoryHashtag(hashtag=hashtag, x=0.23, y=0.32, width=0.5, height=0.22)],
     medias=[StoryMedia(media_pk=media_pk, x=0.5, y=0.5, width=0.6, height=0.8)],
     polls=[StoryPoll(x = 0.5, y = 0.5, width = 0.7, height = 0.5, question = "Question", options = ["Option 1", "Option 2", "Option 3"])],
+)
+```
+
+## Upload Story with Music
+
+Story music upload works by rendering an MP4 locally and then publishing it with the normal story upload flow.
+
+```bash
+pip install "instagrapi[video]"
+pip install --no-deps "moviepy==2.2.1"
+```
+
+``` python
+from pathlib import Path
+
+track = cl.search_music("song name")[0]
+
+cl.video_upload_to_story_with_music(
+    Path("/app/story.mp4"),
+    "Credits @example",
+    track,
+    thumbnail=Path("/app/story-thumb.jpg"),
+)
+
+cl.photo_upload_to_story_with_music(
+    Path("/app/story.jpg"),
+    "Credits @example",
+    track,
+    duration=7,
 )
 ```
 

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -502,6 +502,57 @@ class UploadPhotoMixin:
                 )
         raise PhotoConfigureStoryError(response=self.last_response, **self.last_json)
 
+    def photo_upload_to_story_with_music(
+        self,
+        path: Path,
+        caption: str,
+        track: Union[Track, Dict],
+        thumbnail: Path = None,
+        mentions: List[StoryMention] = [],
+        locations: List[StoryLocation] = [],
+        links: List[StoryLink] = [],
+        hashtags: List[StoryHashtag] = [],
+        stickers: List[StorySticker] = [],
+        medias: List[StoryMedia] = [],
+        polls: List[StoryPoll] = [],
+        extra_data: Dict[str, object] = {},
+        duration: float = 15.0,
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: Optional[int] = None,
+        original_volume: float = 0.0,
+        music_volume: float = 1.0,
+        product: str = "story_camera_music_overlay_post_capture",
+        alacorn_session_id: str = "null",
+    ) -> Story:
+        """
+        Upload photo as a story with a selected music track.
+
+        Instagram story photos cannot carry a baked audio track by themselves,
+        so this helper renders the photo into a short video story first.
+        """
+        return self._upload_story_with_music(
+            path,
+            caption,
+            track,
+            thumbnail=thumbnail,
+            mentions=mentions,
+            locations=locations,
+            links=links,
+            hashtags=hashtags,
+            stickers=stickers,
+            medias=medias,
+            polls=polls,
+            extra_data=extra_data,
+            audio_asset_start_time=audio_asset_start_time,
+            overlap_duration=overlap_duration,
+            original_volume=original_volume,
+            music_volume=music_volume,
+            product=product,
+            alacorn_session_id=alacorn_session_id,
+            is_photo=True,
+            duration=duration,
+        )
+
     def photo_upload_to_cutout_sticker(
         self,
         path: Path,

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -1,7 +1,9 @@
+import contextlib
 import random
+import tempfile
 import time
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -25,11 +27,12 @@ from instagrapi.types import (
     StoryMention,
     StoryPoll,
     StorySticker,
+    Track,
     Usertag,
 )
 from instagrapi.utils.serialization import dumps
 from instagrapi.utils.timing import date_time_original
-from instagrapi.utils.video import analyze_video_for_upload
+from instagrapi.utils.video import MOVIEPY_2_INSTALL_MESSAGE, analyze_video_for_upload
 
 
 class DownloadVideoMixin:
@@ -122,6 +125,216 @@ class UploadVideoMixin:
     """
     Helpers for downloading video
     """
+
+    def _story_music_track_url(self, track: Union[Track, Dict]) -> str:
+        track_url = (
+            self._track_value(track, "uri")
+            or self._track_value(track, "progressive_download_url")
+            or self._track_value(track, "fast_start_progressive_download_url")
+            or self._track_value(track, "reactive_audio_download_url")
+        )
+        assert track_url, (
+            "track.uri, track.progressive_download_url, "
+            "track.fast_start_progressive_download_url or track.reactive_audio_download_url is required"
+        )
+        return str(track_url)
+
+    def _render_story_video_with_music(
+        self,
+        path: Path,
+        track: Union[Track, Dict],
+        output_path: Path,
+        audio_asset_start_time: int,
+        is_photo: bool = False,
+        duration: Optional[float] = None,
+        music_volume: float = 1.0,
+    ) -> float:
+        try:
+            import moviepy as mp
+        except ImportError as exc:
+            raise RuntimeError(f"story upload with music requires MoviePy 2.2.1. {MOVIEPY_2_INSTALL_MESSAGE}") from exc
+
+        media_clip = None
+        media_with_audio = None
+        audio_clip = None
+        audio_segment = None
+        tmpaudio = self.track_download_by_url(
+            self._story_music_track_url(track),
+            "track",
+            output_path.parent,
+        )
+        try:
+            if is_photo:
+                media_clip = mp.ImageClip(str(path)).with_duration(float(duration or 15.0))
+                if hasattr(media_clip, "with_fps"):
+                    media_clip = media_clip.with_fps(30)
+                else:
+                    media_clip.fps = 30
+            else:
+                media_clip = mp.VideoFileClip(str(path))
+            media_duration = float(media_clip.duration)
+            audio_clip = mp.AudioFileClip(str(tmpaudio))
+            start = audio_asset_start_time / 1000
+            audio_segment = audio_clip.subclipped(start, start + media_duration)
+            if music_volume != 1.0 and hasattr(audio_segment, "with_volume_scaled"):
+                audio_segment = audio_segment.with_volume_scaled(music_volume)
+            media_with_audio = media_clip.with_audio(audio_segment)
+            media_with_audio.write_videofile(str(output_path))
+            return media_duration
+        finally:
+            closed = set()
+            for clip in (media_with_audio, media_clip, audio_segment, audio_clip):
+                if not clip or id(clip) in closed:
+                    continue
+                closed.add(id(clip))
+                with contextlib.suppress(AttributeError):
+                    clip.close()
+
+    def story_music_extra_data(
+        self,
+        track: Union[Track, Dict],
+        extra_data: Dict[str, object] = {},
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: int = 30000,
+        original_volume: float = 0.0,
+        music_volume: float = 1.0,
+        product: str = "story_camera_music_overlay_post_capture",
+        alacorn_session_id: str = "null",
+        audio_overlay_uuid: Optional[str] = None,
+    ) -> Dict[str, object]:
+        """
+        Build Story music metadata for story upload configure requests.
+
+        This helper only builds the Story metadata fields. Use
+        ``photo_upload_to_story_with_music`` or ``video_upload_to_story_with_music``
+        when the selected track also needs to be muxed into the uploaded media.
+        """
+        audio_asset_id = self._track_value(track, "audio_asset_id") or self._track_value(track, "id")
+        audio_cluster_id = self._track_value(track, "audio_cluster_id")
+        assert audio_asset_id, "track.audio_asset_id or track.id is required"
+        assert audio_cluster_id, "track.audio_cluster_id is required"
+        if audio_asset_start_time is None:
+            audio_asset_start_time = self._track_highlight_start(track)
+
+        audio_asset_id = str(audio_asset_id)
+        audio_cluster_id = str(audio_cluster_id)
+        artist_name = self._track_value(track, "display_artist") or ""
+        track_name = self._track_value(track, "title") or ""
+        audio_overlay_uuid = audio_overlay_uuid or str(uuid4())
+        data = dict(extra_data or {})
+        data["music_burnin_params"] = dumps(
+            {
+                "asset_fbid": audio_asset_id,
+                "offset_ms": int(audio_asset_start_time),
+            }
+        )
+        data["audio_muted"] = False
+        data["has_original_sound"] = "0" if original_volume == 0 else "1"
+        data["music_params"] = {
+            "audio_asset_id": audio_asset_id,
+            "audio_cluster_id": audio_cluster_id,
+            "audio_asset_start_time_in_ms": int(audio_asset_start_time),
+            "overlap_duration_in_ms": int(overlap_duration),
+            "product": product,
+            "song_name": track_name,
+            "artist_name": artist_name,
+            "alacorn_session_id": alacorn_session_id,
+        }
+        music_canonical_id = self._track_value(track, "music_canonical_id")
+        if music_canonical_id:
+            data["music_params"]["music_canonical_id"] = music_canonical_id
+        edits = dict(data.get("edits") or {})
+        edits["audio_state_edits"] = {
+            "has_music_sticker": True,
+            "is_music_burned_into_video": True,
+            "is_video_muted": False,
+            "did_user_mute_audio": False,
+            "force_play_video_audio": True,
+        }
+        media_audio_overlay_info = dict(edits.get("media_audio_overlay_info") or {})
+        media_audio_overlay_info.update(
+            {
+                "audio_mix_burned_in": True,
+                "video_volume": original_volume,
+                "media_audio_overlays": [
+                    {
+                        "audio_asset_id": audio_asset_id,
+                        "audio_overlay_uuid": audio_overlay_uuid,
+                        "audio_volume": music_volume,
+                        "seek_time_ms": int(audio_asset_start_time),
+                        "start_at_time_ms": 0,
+                        "audio_duration_ms": int(overlap_duration),
+                        "media_audio_overlay_type": "audio_track",
+                    }
+                ],
+            }
+        )
+        edits["media_audio_overlay_info"] = media_audio_overlay_info
+        data["edits"] = edits
+        return data
+
+    def _upload_story_with_music(
+        self,
+        path: Path,
+        caption: str,
+        track: Union[Track, Dict],
+        thumbnail: Path = None,
+        mentions: List[StoryMention] = [],
+        locations: List[StoryLocation] = [],
+        links: List[StoryLink] = [],
+        hashtags: List[StoryHashtag] = [],
+        stickers: List[StorySticker] = [],
+        medias: List[StoryMedia] = [],
+        polls: List[StoryPoll] = [],
+        extra_data: Dict[str, object] = {},
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: Optional[int] = None,
+        original_volume: float = 0.0,
+        music_volume: float = 1.0,
+        product: str = "story_camera_music_overlay_post_capture",
+        alacorn_session_id: str = "null",
+        is_photo: bool = False,
+        duration: Optional[float] = None,
+    ) -> Story:
+        path = Path(path)
+        if thumbnail is not None:
+            thumbnail = Path(thumbnail)
+        if audio_asset_start_time is None:
+            audio_asset_start_time = self._track_highlight_start(track)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "story-with-music.mp4"
+            media_duration = self._render_story_video_with_music(
+                path,
+                track,
+                output_path,
+                audio_asset_start_time=audio_asset_start_time,
+                is_photo=is_photo,
+                duration=duration,
+                music_volume=music_volume,
+            )
+            music_extra = self.story_music_extra_data(
+                track,
+                extra_data=extra_data,
+                audio_asset_start_time=audio_asset_start_time,
+                overlap_duration=overlap_duration or int(media_duration * 1000),
+                original_volume=original_volume,
+                music_volume=music_volume,
+                product=product,
+                alacorn_session_id=alacorn_session_id,
+            )
+            return self.video_upload_to_story(
+                output_path,
+                caption,
+                thumbnail=thumbnail,
+                mentions=mentions,
+                locations=locations,
+                links=links,
+                hashtags=hashtags,
+                stickers=stickers,
+                medias=medias,
+                polls=polls,
+                extra_data=music_extra,
+            )
 
     def video_rupload(
         self,
@@ -480,6 +693,56 @@ class UploadVideoMixin:
                     story_kwargs,
                 )
         raise VideoConfigureStoryError(response=self.last_response, **self.last_json)
+
+    def video_upload_to_story_with_music(
+        self,
+        path: Path,
+        caption: str,
+        track: Union[Track, Dict],
+        thumbnail: Path = None,
+        mentions: List[StoryMention] = [],
+        locations: List[StoryLocation] = [],
+        links: List[StoryLink] = [],
+        hashtags: List[StoryHashtag] = [],
+        stickers: List[StorySticker] = [],
+        medias: List[StoryMedia] = [],
+        polls: List[StoryPoll] = [],
+        extra_data: Dict[str, object] = {},
+        audio_asset_start_time: Optional[int] = None,
+        overlap_duration: Optional[int] = None,
+        original_volume: float = 0.0,
+        music_volume: float = 1.0,
+        product: str = "story_camera_music_overlay_post_capture",
+        alacorn_session_id: str = "null",
+    ) -> Story:
+        """
+        Upload video as a story with a selected music track.
+
+        The helper locally muxes the selected track into the uploaded video and
+        adds Story music metadata to the configure request. It replaces the
+        uploaded video's audio with the selected track.
+        """
+        return self._upload_story_with_music(
+            path,
+            caption,
+            track,
+            thumbnail=thumbnail,
+            mentions=mentions,
+            locations=locations,
+            links=links,
+            hashtags=hashtags,
+            stickers=stickers,
+            medias=medias,
+            polls=polls,
+            extra_data=extra_data,
+            audio_asset_start_time=audio_asset_start_time,
+            overlap_duration=overlap_duration,
+            original_volume=original_volume,
+            music_volume=music_volume,
+            product=product,
+            alacorn_session_id=alacorn_session_id,
+            is_photo=False,
+        )
 
     def video_configure_to_story(
         self,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -350,7 +350,9 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.TestCase):
                 last_exc = exc
                 print(f"Fresh account attempt {attempt} failed for {acc['username']}: {exc.__class__.__name__} {exc}")
                 continue
-        raise last_exc or RuntimeError("No usable fresh account returned")
+        if last_exc:
+            raise RuntimeError(f"No usable fresh account returned: {last_exc}") from last_exc
+        raise RuntimeError("No usable fresh account returned")
 
     def fresh_accounts(self, count: int, exclude_user_ids=None):
         exclude_user_ids = {str(user_id) for user_id in (exclude_user_ids or set())}

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -262,6 +262,150 @@ class ClientStoryLocationStickerLiveTestCase(_helpers.ClientPrivateTestCase):
             self.cleanup_uploaded_story(story)
 
 
+class ClientStoryMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):
+    photo_path = Path("examples/background.png")
+
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for story music upload live tests")
+        try:
+            self.cl = self.fresh_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def first_music_track(self):
+        tracks = self.cl.search_music("Runaway")
+        if not tracks:
+            self.skipTest("search_music did not return a usable track")
+        return tracks[0]
+
+    def make_silent_story_mp4(self, duration=4):
+        try:
+            import imageio_ffmpeg
+        except ImportError:
+            self.skipTest("imageio_ffmpeg is required to generate a silent Story fixture")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as tmp:
+            path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+
+        try:
+            subprocess.run(
+                [
+                    imageio_ffmpeg.get_ffmpeg_exe(),
+                    "-y",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    f"color=c=black:s=720x1280:r=30:d={duration}",
+                    "-c:v",
+                    "libx264",
+                    "-pix_fmt",
+                    "yuv420p",
+                    str(path),
+                ],
+                check=True,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            self.skipTest(f"Could not generate silent Story fixture: {exc}")
+        return path
+
+    def cleanup_uploaded_story(self, story):
+        if not story:
+            return
+        try:
+            self.assertTrue(self.cl.story_delete(story.id))
+        except Exception as exc:
+            print(f"Story music upload live cleanup story_delete failed: {exc.__class__.__name__} {exc}")
+
+    def uploaded_story_payload(self, story, attempts=8, delay=5):
+        last_items = []
+        for attempt in range(attempts):
+            if attempt:
+                time.sleep(delay)
+            result = self.cl.private_request(f"feed/user/{self.cl.user_id}/story/")
+            reel = result.get("reel") or {}
+            last_items = reel.get("items") or []
+            for item in last_items:
+                if str(item.get("pk")) == str(story.pk) or str(item.get("id")) == str(story.id):
+                    return item
+        self.fail(f"Uploaded story payload was not visible after {attempts} attempts: {last_items}")
+
+    def download_story_video(self, story):
+        info = self.assertUploadedStoryAccessible(story, media_type=2, attempts=8, delay=5)
+        self.assertTrue(info.video_url, "Uploaded story did not expose video_url")
+        video_path = self.cl.video_download_by_url(str(info.video_url), f"story-{story.pk}", tempfile.gettempdir())
+        self.addCleanup(lambda: Path(video_path).unlink(missing_ok=True))
+        return info, Path(video_path)
+
+    def assert_video_file_has_audio_stream(self, path):
+        try:
+            import imageio_ffmpeg
+        except ImportError:
+            self.skipTest("imageio_ffmpeg is required to inspect uploaded Story audio")
+        result = subprocess.run(
+            [imageio_ffmpeg.get_ffmpeg_exe(), "-hide_banner", "-i", str(path)],
+            check=False,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        streams = result.stderr.decode("utf-8", errors="replace")
+        self.assertIn("Audio:", streams)
+
+    def assert_story_music_result(self, story, expected_duration):
+        info, downloaded_video = self.download_story_video(story)
+        self.assertGreater(info.video_duration, 0)
+        self.assertLess(abs(info.video_duration - expected_duration), 1.5)
+        payload = self.uploaded_story_payload(story)
+        self.assertEqual(payload.get("media_type"), 2)
+        self.assertTrue(payload.get("video_versions"), "Uploaded Story payload did not include video_versions")
+        self.assert_video_file_has_audio_stream(downloaded_video)
+        return payload
+
+    def test_video_upload_to_story_with_music_live(self):
+        path = self.make_silent_story_mp4(duration=4)
+        track = self.first_music_track()
+        story = None
+        try:
+            story = self.cl.video_upload_to_story_with_music(
+                path,
+                "Story video music live test",
+                track,
+                overlap_duration=4000,
+            )
+            self.assertIsInstance(story, Story)
+            self.assertEqual(story.media_type, 2)
+            self.assert_story_music_result(story, expected_duration=4)
+        finally:
+            self.cleanup_uploaded_story(story)
+
+    def test_photo_upload_to_story_with_music_live(self):
+        track = self.first_music_track()
+        story = None
+        try:
+            story = self.cl.photo_upload_to_story_with_music(
+                self.photo_path,
+                "Story photo music live test",
+                track,
+                duration=7,
+                overlap_duration=7000,
+            )
+            self.assertIsInstance(story, Story)
+            self.assertEqual(story.media_type, 2)
+            self.assert_story_music_result(story, expected_duration=7)
+        finally:
+            self.cleanup_uploaded_story(story)
+
+
 # class BloksTestCase(_helpers.ClientPrivateTestCase):
 #
 #     def test_bloks_change_password(self):

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -547,6 +547,231 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(upload_extra["music_params"]["overlap_duration_in_ms"], 2500)
         self.assertIn("clips_audio_metadata", upload_extra)
 
+    def test_story_music_extra_data_builds_story_music_payload_from_dict(self):
+        client = self.build_client()
+        track = {
+            "id": "track-id",
+            "audio_asset_id": "asset-id",
+            "audio_cluster_id": "cluster-id",
+            "highlight_start_times_in_ms": [40500],
+            "title": "Runaway",
+            "display_artist": "AURORA",
+            "music_canonical_id": "canonical-id",
+        }
+        extra_data = {
+            "share_to_facebook": "1",
+            "edits": {"crop_zoom": 1.0},
+        }
+
+        result = client.story_music_extra_data(
+            track,
+            extra_data=extra_data,
+            overlap_duration=34000,
+            audio_overlay_uuid="overlay-id",
+        )
+
+        self.assertEqual(extra_data, {"share_to_facebook": "1", "edits": {"crop_zoom": 1.0}})
+        self.assertEqual(result["share_to_facebook"], "1")
+        self.assertEqual(result["edits"]["crop_zoom"], 1.0)
+        self.assertEqual(
+            json.loads(result["music_burnin_params"]),
+            {"asset_fbid": "asset-id", "offset_ms": 40500},
+        )
+        self.assertEqual(
+            result["music_params"],
+            {
+                "audio_asset_id": "asset-id",
+                "audio_cluster_id": "cluster-id",
+                "audio_asset_start_time_in_ms": 40500,
+                "overlap_duration_in_ms": 34000,
+                "product": "story_camera_music_overlay_post_capture",
+                "song_name": "Runaway",
+                "artist_name": "AURORA",
+                "alacorn_session_id": "null",
+                "music_canonical_id": "canonical-id",
+            },
+        )
+        self.assertEqual(
+            result["edits"]["audio_state_edits"],
+            {
+                "has_music_sticker": True,
+                "is_music_burned_into_video": True,
+                "is_video_muted": False,
+                "did_user_mute_audio": False,
+                "force_play_video_audio": True,
+            },
+        )
+        self.assertEqual(
+            result["edits"]["media_audio_overlay_info"],
+            {
+                "audio_mix_burned_in": True,
+                "video_volume": 0.0,
+                "media_audio_overlays": [
+                    {
+                        "audio_asset_id": "asset-id",
+                        "audio_overlay_uuid": "overlay-id",
+                        "audio_volume": 1.0,
+                        "seek_time_ms": 40500,
+                        "start_at_time_ms": 0,
+                        "audio_duration_ms": 34000,
+                        "media_audio_overlay_type": "audio_track",
+                    }
+                ],
+            },
+        )
+
+    def test_video_upload_to_story_with_music_muxes_track_and_uploads_story(self):
+        client = self.build_client()
+        extra_data = {"share_to_facebook": "1"}
+        track = {
+            "id": "track-id",
+            "audio_cluster_id": "cluster-id",
+            "highlight_start_times_in_ms": [1500],
+            "title": "Story song",
+            "display_artist": "Story artist",
+            "uri": "https://example.com/track.m4a",
+        }
+        audio_segments = []
+        video_paths_seen = []
+
+        class FakeAudioClip:
+            def __init__(self, path):
+                self.path = path
+
+            def subclipped(self, start, end):
+                audio_segments.append((start, end))
+                return self
+
+            def close(self):
+                return None
+
+        class FakeVideoClip:
+            def __init__(self, path):
+                self.path = path
+                self.duration = 2.5
+
+            def with_audio(self, audio_clip):
+                self.audio_clip = audio_clip
+                return self
+
+            def write_videofile(self, path):
+                Path(path).write_bytes(b"video")
+
+            def close(self):
+                return None
+
+        fake_mp = types.ModuleType("moviepy")
+        fake_mp.VideoFileClip = FakeVideoClip
+        fake_mp.AudioFileClip = FakeAudioClip
+
+        def upload_side_effect(path, caption="", **kwargs):
+            video_paths_seen.append(Path(path))
+            self.assertTrue(Path(path).exists())
+            return "uploaded"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = Path(tmpdir) / "track.m4a"
+            audio_path.write_bytes(b"audio")
+            with mock.patch.dict("sys.modules", {"moviepy": fake_mp}):
+                with mock.patch.object(client, "track_download_by_url", return_value=audio_path) as download:
+                    with mock.patch.object(
+                        client,
+                        "video_upload_to_story",
+                        side_effect=upload_side_effect,
+                    ) as upload:
+                        result = client.video_upload_to_story_with_music(
+                            Path("input.mp4"),
+                            "caption",
+                            track,
+                            extra_data=extra_data,
+                        )
+
+        self.assertEqual(result, "uploaded")
+        self.assertEqual(extra_data, {"share_to_facebook": "1"})
+        download.assert_called_once()
+        self.assertEqual(download.call_args.args[0], "https://example.com/track.m4a")
+        self.assertEqual(audio_segments, [(1.5, 4.0)])
+        self.assertEqual(len(video_paths_seen), 1)
+        upload.assert_called_once()
+        self.assertEqual(upload.call_args.args[:2], (video_paths_seen[0], "caption"))
+        upload_extra = upload.call_args.kwargs["extra_data"]
+        self.assertEqual(upload_extra["share_to_facebook"], "1")
+        self.assertEqual(upload_extra["music_params"]["audio_asset_start_time_in_ms"], 1500)
+        self.assertEqual(upload_extra["music_params"]["overlap_duration_in_ms"], 2500)
+        self.assertEqual(upload_extra["edits"]["media_audio_overlay_info"]["video_volume"], 0.0)
+
+    def test_photo_upload_to_story_with_music_renders_photo_story_video(self):
+        client = self.build_client()
+        track = {
+            "id": "track-id",
+            "audio_cluster_id": "cluster-id",
+            "highlight_start_times_in_ms": [0],
+            "title": "Photo song",
+            "display_artist": "Photo artist",
+            "progressive_download_url": "https://example.com/track.m4a",
+        }
+        audio_segments = []
+        image_durations = []
+        image_clips = []
+
+        class FakeAudioClip:
+            def __init__(self, path):
+                self.path = path
+
+            def subclipped(self, start, end):
+                audio_segments.append((start, end))
+                return self
+
+            def close(self):
+                return None
+
+        class FakeImageClip:
+            def __init__(self, path):
+                self.path = path
+                self.duration = None
+                self.fps = None
+                image_clips.append(self)
+
+            def with_duration(self, duration):
+                self.duration = duration
+                image_durations.append(duration)
+                return self
+
+            def with_audio(self, audio_clip):
+                self.audio_clip = audio_clip
+                return self
+
+            def write_videofile(self, path):
+                Path(path).write_bytes(b"video")
+
+            def close(self):
+                return None
+
+        fake_mp = types.ModuleType("moviepy")
+        fake_mp.ImageClip = FakeImageClip
+        fake_mp.AudioFileClip = FakeAudioClip
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = Path(tmpdir) / "track.m4a"
+            audio_path.write_bytes(b"audio")
+            with mock.patch.dict("sys.modules", {"moviepy": fake_mp}):
+                with mock.patch.object(client, "track_download_by_url", return_value=audio_path):
+                    with mock.patch.object(client, "video_upload_to_story", return_value="uploaded") as upload:
+                        result = client.photo_upload_to_story_with_music(
+                            Path("story.jpg"),
+                            "caption",
+                            track,
+                            duration=7,
+                        )
+
+        self.assertEqual(result, "uploaded")
+        self.assertEqual(image_durations, [7])
+        self.assertEqual(audio_segments, [(0.0, 7.0)])
+        self.assertEqual(image_clips[0].fps, 30)
+        self.assertEqual(upload.call_args.kwargs["extra_data"]["music_params"]["overlap_duration_in_ms"], 7000)
+        upload.assert_called_once()
+        self.assertEqual(upload.call_args.args[1], "caption")
+
     def test_photo_story_upload_falls_back_to_recent_story_when_configure_has_no_media(self):
         client = self.build_client()
         existing = self.build_story("10")


### PR DESCRIPTION
## Summary
- add Story music metadata helper for story configure payloads
- add video/photo story upload helpers that mux a selected track into a local MP4 before upload
- add live Story music tests that re-fetch the uploaded Story and inspect the downloaded MP4 for an audio stream
- document Story music usage and MoviePy requirements

## Tests
- .venv/bin/python -m pytest tests/regression/test_upload.py
- sk.test: .venv/bin/python -m pytest tests/live/test_story.py -k "with_music_live" (2 passed)
- .venv/bin/python -m ruff check instagrapi/mixins/video.py instagrapi/mixins/photo.py tests/regression/test_upload.py tests/live/test_story.py tests/helpers.py
- .venv/bin/python -m py_compile instagrapi/mixins/video.py instagrapi/mixins/photo.py tests/live/test_story.py tests/helpers.py
- git diff --check

Closes #1848