### PR TITLE
Add professional account conversion helpers

### DIFF
--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -10,6 +10,9 @@ Viewing and managing your profile
 | account_change_picture(path: Path) | UserShort | Change profile picture |
 | account_set_private() | bool | Switch account to private mode |
 | account_set_public() | bool | Switch account to public mode |
+| account_convert_to_business(category_id: str \| int = "2347428775505624", should_show_category: bool = True, should_show_public_contacts: bool = False) | Account | Convert the current account to a business professional account |
+| account_convert_to_creator(category_id: str \| int = "2347428775505624", should_show_category: bool = True, should_show_public_contacts: bool = False) | Account | Convert the current account to a creator professional account |
+| account_convert_to_professional(to_account_type: int = 3, category_id: str \| int = "2347428775505624", should_show_category: bool = True, should_show_public_contacts: bool = False) | Account | Generic professional account conversion helper; `2` is business and `3` is creator |
 | account_security_info() | dict | Return account security settings, backup codes, trusted devices, and 2FA state |
 | set_external_url(external_url: str) | dict | Replace bio links with a single external URL |
 | remove_bio_links(link_ids: List[int]) | dict | Remove one or more bio links by link ID |
@@ -45,6 +48,9 @@ Account(pk=1903424587, username='example', ..., external_url='https://github.com
 
 >>> cl.account_set_biography("Python, APIs, and automation")
 True
+
+>>> cl.account_convert_to_creator(category_id="2347428775505624")
+Account(pk=1903424587, username='example', ..., account_type=3)
 
 >>> media_pk = cl.media_pk_from_url('https://www.instagram.com/p/BWnh360Fitr/')
 1560364774164147051
@@ -82,6 +88,8 @@ Notes:
 
 * `account_edit(**data)` only applies supported fields and preserves missing required profile fields from `account_info()`.
 * Use `account_set_biography()` when you want Instagram to re-process biography entities/markup explicitly.
+* Professional conversion uses Instagram's mobile conversion flow and may still be blocked by account-specific eligibility, category, contact, or Account Center requirements.
+* `account_convert_to_business()` sends `to_account_type=2`; `account_convert_to_creator()` sends `to_account_type=3`.
 * `send_password_reset()` starts Instagram's recovery flow by requesting a reset link or code. It does not set a new password by itself; continue with the link/code flow that Instagram sends to the account email or phone.
 * `account_security_info()` and `insights_*` style methods require an authenticated session and may depend on the account type or enabled security features.
 

--- a/instagrapi/mixins/account.py
+++ b/instagrapi/mixins/account.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional, Union
 
 from instagrapi.extractors import extract_account, extract_user_short
 from instagrapi.types import Account, UserShort
@@ -61,6 +61,102 @@ class AccountMixin:
         """
         result = self.private_request("accounts/current_user/?edit=true")
         return extract_account(result["user"])
+
+    def account_convert_to_professional(
+        self,
+        to_account_type: int = 3,
+        category_id: Union[str, int] = "2347428775505624",
+        should_show_category: bool = True,
+        should_show_public_contacts: bool = False,
+        entry_point: str = "setting",
+        creator_destination_migration: bool = False,
+        extra_data: Optional[Dict] = None,
+    ) -> Account:
+        """
+        Convert the current account to a professional account.
+
+        Parameters
+        ----------
+        to_account_type: int, default 3
+            Instagram professional account type. ``2`` is business and ``3`` is creator.
+        category_id: str or int, default "2347428775505624"
+            Professional category id selected during conversion.
+        should_show_category: bool, default True
+            Whether to show the category on the profile.
+        should_show_public_contacts: bool, default False
+            Whether to show public contact buttons on the profile.
+        entry_point: str, default "setting"
+            Instagram entry point name sent with the conversion request.
+        creator_destination_migration: bool, default False
+            Preserve Instagram's creator migration flag for compatible request shape.
+        extra_data: Dict, optional
+            Additional fields to merge into the conversion payload.
+
+        Returns
+        -------
+        Account
+            Refreshed account info after the conversion request.
+        """
+        if to_account_type not in (2, 3):
+            raise ValueError("to_account_type must be 2 (business) or 3 (creator)")
+        data = {
+            "entry_point": entry_point,
+            "creator_destination_migration": self._account_bool_value(creator_destination_migration),
+            "to_account_type": str(to_account_type),
+            "category_id": str(category_id),
+            "should_show_category": self._account_bool_flag(should_show_category),
+            "should_show_public_contacts": self._account_bool_flag(should_show_public_contacts),
+        }
+        data.update(extra_data or {})
+        self.private_request(
+            "business/account/convert_account/",
+            data=self.with_default_data(data),
+        )
+        return self.account_info()
+
+    def account_convert_to_business(
+        self,
+        category_id: Union[str, int] = "2347428775505624",
+        should_show_category: bool = True,
+        should_show_public_contacts: bool = False,
+        **kwargs,
+    ) -> Account:
+        """
+        Convert the current account to a business professional account.
+        """
+        return self.account_convert_to_professional(
+            to_account_type=2,
+            category_id=category_id,
+            should_show_category=should_show_category,
+            should_show_public_contacts=should_show_public_contacts,
+            **kwargs,
+        )
+
+    def account_convert_to_creator(
+        self,
+        category_id: Union[str, int] = "2347428775505624",
+        should_show_category: bool = True,
+        should_show_public_contacts: bool = False,
+        **kwargs,
+    ) -> Account:
+        """
+        Convert the current account to a creator professional account.
+        """
+        return self.account_convert_to_professional(
+            to_account_type=3,
+            category_id=category_id,
+            should_show_category=should_show_category,
+            should_show_public_contacts=should_show_public_contacts,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _account_bool_flag(value: bool) -> str:
+        return "1" if value else "0"
+
+    @staticmethod
+    def _account_bool_value(value: bool) -> str:
+        return "true" if value else "false"
 
     def change_password(
         self,

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -89,27 +89,15 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
         self.fail(f"Album resource usertags were not visible after {attempts} media_info_v1 attempts: {last_resources}")
 
     def ensure_creator_account(self):
-        result = self.cl.private_request("accounts/current_user/?edit=true")
-        user = result.get("user") or {}
-        if user.get("account_type") == 3:
+        account = self.cl.account_info()
+        if account.account_type == 3:
             return
-        result = self.cl.private_request(
-            "business/account/convert_account/",
-            data=self.cl.with_default_data(
-                {
-                    "entry_point": "setting",
-                    "creator_destination_migration": "false",
-                    "to_account_type": "3",
-                    "category_id": "2347428775505624",
-                    "should_show_category": "1",
-                    "should_show_public_contacts": "0",
-                }
-            ),
+        account = self.cl.account_convert_to_creator(
+            category_id="2347428775505624",
+            should_show_category=True,
+            should_show_public_contacts=False,
         )
-        self.assertEqual(result.get("status"), "ok")
-        result = self.cl.private_request("accounts/current_user/?edit=true")
-        user = result.get("user") or {}
-        self.assertEqual(user.get("account_type"), 3)
+        self.assertEqual(account.account_type, 3)
 
     def assertScheduledMediaAccessible(
         self, media, schedule_at, caption_text, product_type="feed", attempts=5, delay=3

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -41,6 +41,72 @@ class AccountRegressionTestCase(unittest.TestCase):
         self.assertEqual(result, {"status": "ok"})
         send_password_reset.assert_called_once_with("username")
 
+    def test_account_convert_to_professional_posts_conversion_payload(self):
+        client = Client()
+        account = object()
+
+        with mock.patch.object(client, "with_default_data", side_effect=lambda data: {"default": "yes", **data}):
+            with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+                with mock.patch.object(client, "account_info", return_value=account) as account_info:
+                    result = client.account_convert_to_professional(
+                        to_account_type=3,
+                        category_id=2347428775505624,
+                        should_show_category=True,
+                        should_show_public_contacts=False,
+                        entry_point="setting",
+                        extra_data={"custom": "value"},
+                    )
+
+        self.assertIs(result, account)
+        private_request.assert_called_once_with(
+            "business/account/convert_account/",
+            data={
+                "default": "yes",
+                "entry_point": "setting",
+                "creator_destination_migration": "false",
+                "to_account_type": "3",
+                "category_id": "2347428775505624",
+                "should_show_category": "1",
+                "should_show_public_contacts": "0",
+                "custom": "value",
+            },
+        )
+        account_info.assert_called_once_with()
+
+    def test_account_convert_to_business_uses_business_account_type(self):
+        client = Client()
+
+        with mock.patch.object(client, "account_convert_to_professional", return_value="account") as convert:
+            result = client.account_convert_to_business(category_id="123", should_show_public_contacts=True)
+
+        self.assertEqual(result, "account")
+        convert.assert_called_once_with(
+            to_account_type=2,
+            category_id="123",
+            should_show_category=True,
+            should_show_public_contacts=True,
+        )
+
+    def test_account_convert_to_creator_uses_creator_account_type(self):
+        client = Client()
+
+        with mock.patch.object(client, "account_convert_to_professional", return_value="account") as convert:
+            result = client.account_convert_to_creator(category_id="456", should_show_category=False)
+
+        self.assertEqual(result, "account")
+        convert.assert_called_once_with(
+            to_account_type=3,
+            category_id="456",
+            should_show_category=False,
+            should_show_public_contacts=False,
+        )
+
+    def test_account_convert_to_professional_rejects_personal_account_type(self):
+        client = Client()
+
+        with self.assertRaises(ValueError):
+            client.account_convert_to_professional(to_account_type=1)
+
     def test_confirm_email_posts_verify_email_code_payload(self):
         client = Client()
         client.phone_id = "phone-id"


### PR DESCRIPTION
## Summary
- add account_convert_to_professional with business and creator convenience wrappers
- document professional account conversion in the account usage guide
- switch live scheduled-upload setup to use the new creator conversion helper

## Tests
- git diff --check
- .venv/bin/ruff check instagrapi/mixins/account.py tests/regression/test_account.py tests/live/test_upload.py
- .venv/bin/python -m pytest tests/regression/test_account.py tests/regression/test_upload.py
- .venv/bin/python -m pytest tests/regression
- .venv/bin/mkdocs build --strict