### PR TITLE
Add scheduled video and album uploads

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -317,12 +317,13 @@ Upload medias to your feed. Common arguments:
 * `caption`  - Text for you post
 * `usertags` - List[Usertag] of mention users (see `Usertag` in [types.py](https://github.com/subzeroid/instagrapi/blob/master/instagrapi/types.py))
 * `location` - Location (e.g. `Location(name='Test', lat=42.0, lng=42.0)`)
+* `schedule_at` - Unix timestamp in seconds or `datetime` for scheduled publishing on eligible professional accounts
 
 | Method                                                                                                                                 | Return  | Description
 | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------
-| photo_upload(path: Path, caption: str, upload_id: str, usertags: List[Usertag], location: Location, extra_data: Dict = {})             | Media   | Upload photo (Support JPG files)
-| video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {})            | Media   | Upload video (Support MP4 files)
-| album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {})                      | Media   | Upload Album (Support JPG/MP4 files)
+| photo_upload(path: Path, caption: str, upload_id: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None)             | Media   | Upload photo (Support JPG files)
+| video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None)            | Media   | Upload video (Support MP4 files)
+| album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None)                      | Media   | Upload Album (Support JPG/MP4 files)
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
 | clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual", share_to_facebook: bool = False) | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts. Set `share_to_facebook=True` to cross-post to a linked Facebook destination
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
@@ -332,10 +333,14 @@ Upload medias to your feed. Common arguments:
 | clip_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Reels music configure fields for manual `clip_upload(..., extra_data=...)`
 | clip_upload_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Media | Upload a Reel with music metadata without local audio muxing
 | clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload a Reel after locally muxing the track into the video with MoviePy
-| photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed photo with music metadata
-| album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}) | Media | Upload feed album/carousel with music metadata
+| photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}, schedule_at: int \| datetime = None) | Media | Upload feed photo with music metadata
+| album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}, schedule_at: int \| datetime = None) | Media | Upload feed album/carousel with music metadata
 
 For video uploads in Android environments, pass `thumbnail=...` to avoid automatic thumbnail generation, or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
+
+Scheduled publishing is available only where the Instagram app enables scheduled content, typically professional
+creator/business accounts. `schedule_at` works for feed photo, feed video, and album/carousel uploads. Reels, IGTV,
+Story, Direct, and cutout sticker upload helpers do not use this scheduled publishing flow.
 
 
 In `extra_data`, you can pass additional media settings, for example:
