### PR TITLE
Add scheduled photo upload support

### DIFF
--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -1,6 +1,7 @@
 import json
 import random
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
@@ -224,6 +225,7 @@ class UploadPhotoMixin:
         usertags: List[Usertag] = [],
         location: Location = None,
         extra_data: Dict[str, str] = {},
+        schedule_at: Optional[Union[int, datetime]] = None,
     ) -> Media:
         """
         Upload photo and configure to feed
@@ -242,6 +244,8 @@ class UploadPhotoMixin:
             Location tag for this upload, default is None
         extra_data: Dict[str, str], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
+        schedule_at: int or datetime, optional
+            Unix timestamp in seconds or datetime when the photo should be published.
 
         Returns
         -------
@@ -253,6 +257,7 @@ class UploadPhotoMixin:
         if path.suffix.lower() not in valid_extensions:
             raise ValueError("Invalid file format. Only JPG/JPEG/PNG/WEBP files are supported.")
 
+        extra_data = self._scheduled_extra_data(extra_data, schedule_at)
         previous_media_ids = self._current_media_ids()
         upload_id, width, height = self.photo_rupload(path, upload_id)
         for attempt in range(10):
@@ -290,6 +295,7 @@ class UploadPhotoMixin:
         overlap_duration: int = 30000,
         browse_session_id: Optional[str] = None,
         alacorn_session_id: Optional[str] = None,
+        schedule_at: Optional[Union[int, datetime]] = None,
     ) -> Media:
         """
         Upload a feed photo with attached music.
@@ -320,6 +326,8 @@ class UploadPhotoMixin:
         alacorn_session_id: str, optional
             Music browser session id returned by ``music_in_feed_audio_browser``.
             Fetched automatically when omitted.
+        schedule_at: int or datetime, optional
+            Unix timestamp in seconds or datetime when the photo should be published.
 
         Returns
         -------
@@ -341,7 +349,24 @@ class UploadPhotoMixin:
             usertags=usertags,
             location=location,
             extra_data=data,
+            schedule_at=schedule_at,
         )
+
+    @staticmethod
+    def _scheduled_extra_data(
+        extra_data: Dict[str, str],
+        schedule_at: Optional[Union[int, datetime]],
+    ) -> Dict[str, str]:
+        data = dict(extra_data or {})
+        if schedule_at is None:
+            return data
+        scheduled_publish_time = int(schedule_at.timestamp() if isinstance(schedule_at, datetime) else schedule_at)
+        data["publish_mode"] = "scheduled"
+        data["content_scheduling_metadata"] = json.dumps(
+            {"scheduled_publish_time": scheduled_publish_time},
+            separators=(",", ":"),
+        )
+        return data
 
     def photo_configure(
         self,

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import MediaNotFound
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -87,6 +88,53 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
                 return info
         self.fail(f"Album resource usertags were not visible after {attempts} media_info_v1 attempts: {last_resources}")
 
+    def ensure_creator_account(self):
+        result = self.cl.private_request("accounts/current_user/?edit=true")
+        user = result.get("user") or {}
+        if user.get("account_type") == 3:
+            return
+        result = self.cl.private_request(
+            "business/account/convert_account/",
+            data=self.cl.with_default_data(
+                {
+                    "entry_point": "setting",
+                    "creator_destination_migration": "false",
+                    "to_account_type": "3",
+                    "category_id": "2347428775505624",
+                    "should_show_category": "1",
+                    "should_show_public_contacts": "0",
+                }
+            ),
+        )
+        self.assertEqual(result.get("status"), "ok")
+        result = self.cl.private_request("accounts/current_user/?edit=true")
+        user = result.get("user") or {}
+        self.assertEqual(user.get("account_type"), 3)
+
+    def assertScheduledMediaAccessible(self, media, schedule_at, caption_text, attempts=5, delay=3):
+        self.assertIsInstance(media, Media)
+        last_result = {}
+        for attempt in range(attempts):
+            if attempt:
+                time.sleep(delay)
+            result = self.cl.private_request(
+                "media/infos/",
+                params={"media_ids": media.id, "include_unpublished": "1"},
+            )
+            last_result = result
+            items = result.get("items") or []
+            if not items:
+                continue
+            payload = items[0]
+            metadata = payload.get("content_scheduling_metadata") or {}
+            self.assertEqual(str(payload.get("id")), str(media.id))
+            self.assertEqual(payload.get("product_type"), "feed")
+            self.assertEqual((payload.get("caption") or {}).get("text", ""), caption_text)
+            self.assertTrue(metadata.get("scheduled_content_id"))
+            self.assertEqual(metadata.get("scheduled_publish_time"), schedule_at)
+            return payload
+        self.fail(f"Scheduled media {media.id} was not accessible through media/infos: {last_result}")
+
     def test_photo_upload_without_location(self):
         path = self.copy_media_fixture("examples/kanada.jpg")
         self.assertIsInstance(path, Path)
@@ -113,6 +161,24 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             self.assertEqual(media.caption_text, caption_text)
             self.assertLocation(media.location)
             self.assertUploadedMediaAccessible(media, media_type=1, caption_text=caption_text)
+        finally:
+            if media:
+                self.assertTrue(self.cl.media_delete(media.id))
+
+    def test_photo_upload_scheduled(self):
+        self.ensure_creator_account()
+        path = self.copy_media_fixture("examples/kanada.jpg")
+        self.assertIsInstance(path, Path)
+        media = None
+        try:
+            schedule_at = int(time.time()) + 3600
+            caption_text = f"Test caption for scheduled photo {schedule_at}"
+            media = self.cl.photo_upload(path, caption_text, schedule_at=schedule_at)
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.caption_text, caption_text)
+            self.assertScheduledMediaAccessible(media, schedule_at, caption_text)
+            with self.assertRaises(MediaNotFound):
+                self.cl.media_info_v1(media.pk)
         finally:
             if media:
                 self.assertTrue(self.cl.media_delete(media.id))

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from instagrapi.extractors import extract_media_v1
 from tests.helpers import *
 
