### PR TITLE
Add followed hashtag helper

### DIFF
--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -11,6 +11,7 @@ Pass hashtag names without the leading `#`, for example `pizza`. If a leading `#
 | hashtag_medias_recent(name: str, amount: int = 27) | List[Media] | Return recent posts for a hashtag |
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Return reels/clips for a hashtag via private API |
 | hashtag_follow(hashtag: str, unfollow: bool = False) | bool | Follow a hashtag |
+| hashtag_following(amount: int = 0) | List[Hashtag] | Return hashtags followed by the authenticated account |
 | hashtag_unfollow(hashtag: str) | bool | Unfollow a hashtag |
 
 
@@ -147,6 +148,9 @@ QVFEUXpfM0RtaDdmMExPQ0k0UWRlaHFJa2RVdVlaX01LTzhkNF9Dd1N2UlhtVy1vSTZvMERfYW5XN205
 >>> cl.hashtag_follow("python")
 True
 
+>>> cl.hashtag_following(amount=1)
+[Hashtag(id='17841562401125985', name='python', media_count=12000000, profile_pic_url=None)]
+
 >>> cl.hashtag_unfollow("python")
 True
 ```
@@ -155,5 +159,6 @@ Notes:
 
 * Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable and the `_a1` helpers were removed. Use the high-level hashtag methods or the authenticated private/mobile `_v1` helpers.
 * High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` use the private/mobile helpers.
+* `hashtag_following()` returns the authenticated following-list hashtag preview. Instagram may limit how many followed hashtags are included.
 * For resumable pagination, use `hashtag_medias_v1_chunk()` and persist the encoded `max_id` cursor.
 * `hashtag_medias_v1_chunk()` accepts `top`, `recent`, or `clips` as `tab_key`.

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -322,6 +322,56 @@ class HashtagMixin:
         result = self.private_request(f"web/tags/{name}/{hashtag}/", domain="www.instagram.com", data=data)
         return result["status"] == "ok"
 
+    def hashtag_following(self, amount: int = 0) -> List[Hashtag]:
+        """
+        Get hashtags followed by the authenticated account
+
+        Parameters
+        ----------
+        amount: int, optional
+            Maximum number of hashtags to return. Value 0 returns all hashtags
+            returned by Instagram.
+
+        Returns
+        -------
+        List[Hashtag]
+            List of objects of Hashtag
+        """
+        assert self.user_id, "Login required"
+        result = self.private_graphql_following_list(
+            str(self.user_id),
+            self.rank_token,
+            priority="u=3, i",
+            skip_preview_hashtags=False,
+            skip_hashtag_count=False,
+        )
+        data = result.get("data") or {}
+        following = next(
+            (
+                value
+                for key, value in data.items()
+                if isinstance(value, dict) and "xdt_api__v1__friendships__following" in key
+            ),
+            {},
+        )
+        hashtags = []
+        for item in following.get("preview_hashtags") or []:
+            if not isinstance(item, dict):
+                continue
+            node = item.get("hashtag") or item.get("node") or item
+            if not isinstance(node, dict) or not node:
+                continue
+            node = dict(node)
+            node["id"] = node.get("id") or node.get("pk")
+            node["media_count"] = node.get("media_count") or node.get("post_count") or node.get("postCount")
+            node["profile_pic_url"] = node.get("profile_pic_url") or node.get("profilePictureUrl") or None
+            if not node.get("id") or not node.get("name"):
+                continue
+            hashtags.append(Hashtag(**node))
+        if amount:
+            hashtags = hashtags[:amount]
+        return hashtags
+
     def hashtag_unfollow(self, hashtag: str) -> bool:
         """
         Unfollow to hashtag

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -2059,6 +2059,8 @@ class UserMixin:
         order: str = None,
         exclude_field_is_favorite: bool = None,
         exclude_unused_fields: bool = None,
+        skip_preview_hashtags: bool = True,
+        skip_hashtag_count: bool = True,
     ) -> dict:
         request_data = {
             "search_surface": "follow_list_page",
@@ -2068,7 +2070,7 @@ class UserMixin:
         variables = {
             "user_id": str(user_id),
             "skip_use_clickable_see_more": True,
-            "skip_preview_hashtags": True,
+            "skip_preview_hashtags": skip_preview_hashtags,
             "skip_should_limit_list_of_followers": True,
             "skip_pending_admins": True,
             "skip_more_groups_available": True,
@@ -2083,7 +2085,7 @@ class UserMixin:
             "include_unseen_count": True,
             "skip_has_more": True,
             "enable_groups": True,
-            "skip_hashtag_count": True,
+            "skip_hashtag_count": skip_hashtag_count,
         }
         if exclude_field_is_favorite is not None:
             variables["exclude_field_is_favorite"] = exclude_field_is_favorite

--- a/tests/live/test_hashtag.py
+++ b/tests/live/test_hashtag.py
@@ -67,3 +67,11 @@ class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(data["id"])
             self.assertTrue(data["code"])
             self.assertTrue(data["media_type"])
+
+    def test_hashtag_following(self):
+        hashtags = self.cl.hashtag_following(amount=1)
+        self.assertIsInstance(hashtags, list)
+        if hashtags:
+            self.assertIsInstance(hashtags[0], Hashtag)
+            self.assertTrue(hashtags[0].id)
+            self.assertTrue(hashtags[0].name)

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -40,3 +40,44 @@ class HashtagRegressionTestCase(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Hashtag name cannot be empty"):
             client.hashtag_medias_recent("#")
+
+    def test_hashtag_following_fetches_current_account_hashtags(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "123"}
+        response = {
+            "data": {
+                "1$xdt_api__v1__friendships__following(_request_data:$request_data,user_id:$user_id)": {
+                    "hashtag_count": 2,
+                    "preview_hashtags": [
+                        {
+                            "id": "17843845123043063",
+                            "name": "fotodestages",
+                            "media_count": 716293,
+                            "profile_pic_url": "https://example.com/fotodestages.jpg",
+                        },
+                        {
+                            "id": "17875609661266431",
+                            "name": "coachingbydregold",
+                            "media_count": 1,
+                            "profile_pic_url": "https://example.com/coachingbydregold.jpg",
+                        },
+                    ],
+                }
+            }
+        }
+        client.private_graphql_following_list = Mock(return_value=response)
+
+        hashtags = client.hashtag_following(amount=1)
+
+        self.assertEqual(len(hashtags), 1)
+        self.assertIsInstance(hashtags[0], Hashtag)
+        self.assertEqual(hashtags[0].id, "17843845123043063")
+        self.assertEqual(hashtags[0].name, "fotodestages")
+        self.assertEqual(hashtags[0].media_count, 716293)
+        client.private_graphql_following_list.assert_called_once_with(
+            "123",
+            client.rank_token,
+            priority="u=3, i",
+            skip_preview_hashtags=False,
+            skip_hashtag_count=False,
+        )


### PR DESCRIPTION
## Summary

- Closes #1643.
- Add `Client.hashtag_following(amount=0)` for hashtags followed by the authenticated account.
- Reuse the authenticated private GraphQL following-list request with hashtag preview/count fields enabled.
- Document the new helper and note that Instagram may limit the returned preview size.
- Add regression coverage plus a targeted live test for the new method.

## Notes

The older web GraphQL hashtag-following edge currently returns an execution error for this use case, so this helper uses the authenticated mobile following-list data that is still available.

## Test plan

- `./.venv/bin/python -m pytest tests/regression -q` -> 406 passed, 2 skipped, 5 subtests passed
- `./.venv/bin/python -m ruff check instagrapi tests docs` -> All checks passed
- `./.venv/bin/python -m pytest tests/live/test_hashtag.py::ClientHashtagTestCase::test_hashtag_following -q` -> 1 passed, 1 warning