@@ -369,10 +374,17 @@ automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying
 ### Example:
 
 ``` python
+>>> import time
 >>> from instagrapi import Client
 
 >>> cl = Client()
 >>> cl.login(USERNAME, PASSWORD)
+
+>>> scheduled_photo = cl.photo_upload(
+...     "/app/image.jpg",
+...     "Scheduled photo",
+...     schedule_at=int(time.time()) + 3600,
+... )
 
 >>> if cl.clip_trial_eligible():
 ...     trial_reel = cl.clip_upload(

--- a/instagrapi/mixins/album.py
+++ b/instagrapi/mixins/album.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
@@ -132,6 +133,7 @@ class UploadAlbumMixin:
         configure_exception=None,
         to_story=False,
         extra_data: Dict[str, str] = {},
+        schedule_at: Optional[Union[int, datetime]] = None,
     ) -> Media:
         """
         Upload album to feed
@@ -157,6 +159,8 @@ class UploadAlbumMixin:
             Currently not used, default is False
         extra_data: Dict[str, str], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
+        schedule_at: int or datetime, optional
+            Unix timestamp in seconds or datetime when the album should be published.
 
         Returns
         -------
@@ -165,6 +169,7 @@ class UploadAlbumMixin:
         """
         if not paths:
             raise AlbumUnknownFormat("Album upload requires at least one media path.")
+        extra_data = self._scheduled_extra_data(extra_data, schedule_at)
         children = []
         for path in paths:
             path = Path(path)
@@ -246,6 +251,7 @@ class UploadAlbumMixin:
         overlap_duration: int = 30000,
         browse_session_id: Optional[str] = None,
         alacorn_session_id: Optional[str] = None,
+        schedule_at: Optional[Union[int, datetime]] = None,
     ) -> Media:
         """
         Upload a feed album/carousel with attached music.
@@ -283,6 +289,8 @@ class UploadAlbumMixin:
         alacorn_session_id: str, optional
             Music browser session id returned by ``music_in_feed_audio_browser``.
             Fetched automatically when omitted.
+        schedule_at: int or datetime, optional
+            Unix timestamp in seconds or datetime when the album should be published.
 
         Returns
         -------
@@ -307,6 +315,7 @@ class UploadAlbumMixin:
             configure_exception=configure_exception,
             to_story=to_story,
             extra_data=data,
+            schedule_at=schedule_at,
         )
 
     def album_configure(

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -360,13 +360,17 @@ class UploadPhotoMixin:
         data = dict(extra_data or {})
         if schedule_at is None:
             return data
-        scheduled_publish_time = int(schedule_at.timestamp() if isinstance(schedule_at, datetime) else schedule_at)
+        scheduled_publish_time = UploadPhotoMixin._scheduled_publish_time(schedule_at)
         data["publish_mode"] = "scheduled"
         data["content_scheduling_metadata"] = json.dumps(
             {"scheduled_publish_time": scheduled_publish_time},
             separators=(",", ":"),
         )
         return data
+
+    @staticmethod
+    def _scheduled_publish_time(schedule_at: Union[int, datetime]) -> int:
+        return int(schedule_at.timestamp() if isinstance(schedule_at, datetime) else schedule_at)
 
     def photo_configure(
         self,

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -2,6 +2,7 @@ import contextlib
 import random
 import tempfile
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
@@ -436,6 +437,7 @@ class UploadVideoMixin:
         usertags: List[Usertag] = [],
         location: Location = None,
         extra_data: Dict[str, str] = {},
+        schedule_at: Optional[Union[int, datetime]] = None,
     ) -> Media:
         """
         Upload video and configure to feed
@@ -454,6 +456,8 @@ class UploadVideoMixin:
             Location tag for this upload, default is None
         extra_data: Dict[str, str], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
+        schedule_at: int or datetime, optional
+            Unix timestamp in seconds or datetime when the video should be published.
 
         Returns
         -------
@@ -463,6 +467,7 @@ class UploadVideoMixin:
         path = Path(path)
         if thumbnail is not None:
             thumbnail = Path(thumbnail)
+        extra_data = self._scheduled_extra_data(extra_data, schedule_at)
         upload_id, width, height, duration, thumbnail = self.video_rupload(path, thumbnail, to_story=False)
         for attempt in range(50):
             self.logger.debug(f"Attempt #{attempt} to configure Video: {path}")

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -1,4 +1,4 @@
-from instagrapi.exceptions import MediaNotFound
+from instagrapi.exceptions import ClientNotFoundError, MediaNotFound
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -111,7 +111,9 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
         user = result.get("user") or {}
         self.assertEqual(user.get("account_type"), 3)
 
-    def assertScheduledMediaAccessible(self, media, schedule_at, caption_text, attempts=5, delay=3):
+    def assertScheduledMediaAccessible(
+        self, media, schedule_at, caption_text, product_type="feed", attempts=5, delay=3
+    ):
         self.assertIsInstance(media, Media)
         last_result = {}
         for attempt in range(attempts):
@@ -128,12 +130,51 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             payload = items[0]
             metadata = payload.get("content_scheduling_metadata") or {}
             self.assertEqual(str(payload.get("id")), str(media.id))
-            self.assertEqual(payload.get("product_type"), "feed")
+            self.assertEqual(payload.get("product_type"), product_type)
             self.assertEqual((payload.get("caption") or {}).get("text", ""), caption_text)
             self.assertTrue(metadata.get("scheduled_content_id"))
             self.assertEqual(metadata.get("scheduled_publish_time"), schedule_at)
             return payload
         self.fail(f"Scheduled media {media.id} was not accessible through media/infos: {last_result}")
+
+    def skip_unavailable_scheduled_publish(self, exc):
+        if exc is None or isinstance(
+            exc,
+            (ClientNotFoundError, ClientThrottledError, PleaseWaitFewMinutes, RetryError),
+        ):
+            self.skipTest("No usable scheduled publishing account was available")
+        raise exc
+
+    def scheduled_publish_clients(self, additional_count=4):
+        seen_user_ids = set()
+        if self.cl:
+            seen_user_ids.add(str(self.cl.user_id))
+            yield self.cl
+        for cl in self.fresh_accounts(additional_count, exclude_user_ids=seen_user_ids):
+            yield cl
+
+    def upload_with_scheduled_publish(self, upload):
+        last_exc = None
+        for cl in self.scheduled_publish_clients():
+            self.cl = cl
+            self.ensure_creator_account()
+            try:
+                return upload()
+            except (ClientNotFoundError, ClientThrottledError, PleaseWaitFewMinutes, RetryError) as exc:
+                last_exc = exc
+                continue
+        self.skip_unavailable_scheduled_publish(last_exc)
+
+    def cleanup_scheduled_media(self, media):
+        if not media:
+            return
+        try:
+            deleted = self.cl.media_delete(media.id)
+        except Exception as exc:
+            print(f"Scheduled media cleanup media_delete failed: {exc.__class__.__name__} {exc}")
+            return
+        if not deleted:
+            print(f"Scheduled media cleanup media_delete returned False for {media.id}")
 
     def test_photo_upload_without_location(self):
         path = self.copy_media_fixture("examples/kanada.jpg")
@@ -166,14 +207,15 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
                 self.assertTrue(self.cl.media_delete(media.id))
 
     def test_photo_upload_scheduled(self):
-        self.ensure_creator_account()
         path = self.copy_media_fixture("examples/kanada.jpg")
         self.assertIsInstance(path, Path)
         media = None
         try:
             schedule_at = int(time.time()) + 3600
             caption_text = f"Test caption for scheduled photo {schedule_at}"
-            media = self.cl.photo_upload(path, caption_text, schedule_at=schedule_at)
+            media = self.upload_with_scheduled_publish(
+                lambda: self.cl.photo_upload(path, caption_text, schedule_at=schedule_at)
+            )
             self.assertIsInstance(media, Media)
             self.assertEqual(media.caption_text, caption_text)
             self.assertScheduledMediaAccessible(media, schedule_at, caption_text)
@@ -181,7 +223,26 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
                 self.cl.media_info_v1(media.pk)
         finally:
             if media:
-                self.assertTrue(self.cl.media_delete(media.id))
+                self.cleanup_scheduled_media(media)
+
+    def test_video_upload_scheduled(self):
+        path = self.make_video_fixture(label="scheduled feed video fixture")
+        self.assertIsInstance(path, Path)
+        media = None
+        try:
+            schedule_at = int(time.time()) + 3600
+            caption_text = f"Test caption for scheduled video {schedule_at}"
+            media = self.upload_with_scheduled_publish(
+                lambda: self.cl.video_upload(path, caption_text, schedule_at=schedule_at)
+            )
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.caption_text, caption_text)
+            self.assertScheduledMediaAccessible(media, schedule_at, caption_text)
+            with self.assertRaises(MediaNotFound):
+                self.cl.media_info_v1(media.pk)
+        finally:
+            if media:
+                self.cleanup_scheduled_media(media)
 
     def test_video_upload(self):
         path = self.make_video_fixture(label="feed video fixture")
@@ -197,6 +258,28 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
         finally:
             if media:
                 self.assertTrue(self.cl.media_delete(media.id))
+
+    def test_album_upload_scheduled(self):
+        paths = [
+            self.copy_media_fixture("examples/kanada.jpg"),
+            self.copy_media_fixture("examples/background.png"),
+        ]
+        [self.assertIsInstance(path, Path) for path in paths]
+        media = None
+        try:
+            schedule_at = int(time.time()) + 3600
+            caption_text = f"Test caption for scheduled album {schedule_at}"
+            media = self.upload_with_scheduled_publish(
+                lambda: self.cl.album_upload(paths, caption_text, schedule_at=schedule_at)
+            )
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.caption_text, caption_text)
+            self.assertScheduledMediaAccessible(media, schedule_at, caption_text, product_type="carousel_container")
+            with self.assertRaises(MediaNotFound):
+                self.cl.media_info_v1(media.pk)
+        finally:
+            if media:
+                self.cleanup_scheduled_media(media)
 
     def test_album_upload(self):
         paths = [

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -309,6 +309,73 @@ class UploadRegressionTestCase(unittest.TestCase):
         extra_data = configure.call_args.kwargs["extra_data"]
         self.assertEqual(json.loads(extra_data["content_scheduling_metadata"]), {"scheduled_publish_time": 1779808917})
 
+    def test_video_upload_sends_scheduled_publish_metadata(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=2)
+        schedule_at = 1779808917
+
+        with mock.patch.object(
+            client,
+            "video_rupload",
+            return_value=("1", 720, 1280, 5, Path("/tmp/thumb.jpg")),
+        ):
+            with mock.patch.object(
+                client, "video_configure", return_value={"status": "ok", "media": media_payload}
+            ) as configure:
+                with mock.patch("time.sleep"):
+                    media = client.video_upload(Path("example.mp4"), "caption", schedule_at=schedule_at)
+
+        self.assertIsInstance(media, Media)
+        extra_data = configure.call_args.kwargs["extra_data"]
+        self.assertEqual(extra_data["publish_mode"], "scheduled")
+        self.assertEqual(json.loads(extra_data["content_scheduling_metadata"]), {"scheduled_publish_time": schedule_at})
+
+    def test_album_upload_sends_scheduled_publish_metadata(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=8)
+        media_payload["carousel_media"] = [self.build_media_payload(media_type=1)]
+        schedule_at = 1779808917
+
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(
+                client,
+                "album_configure",
+                return_value={"status": "ok", "media": media_payload},
+            ) as configure:
+                with mock.patch("time.sleep"):
+                    media = client.album_upload([Path("one.jpg")], "caption", schedule_at=schedule_at)
+
+        self.assertIsInstance(media, Media)
+        extra_data = configure.call_args.kwargs["extra_data"]
+        self.assertEqual(extra_data["publish_mode"], "scheduled")
+        self.assertEqual(json.loads(extra_data["content_scheduling_metadata"]), {"scheduled_publish_time": schedule_at})
+
+    def test_album_upload_with_music_forwards_schedule_at_without_mutating_extra_data(self):
+        client = self.build_client()
+        track = {
+            "id": "track-id",
+            "audio_cluster_id": "cluster-id",
+            "highlight_start_times_in_ms": [12000],
+            "title": "Album song",
+            "display_artist": "Album artist",
+        }
+        extra_data = {"disable_comments": 1}
+        schedule_at = datetime.fromtimestamp(1779808917, tz=timezone.utc)
+
+        with mock.patch.object(client, "album_upload", return_value="uploaded") as album_upload:
+            result = client.album_upload_with_music(
+                [Path("one.jpg"), Path("two.jpg")],
+                "caption",
+                track,
+                extra_data=extra_data,
+                alacorn_session_id="alacorn-1",
+                schedule_at=schedule_at,
+            )
+
+        self.assertEqual(result, "uploaded")
+        self.assertEqual(extra_data, {"disable_comments": 1})
+        self.assertEqual(album_upload.call_args.kwargs["schedule_at"], schedule_at)
+
     def test_video_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 


### PR DESCRIPTION
## Summary
- add schedule_at support to feed video uploads
- add schedule_at support to feed album/carousel uploads, including album uploads with music
- document the supported scheduled publishing upload helpers

## Notes
- Reels/clip scheduling is not included here: live checks did not produce a reliable scheduled media result through the available app flow.

## Tests
- git diff --check
- .venv/bin/ruff check instagrapi/mixins/photo.py instagrapi/mixins/video.py instagrapi/mixins/album.py tests/regression/test_upload.py tests/live/test_upload.py
- .venv/bin/python -m pytest tests/regression/test_upload.py
- live scheduled upload checks for photo, video, and album/carousel