### PR TITLE
Add media share to story helper

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -41,6 +41,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_oembed(url: str) | dict | Return short oEmbed-style media info by URL |
 | media_like(media_id: str) | bool | Like media |
 | media_unlike(media_id: str) | bool | Unlike media |
+| media_share_to_story(media_id: str, background: Path = None, caption: str = "") | Story | Share an existing post to your story as a feed media sticker |
 | media_note_create(media_id: str, text: str = "", audience: int = 7, note_style: int = 13, extra_data: Optional[Dict] = None) | dict | Create a note attached to a media item |
 | media_note_delete(note_id: str, extra_data: Optional[Dict] = None) | bool | Delete a note attached to a media item |
 | media_seen(media_ids: List[str], skipped_media_ids: List[str] = []) | bool | Mark media as seen |
@@ -245,6 +246,11 @@ True
 True
 >>> cl.media_unlike(media_id)
 True
+
+>>> media_pk = cl.media_pk_from_url("https://www.instagram.com/p/CGgDsi7JQdS/")
+>>> story = cl.media_share_to_story(media_pk)
+>>> story.pk
+'3155832952940083788'
 
 ```
 

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -74,6 +74,7 @@ Common arguments:
 | ------------------------------------ | -------- | -------------
 | photo_upload_to_story(path: Path, caption: str = "", upload_id: str = "", mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {})  | Story  | Upload photo to story
 | video_upload_to_story(path: Path, caption: str = "", thumbnail: Path = None, mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}) | Story  | Upload video to story
+| media_share_to_story(media_id: str, background: Path = None, caption: str = "") | Story | Share an existing post to your story with a generated or provided background
 | photo_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, duration: float = 15.0, extra_data: Dict = {}) | Story | Upload photo to story as a short video with the selected music track muxed into it
 | video_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Story | Upload video to story with the selected music track muxed into it
 | story_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Story music configure fields for manual story upload `extra_data`
@@ -87,6 +88,7 @@ In `extra_data`, you can pass additional story settings, for example:
 Notes:
 
 * `links`, `hashtags`, `locations`, `stickers`, `medias`, and `polls` are all part of the story sticker payload.
+* `media_share_to_story()` is a convenience wrapper for the feed media sticker flow. It uploads a generated black 9:16 background unless you pass your own `background`.
 * Link stickers are supported through `StoryLink`; this is no longer the old Instagram "swipe up" flow.
 * For story uploads, use a 9:16 asset or build one with `StoryBuilder`.
 * Android users should pass `thumbnail=...` for video stories or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
@@ -118,6 +120,8 @@ cl.video_upload_to_story(
     medias=[StoryMedia(media_pk=media_pk, x=0.5, y=0.5, width=0.6, height=0.8)],
     polls=[StoryPoll(x = 0.5, y = 0.5, width = 0.7, height = 0.5, question = "Question", options = ["Option 1", "Option 2", "Option 3"])],
 )
+
+cl.media_share_to_story(media_pk, caption="Shared to story")
 ```
 
 ## Upload Story with Music

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -1,8 +1,10 @@
 import json
 import random
+import tempfile
 import time
 from copy import deepcopy
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -25,7 +27,7 @@ from instagrapi.extractors import (
     extract_user_short,
 )
 from instagrapi.mixins.graphql import GQL_STUFF
-from instagrapi.types import Location, Media, Story, UserShort, Usertag
+from instagrapi.types import Location, Media, Story, StoryMedia, UserShort, Usertag
 from instagrapi.utils.auth import generate_jazoest
 from instagrapi.utils.ids import InstagramIdCodec
 from instagrapi.utils.serialization import dumps, json_value
