### PR TITLE
Add phone confirmation code helper

### DIFF
--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -21,6 +21,8 @@ Viewing and managing your profile
 | change_password(old_password: str, new_password: str) | bool | Change account password |
 | send_confirm_email(email: str) | dict | Send a confirmation code to a new email address |
 | confirm_email(email: str, code: str) | dict | Confirm a new email address with the received code |
+| send_confirm_phone_number(phone_number: str) | dict | Send a confirmation code to a new phone number |
+| confirm_phone_number(phone_number: str, code: str, has_sms_consent: bool = False) | dict | Confirm a new phone number with the received SMS code |
 
 Example:
 
@@ -82,6 +84,9 @@ UserShort(pk=1903424587, username='example', ...)
     'robocall_after_max_sms': True},
     'status': 'ok'
 }
+
+>>> cl.confirm_phone_number("+5599999999", "123456")
+{'status': 'ok'}
 ```
 
 Notes:

--- a/instagrapi/mixins/account.py
+++ b/instagrapi/mixins/account.py
@@ -437,3 +437,29 @@ class AccountMixin:
                 }
             ),
         )
+
+    def confirm_phone_number(self, phone_number: str, code: str, has_sms_consent: bool = False) -> dict:
+        """
+        Confirm new phone number by SMS code
+
+        Parameters
+        ----------
+        phone_number: str
+            Phone number
+        code: str
+            Confirmation code
+        has_sms_consent: bool, default False
+            Whether to include Instagram's SMS consent flag
+
+        Returns
+        -------
+        dict
+            Jsonified response from Instagram
+        """
+        data = {"phone_number": phone_number, "verification_code": code}
+        if has_sms_consent:
+            data["has_sms_consent"] = "true"
+        return self.private_request(
+            "accounts/verify_sms_code/",
+            self.with_extra_data(data),
+        )

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -130,3 +130,28 @@ class AccountRegressionTestCase(unittest.TestCase):
                 "code": "123456",
             },
         )
+
+    def test_confirm_phone_number_posts_verify_sms_code_payload(self):
+        client = Client()
+        client.phone_id = "phone-id"
+        client.authorization_data = {"ds_user_id": "123"}
+        client.uuid = "uuid"
+        client.android_device_id = "android-id"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.confirm_phone_number("+15551234567", "123456", has_sms_consent=True)
+
+        self.assertEqual(result, {"status": "ok"})
+        private_request.assert_called_once_with(
+            "accounts/verify_sms_code/",
+            {
+                "_uuid": "uuid",
+                "device_id": "android-id",
+                "phone_id": "phone-id",
+                "_uid": "123",
+                "guid": "uuid",
+                "phone_number": "+15551234567",
+                "verification_code": "123456",
+                "has_sms_consent": "true",
+            },
+        )


### PR DESCRIPTION
## Summary
- Add `confirm_phone_number(phone_number, code, has_sms_consent=False)` to complete the account phone confirmation flow after `send_confirm_phone_number(...)`.
- Submit the SMS code to `accounts/verify_sms_code/` with `phone_number`, `verification_code`, and optional `has_sms_consent=true`.
- Document the full phone confirmation flow in the account usage guide.

Fixes #1625.

## Tests
- [x] `.venv/bin/python -m pytest tests/regression -q` — 405 passed, 2 skipped, 5 subtests passed
- [x] `.venv/bin/ruff check instagrapi/mixins/account.py tests/regression/test_account.py`
- [x] `.venv/bin/ruff format --check instagrapi/mixins/account.py tests/regression/test_account.py`
- [x] `git diff --check`

## Live Tests
No direct live test is included for account phone confirmation. That flow requires a real new phone number, receiving an SMS code, and mutates the authenticated account contact state. Existing live phone coverage is for phone signup (`tests/live/test_signup.py::SignUpTestCase::test_phone_signup_live`), which uses signup-specific endpoints and environment-provided SMS code handling.