### PR TITLE
Simplify video download media lookup

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -520,7 +520,7 @@ class MediaMixin:
             raise MediaNotFound(media_id=media_id, **(self.last_json or {}))
         return extract_media_v1(media)
 
-    def media_info(self, media_pk: str, use_cache: bool = True, use_public: bool = True) -> Media:
+    def media_info(self, media_pk: str, use_cache: bool = True) -> Media:
         """
         Get Media Information from PK
 
@@ -530,8 +530,6 @@ class MediaMixin:
             Unique identifier of the media
         use_cache: bool, optional
             Whether or not to use information from cache, default value is True
-        use_public: bool, optional
-            Whether or not to try Public GraphQL API before Private Mobile API, default value is True
 
         Returns
         -------
@@ -540,21 +538,18 @@ class MediaMixin:
         """
         media_pk = self.media_pk(media_pk)
         if not use_cache or media_pk not in self._medias_cache:
-            if use_public:
+            try:
                 try:
-                    try:
-                        media = self.media_info_gql(media_pk)
-                    except ClientLoginRequired as e:
-                        if not self.inject_sessionid_to_public():
-                            raise e
-                        media = self.media_info_gql(media_pk)  # retry
-                except Exception as e:
-                    if not isinstance(e, ClientError):
-                        self.logger.exception(e)  # Register unknown error
-                    # Restricted Video: This video is not available in your country.
-                    # Or private account
-                    media = self.media_info_v1(media_pk)
-            else:
+                    media = self.media_info_gql(media_pk)
+                except ClientLoginRequired as e:
+                    if not self.inject_sessionid_to_public():
+                        raise e
+                    media = self.media_info_gql(media_pk)  # retry
+            except Exception as e:
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)  # Register unknown error
+                # Restricted Video: This video is not available in your country.
+                # Or private account
                 media = self.media_info_v1(media_pk)
             self._medias_cache[media_pk] = media
         return deepcopy(self._medias_cache[media_pk])  # return copy of cache (dict changes protection)

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -60,7 +60,7 @@ class DownloadVideoMixin:
         Path
             Path for the file downloaded
         """
-        media = self.media_info(media_pk, use_public=False)
+        media = self.media_info_v1(media_pk)
         assert media.media_type == 2, "Must been video"
         filename = "{username}_{media_pk}".format(username=media.user.username, media_pk=media_pk)
         return self.video_download_by_url(media.video_url, filename, folder, overwrite=overwrite)

--- a/tests/regression/test_download.py
+++ b/tests/regression/test_download.py
@@ -42,16 +42,20 @@ class DownloadRegressionTestCase(unittest.TestCase):
             video_url="https://example.com/video.mp4",
         )
 
-    def test_video_download_skips_public_media_info_lookup(self):
+    def test_video_download_uses_private_media_info_lookup(self):
         client = Client()
         media = self._video_media()
         expected = Path("/tmp/example.mp4")
 
-        with mock.patch.object(client, "media_info", return_value=media) as media_info:
-            with mock.patch.object(client, "video_download_by_url", return_value=expected) as download_by_url:
-                result = client.video_download(media.pk, folder="/tmp", overwrite=False)
+        with mock.patch.object(
+            client, "media_info", side_effect=AssertionError("public-first media_info")
+        ) as media_info:
+            with mock.patch.object(client, "media_info_v1", return_value=media) as media_info_v1:
+                with mock.patch.object(client, "video_download_by_url", return_value=expected) as download_by_url:
+                    result = client.video_download(media.pk, folder="/tmp", overwrite=False)
 
-        media_info.assert_called_once_with(media.pk, use_public=False)
+        media_info.assert_not_called()
+        media_info_v1.assert_called_once_with(media.pk)
         download_by_url.assert_called_once_with(
             media.video_url,
             f"example_{media.pk}",

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -4,40 +4,6 @@ from instagrapi.extractors import extract_media_v1
 from tests.helpers import *
 
 
-class MediaInfoRegressionTestCase(unittest.TestCase):
-    def _video_media(self, media_pk="3903542582802212941"):
-        return Media(
-            pk=media_pk,
-            id=f"{media_pk}_50838397751",
-            code="DYsK0wViWhN",
-            taken_at=datetime(2026, 1, 1),
-            media_type=2,
-            user=UserShort(
-                pk="50838397751",
-                username="example",
-                profile_pic_url="https://example.com/profile.jpg",
-            ),
-            like_count=0,
-            caption_text="",
-            usertags=[],
-            sponsor_tags=[],
-            video_url="https://example.com/video.mp4",
-        )
-
-    def test_media_info_can_skip_public_lookup(self):
-        client = Client()
-        client._medias_cache = {}
-        media = self._video_media()
-
-        with mock.patch.object(client, "media_info_gql", side_effect=AssertionError("public lookup")) as gql:
-            with mock.patch.object(client, "media_info_v1", return_value=media) as v1:
-                result = client.media_info(media.pk, use_public=False)
-
-        gql.assert_not_called()
-        v1.assert_called_once_with(media.pk)
-        self.assertEqual(result.pk, media.pk)
-
-
 class MediaInfoV2RegressionTestCase(unittest.TestCase):
     def _media_or_ad_payload(self):
         return {


### PR DESCRIPTION
## Summary
- remove the `media_info(..., use_public=False)` API added in 2.7.16
- make `video_download()` call `media_info_v1()` directly for private metadata lookup
- keep `media_info()` public-first behavior unchanged

## Tests
- `.venv/bin/python -m pytest tests/regression/test_download.py::DownloadRegressionTestCase::test_video_download_uses_private_media_info_lookup` (RED before implementation)
- `.venv/bin/python -m pytest tests/regression/test_download.py tests/regression/test_media.py`
- `.venv/bin/python -m pytest tests/regression`
- `.venv/bin/ruff check --output-format=github .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/bandit -c pyproject.toml -r instagrapi`
- `.venv/bin/mkdocs build --strict`