@@ -274,6 +276,38 @@ class UploadRegressionTestCase(unittest.TestCase):
 
         self.assertIsInstance(media, Media)
         self.assertEqual(media.pk, "1")
+
+    def test_photo_upload_sends_scheduled_publish_metadata(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=1)
+        schedule_at = 1779808917
+
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(
+                client, "photo_configure", return_value={"status": "ok", "media": media_payload}
+            ) as configure:
+                with mock.patch("time.sleep"):
+                    media = client.photo_upload(Path("example.jpg"), "caption", schedule_at=schedule_at)
+
+        self.assertIsInstance(media, Media)
+        extra_data = configure.call_args.kwargs["extra_data"]
+        self.assertEqual(extra_data["publish_mode"], "scheduled")
+        self.assertEqual(json.loads(extra_data["content_scheduling_metadata"]), {"scheduled_publish_time": schedule_at})
+
+    def test_photo_upload_accepts_datetime_schedule_at(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=1)
+        schedule_at = datetime.fromtimestamp(1779808917, tz=timezone.utc)
+
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(
+                client, "photo_configure", return_value={"status": "ok", "media": media_payload}
+            ) as configure:
+                with mock.patch("time.sleep"):
+                    client.photo_upload(Path("example.jpg"), "caption", schedule_at=schedule_at)
+
+        extra_data = configure.call_args.kwargs["extra_data"]
+        self.assertEqual(json.loads(extra_data["content_scheduling_metadata"]), {"scheduled_publish_time": 1779808917})
 
     def test_video_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()


### PR DESCRIPTION
## Summary
- Add `schedule_at` support to `photo_upload` and `photo_upload_with_music`.
- Send Instagram's scheduled feed configure fields: `publish_mode=scheduled` and `content_scheduling_metadata.scheduled_publish_time`.
- Add regression coverage plus a live scheduled upload test that verifies the unpublished media via `media/infos/?include_unpublished=1` and cleans it up.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_upload.py -q`
- `IG_PROXY=http://127.0.0.1:18180 .venv/bin/python -m pytest tests/live/test_upload.py::ClienUploadTestCase::test_photo_upload_scheduled -q -s`
- `.venv/bin/ruff check instagrapi/mixins/photo.py tests/regression/test_upload.py tests/live/test_upload.py`
- `.venv/bin/ruff format --check instagrapi/mixins/photo.py tests/regression/test_upload.py tests/live/test_upload.py`
- `git diff --check`

Refs #1912