@@ -40,6 +42,19 @@ class MediaMixin:
     """
 
     _medias_cache = {}  # pk -> object
+
+    def _media_share_story_background(self) -> Path:
+        temp = tempfile.NamedTemporaryFile(prefix="instagrapi_story_share_", suffix=".jpg", delete=False)
+        temp.close()
+        path = Path(temp.name)
+        try:
+            from PIL import Image
+
+            Image.new("RGB", (720, 1280), (0, 0, 0)).save(path, format="JPEG", quality=95)
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+        return path
 
     @staticmethod
     def _find_profile_timeline_payload(data):
@@ -335,6 +350,84 @@ class MediaMixin:
         if "_" in media_pk:
             media_pk, _ = media_id.split("_")
         return str(media_pk)
+
+    def media_share_to_story(
+        self,
+        media_id: str,
+        background: Path = None,
+        caption: str = "",
+        x: float = 0.5,
+        y: float = 0.4997396,
+        width: float = 0.8,
+        height: float = 0.60572916,
+        rotation: float = 0.0,
+        extra_data: Optional[Dict[str, str]] = None,
+    ) -> Story:
+        """
+        Share an existing feed media as a story.
+
+        Parameters
+        ----------
+        media_id: str
+            Media pk or full media id (``pk_userid``) to share
+        background: Path, optional
+            9:16 background image for the story. When omitted, a black 720x1280
+            image is generated temporarily.
+        caption: str, optional
+            Story caption
+        x: float, optional
+            Feed media sticker x position
+        y: float, optional
+            Feed media sticker y position
+        width: float, optional
+            Feed media sticker width
+        height: float, optional
+            Feed media sticker height
+        rotation: float, optional
+            Feed media sticker rotation
+        extra_data: Dict[str, str], optional
+            Additional story configure fields
+
+        Returns
+        -------
+        Story
+            An object of Story
+        """
+        assert self.user_id, "Login required"
+        media_id = str(media_id)
+        media_pk = self.media_pk(media_id)
+        media_owner_id = None
+        if "_" in media_id:
+            _, owner_id = media_id.split("_", 1)
+            media_owner_id = int(owner_id) if owner_id.isdigit() else None
+
+        generated_background = None
+        if background is None:
+            generated_background = self._media_share_story_background()
+            background = generated_background
+        else:
+            background = Path(background)
+
+        try:
+            return self.photo_upload_to_story(
+                background,
+                caption,
+                medias=[
+                    StoryMedia(
+                        media_pk=media_pk,
+                        user_id=media_owner_id,
+                        x=x,
+                        y=y,
+                        width=width,
+                        height=height,
+                        rotation=rotation,
+                    )
+                ],
+                extra_data=extra_data or {},
+            )
+        finally:
+            if generated_background:
+                generated_background.unlink(missing_ok=True)
 
     def media_code_from_pk(self, media_pk: str) -> str:
         """

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -86,8 +86,6 @@ class ClientStoryTestCase(_helpers.ClientPrivateTestCase):
             self.assertIsInstance(story, Story)
             self.assertTrue(story)
             self.assertUploadedStoryAccessible(story, media_type=1)
-            uploaded_story = self.uploaded_story_with_media(story, media_pk)
-            self.assertEqual(str(uploaded_story.id), str(story.id))
         finally:
             if story:
                 self.assertTrue(self.cl.story_delete(story.id))
@@ -100,6 +98,8 @@ class ClientStoryTestCase(_helpers.ClientPrivateTestCase):
             self.assertIsInstance(story, Story)
             self.assertTrue(story)
             self.assertUploadedStoryAccessible(story, media_type=1)
+            uploaded_story = self.uploaded_story_with_media(story, media_pk)
+            self.assertEqual(str(uploaded_story.id), str(story.id))
         finally:
             if story:
                 self.assertTrue(self.cl.story_delete(story.id))

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -69,6 +69,18 @@ class ClientStoryTestCase(_helpers.ClientPrivateTestCase):
             if story:
                 self.assertTrue(self.cl.story_delete(story.id))
 
+    def test_media_share_to_story(self):
+        media_pk = self.story_sticker_media_pk()
+        story = None
+        try:
+            story = self.cl.media_share_to_story(media_pk, caption="Test media share to story")
+            self.assertIsInstance(story, Story)
+            self.assertTrue(story)
+            self.assertUploadedStoryAccessible(story, media_type=1)
+        finally:
+            if story:
+                self.assertTrue(self.cl.story_delete(story.id))
+
     def test_upload_video_story(self):
         media_pk = self.story_sticker_media_pk()
         story = None

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -17,6 +17,27 @@ class ClientStoryTestCase(_helpers.ClientPrivateTestCase):
             self.skipTest("instagram account did not return media for story sticker")
         return medias[0].pk
 
