### PR TITLE
Improve Reel upload failure errors

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -37,6 +37,30 @@ class ClipMixin:
     Helpers for CLIP/Reel actions
     """
 
+    def _raise_clip_upload_error(self, response, stage: str) -> None:
+        self.last_response = response
+        status_code = getattr(response, "status_code", None)
+        response_text = getattr(response, "text", "") or ""
+        error_response = {}
+        try:
+            parsed = response.json()
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            error_response = parsed
+            self.last_json = parsed
+        else:
+            self.last_json = {}
+        details = response_text or error_response
+        raise ClipNotUpload(
+            f"Clip upload failed during {stage}: HTTP {status_code}: {details}",
+            response=response,
+            stage=stage,
+            status_code=status_code,
+            error_response=error_response,
+            response_text=response_text,
+        )
+
     def clip_pin(self, media_pk: str, revert: bool = False) -> bool:
         """
         Pin Reel to the Reels tab/profile Reels grid
@@ -477,7 +501,7 @@ class UploadClipMixin:
         )
         self.request_log(response)
         if response.status_code != 200:
-            raise ClipNotUpload(response=self.last_response, **self.last_json)
+            self._raise_clip_upload_error(response, "upload_settings")
         rupload_params = {
             "provenance_metadata": json.dumps({"origin": ["EXTERNAL"]}),
             "upload_media_height": str(height),
@@ -511,7 +535,7 @@ class UploadClipMixin:
         )
         self.request_log(response)
         if response.status_code != 200:
-            raise ClipNotUpload(response=self.last_response, **self.last_json)
+            self._raise_clip_upload_error(response, "rupload_init")
         headers = {
             "Offset": "0",
             "X-Entity-Name": upload_name,
@@ -527,7 +551,7 @@ class UploadClipMixin:
         )
         self.request_log(response)
         if response.status_code != 200:
-            raise ClipNotUpload(response=self.last_response, **self.last_json)
+            self._raise_clip_upload_error(response, "rupload_upload")
         # CONFIGURE
         # self.igtv_composer_session_id = self.generate_uuid()  #issue
         for attempt in range(50):

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -1,4 +1,4 @@
-from instagrapi.exceptions import ClientNotFoundError, MediaNotFound
+from instagrapi.exceptions import ClientNotFoundError, ClipNotUpload, MediaNotFound
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -359,10 +359,36 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             self.assertIsInstance(media, Media)
             self.assertEqual(media.caption_text, caption_text)
             # self.assertLocation(media.location)
-            self.assertUploadedMediaAccessible(media, media_type=2, product_type="clips", caption_text=caption_text)
+            payload = self.assertUploadedMediaAccessible(
+                media,
+                media_type=2,
+                product_type="clips",
+                caption_text=caption_text,
+            )
+            self.assertTrue(payload.get("video_versions"))
+            self.assertEqual((payload.get("caption") or {}).get("text"), caption_text)
         finally:
             if media:
                 self.assertTrue(self.cl.media_delete(media.id))
+
+    def test_clip_upload_direct_failure_reports_response_live(self):
+        path = self.make_video_fixture(label="clip upload failure fixture")
+        response = requests.Response()
+        response.status_code = 400
+        response.url = "https://i.instagram.com/upload_settings/test"
+        response._content = b'{"message":"media_needs_reupload","status":"fail"}'
+        response.request = requests.Request("POST", response.url).prepare()
+
+        with mock.patch.object(self.cl.private, "post", return_value=response):
+            with self.assertRaises(ClipNotUpload) as ctx:
+                self.cl.clip_upload(path, "Upload clip failure")
+
+        exc = ctx.exception
+        self.assertIs(exc.response, response)
+        self.assertEqual(exc.stage, "upload_settings")
+        self.assertEqual(exc.status_code, 400)
+        self.assertEqual(exc.error_response["message"], "media_needs_reupload")
+        self.assertNotIn("response': None", str(exc))
 
     def test_reel_upload_with_music(self):
         # media_type: 2 (video, not IGTV)

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+from instagrapi.exceptions import ClipNotUpload
 from instagrapi.extractors import extract_media_v1
 from tests.helpers import *
 
@@ -982,6 +983,28 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(rupload_params["xsharing_user_ids"], "[]")
         self.assertEqual(rupload_params["upload_media_duration_ms"], "6023")
         self.assertEqual(rupload_params["session_id"], rupload_params["upload_id"])
+
+    def test_clip_upload_preserves_direct_upload_failure_response(self):
+        client = self.build_client()
+        failure = Mock(status_code=400, text='{"message":"media_needs_reupload","status":"fail"}')
+        failure.json.return_value = {"message": "media_needs_reupload", "status": "fail"}
+
+        with mock.patch(
+            "instagrapi.mixins.clip.analyze_video",
+            return_value=(Path("/tmp/thumb.jpg"), 720, 1280, 6.023),
+        ):
+            with mock.patch.object(client.private, "post", return_value=failure):
+                with mock.patch("builtins.open", mock.mock_open(read_data=b"video-bytes")):
+                    with self.assertRaises(ClipNotUpload) as ctx:
+                        client.clip_upload(Path("example.mp4"), "caption")
+
+        exc = ctx.exception
+        self.assertIs(exc.response, failure)
+        self.assertEqual(exc.stage, "upload_settings")
+        self.assertEqual(exc.status_code, 400)
+        self.assertEqual(exc.error_response["message"], "media_needs_reupload")
+        self.assertIn("upload_settings", str(exc))
+        self.assertNotIn("response': None", str(exc))
 
     def test_clip_upload_trial_adds_trial_params_without_mutating_extra_data(self):
         client = self.build_client()


### PR DESCRIPTION
## Summary
- preserve the actual direct upload response when Reel upload setup or rupload steps fail
- include the failing upload stage, HTTP status, parsed JSON body, and response text on `ClipNotUpload`
- add regression coverage for the previous `response=None` error and live coverage for both the failure path and a successful Reel read-back

Fixes #2575

## Tests
- `.venv/bin/python -m pytest tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_upload_preserves_direct_upload_failure_response -q`
- `.venv/bin/python -m pytest tests/regression/test_upload.py tests/regression/test_video_metadata.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py`
- live: `tests/live/test_upload.py::ClienUploadTestCase::test_clip_upload_direct_failure_reports_response_live`
- live: `tests/live/test_upload.py::ClienUploadTestCase::test_clip_upload`