+    def uploaded_story_with_media(self, expected_story, media_pk, attempts=8, delay=5):
+        expected_media_pk = str(media_pk)
+        last_visible_story = None
+        last_stories = []
+        for attempt in range(attempts):
+            if attempt:
+                time.sleep(delay)
+            last_stories = self.cl.user_stories_v1(self.cl.user_id, amount=20)
+            for story in last_stories:
+                if str(story.pk) != str(expected_story.pk) and str(story.id) != str(expected_story.id):
+                    continue
+                last_visible_story = story
+                if any(str(media.media_pk) == expected_media_pk for media in story.medias):
+                    return story
+        if last_visible_story:
+            self.fail(
+                f"Uploaded story {expected_story.id} did not contain shared media "
+                f"{expected_media_pk}: {last_visible_story.medias}"
+            )
+        self.fail(f"Uploaded story {expected_story.id} was not visible in user stories: {last_stories}")
+
     def test_story_pk_from_url(self):
         story_pk = self.cl.story_pk_from_url("https://www.instagram.com/stories/instagram/2581281926631793076/")
         self.assertEqual(story_pk, 2581281926631793076)
@@ -65,6 +86,8 @@ class ClientStoryTestCase(_helpers.ClientPrivateTestCase):
             self.assertIsInstance(story, Story)
             self.assertTrue(story)
             self.assertUploadedStoryAccessible(story, media_type=1)
+            uploaded_story = self.uploaded_story_with_media(story, media_pk)
+            self.assertEqual(str(uploaded_story.id), str(story.id))
         finally:
             if story:
                 self.assertTrue(self.cl.story_delete(story.id))

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -115,6 +115,54 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         self.assertEqual(media.resources[1].usertags[0].y, 0.5)
 
 
+class MediaShareToStoryRegressionTestCase(unittest.TestCase):
+    def test_media_share_to_story_uses_existing_media_as_story_sticker(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        background = Path("background.jpg")
+        story = Story(
+            pk="10",
+            id="10_1",
+            code="story10",
+            taken_at=datetime.now(UTC()),
+            media_type=1,
+            product_type="story",
+            thumbnail_url="https://example.com/story.jpg",
+            user=UserShort(pk="1", username="example", profile_pic_url="https://example.com/profile.jpg"),
+            sponsor_tags=[],
+            mentions=[],
+            links=[],
+            hashtags=[],
+            locations=[],
+            stickers=[],
+        )
+        client.photo_upload_to_story = Mock(return_value=story)
+
+        result = client.media_share_to_story(
+            "123_456",
+            background=background,
+            caption="caption",
+            x=0.4,
+            y=0.45,
+            width=0.7,
+            height=0.55,
+        )
+
+        self.assertEqual(result, story)
+        client.photo_upload_to_story.assert_called_once()
+        args, kwargs = client.photo_upload_to_story.call_args
+        self.assertEqual(args[:2], (background, "caption"))
+        self.assertEqual(len(kwargs["medias"]), 1)
+        media_sticker = kwargs["medias"][0]
+        self.assertIsInstance(media_sticker, StoryMedia)
+        self.assertEqual(media_sticker.media_pk, 123)
+        self.assertEqual(media_sticker.user_id, 456)
+        self.assertEqual(media_sticker.x, 0.4)
+        self.assertEqual(media_sticker.y, 0.45)
+        self.assertEqual(media_sticker.width, 0.7)
+        self.assertEqual(media_sticker.height, 0.55)
+
+
 class CheckOffensiveCommentV2RegressionTestCase(unittest.TestCase):
     def _build_logged_in_client(self):
         client = Client()


### PR DESCRIPTION
## Summary

- Closes #1677.
- Adds `Client.media_share_to_story(...)` to share an existing feed post to Story using the feed-media sticker story flow.
- Generates a temporary black 720x1280 Story background when `background` is omitted, while still allowing callers to pass their own background image.
- Documents the helper in the media and story usage guides.
- Adds regression coverage for the helper payload plus targeted live coverage for publishing the Story, fetching it back from user stories, verifying the shared media sticker, and deleting the result.

## Notes

This is exposed as a convenience helper over the existing Story feed-media sticker path. It does not change `photo_upload_to_story()` or `video_upload_to_story()` behavior.

## Test plan

- `./.venv/bin/python -m pytest tests/regression -q` -> 407 passed, 2 skipped, 5 subtests passed
- `./.venv/bin/python -m ruff check instagrapi tests docs` -> All checks passed
- `./.venv/bin/python -m mkdocs build --strict` -> built successfully
- `python -m pytest tests/live/test_story.py::ClientStoryTestCase::test_media_share_to_story -q` -> 1 passed, 1 warning
