### PR TITLE
Complete realtime Direct MQTT helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,14 @@ for thread in threads:
     print(thread.id, thread.thread_title, last_message.text if last_message else "")
 ```
 
-### Receive Direct messages with Realtime MQTT
+### Work with Direct messages over Realtime MQTT
 
-Realtime MQTT support is experimental and receive-oriented. It opens Instagram's
-private MQTToT connection after login, emits live callbacks, and uses the same
-`Client.proxy` settings as HTTP requests. Use the regular `direct_*` methods for
-replies, reactions, media, and other actions.
+Realtime MQTT support is experimental. It opens Instagram's private MQTToT
+connection after login, emits live callbacks, and uses the same `Client.proxy`
+settings as HTTP requests. The realtime client can receive Direct message sync
+events and publish lightweight Direct actions such as text, reactions, typing,
+and seen state. Use the regular `direct_*` methods for media sends and full
+thread management.
 
 ```python
 import json
@@ -203,6 +205,7 @@ rt.direct_subscribe()
 
 try:
     rt.ping()
+    rt.direct_send_text(THREAD_ID, "Hello from MQTT")
     while True:
         rt.read_once()
 finally:

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -3,9 +3,10 @@
 !!! warning
     Realtime MQTT support is experimental. Instagram can change this private transport without notice.
 
-The realtime client opens Instagram's MQTToT connection for receiving live events after login.
+The realtime client opens Instagram's MQTToT connection for live events after login.
 It is useful when you need callbacks for realtime payloads instead of polling HTTP endpoints.
-Use the Direct methods for sending messages, reactions, and media.
+It can also publish lightweight Direct actions over MQTT. Use the regular Direct methods for media sends
+and complete thread management.
 
 | Method | Return | Description |
 | --- | --- | --- |
@@ -23,6 +24,12 @@ Use the Direct methods for sending messages, reactions, and media.
 | `graph_ql_subscribe(subscriptions)` | Publish raw GraphQL realtime subscriptions |
 | `skywalker_subscribe(subscriptions)` | Publish raw Skywalker subscriptions |
 | `iris_subscribe(seq_id, snapshot_at_ms)` | Publish Direct inbox sync state for message-sync events |
+| `direct_subscribe(amount=1)` | Fetch Direct inbox sync state and subscribe to message-sync events |
+| `direct_send_text(thread_id, text, client_context=None)` | Publish a Direct text message over MQTT |
+| `direct_send_reaction(thread_id, item_id, emoji="", ...)` | Publish a Direct reaction over MQTT |
+| `direct_mark_seen(thread_id, item_id)` | Publish Direct seen state over MQTT |
+| `direct_indicate_activity(thread_id, is_active=True, client_context=None)` | Publish Direct typing/activity state over MQTT |
+| `send_foreground_state(...)` | Publish foreground state and optional topic changes |
 | `publish_json(topic, data)` | Publish a JSON payload to a raw MQTToT topic |
 | `ping()` | Send a keepalive ping and wait for `PINGRESP` |
 | `read_once()` | Read and dispatch one packet |
@@ -79,8 +86,18 @@ finally:
     cl.realtime_disconnect()
 ```
 
-Direct message sync is receive-only. Use the normal `direct_*` methods for replies, reactions, media, and other actions.
-The payload shape is private and can change server-side, so inspect the received dictionary before depending on nested keys.
+Send lightweight Direct actions over MQTT:
+
+``` python
+rt.direct_send_text(thread_id, "Hello from MQTT")
+rt.direct_send_reaction(thread_id, item_id, emoji="❤️")
+rt.direct_indicate_activity(thread_id, is_active=True)
+rt.direct_mark_seen(thread_id, item_id)
+```
+
+For photos, videos, voice, thread creation, request approval, and other full Direct operations, use the normal
+`direct_*` HTTP methods. The MQTT payload shape is private and can change server-side, so inspect received
+dictionaries before depending on nested keys.
 
 Subscribe to raw realtime topics:
 
@@ -96,4 +113,8 @@ Events:
 
 * `receive` is emitted for every decoded publish packet as `{"topic": topic, "payload": payload}`.
 * `message` is emitted for message-sync payloads.
+* `direct` is emitted for parsed Direct realtime payloads from message-sync or realtime-sub streams.
+* `typing`, `seen`, and `presence` are emitted for Direct realtime payloads that can be classified.
+* `send_response` is emitted for MQTT Direct command responses.
+* `iris_sub_response` is emitted for Iris subscription responses.
 * `realtime_sub` is emitted for realtime subscription payloads.

--- a/instagrapi/realtime/client.py
+++ b/instagrapi/realtime/client.py
@@ -1,5 +1,6 @@
 import json
 import time
+import uuid
 from collections import defaultdict
 from typing import Any, Callable, Dict, Iterable, List
 
@@ -7,6 +8,8 @@ from instagrapi.realtime.mqttot import (
     MQTToTConnection,
     MQTToTTopics,
     SocketMQTToTTransport,
+    ThriftDescriptor,
+    ThriftTypes,
     compress_payload,
     decode_packet,
     parse_json_payload,
@@ -15,6 +18,7 @@ from instagrapi.realtime.mqttot import (
     write_disconnect_packet,
     write_pingreq_packet,
     write_publish_packet,
+    write_thrift_object,
 )
 
 REALTIME_HOST = "edge-mqtt.facebook.com"
@@ -130,11 +134,110 @@ class RealtimeClient:
         self.iris_subscribe(**state)
         return state
 
+    def direct_send_text(self, thread_id: int | str, text: str, client_context: str | None = None) -> Dict[str, Any]:
+        return self._publish_direct_command(
+            "send_item",
+            thread_id,
+            {"item_type": "text", "text": text},
+            client_context=client_context or self.new_client_context(),
+        )
+
+    def direct_send_reaction(
+        self,
+        thread_id: int | str,
+        item_id: str,
+        emoji: str = "",
+        reaction_type: str = "like",
+        reaction_status: str = "created",
+        target_item_type: str = "text",
+        client_context: str | None = None,
+    ) -> Dict[str, Any]:
+        return self._publish_direct_command(
+            "send_item",
+            thread_id,
+            {
+                "item_type": "reaction",
+                "item_id": item_id,
+                "node_type": "item",
+                "reaction_type": reaction_type,
+                "reaction_status": reaction_status,
+                "target_item_type": target_item_type,
+                "emoji": emoji,
+            },
+            client_context=client_context or self.new_client_context(),
+        )
+
+    def direct_mark_seen(self, thread_id: int | str, item_id: str) -> Dict[str, Any]:
+        return self._publish_direct_command("mark_seen", thread_id, {"item_id": item_id})
+
+    def direct_indicate_activity(
+        self,
+        thread_id: int | str,
+        is_active: bool = True,
+        client_context: str | None = None,
+    ) -> Dict[str, Any]:
+        return self._publish_direct_command(
+            "indicate_activity",
+            thread_id,
+            {"activity_status": "1" if is_active else "0"},
+            client_context=client_context or self.new_client_context(),
+        )
+
+    def send_foreground_state(
+        self,
+        in_foreground_app: bool | None = None,
+        in_foreground_device: bool | None = None,
+        keep_alive_timeout: int | None = None,
+        subscribe_topics: List[str] | None = None,
+        subscribe_generic_topics: List[str] | None = None,
+        unsubscribe_topics: List[str] | None = None,
+        unsubscribe_generic_topics: List[str] | None = None,
+        request_id: int | None = None,
+    ) -> Dict[str, Any]:
+        state = {
+            "inForegroundApp": in_foreground_app,
+            "inForegroundDevice": in_foreground_device,
+            "keepAliveTimeout": keep_alive_timeout,
+            "subscribeTopics": subscribe_topics,
+            "subscribeGenericTopics": subscribe_generic_topics,
+            "unsubscribeTopics": unsubscribe_topics,
+            "unsubscribeGenericTopics": unsubscribe_generic_topics,
+            "requestId": request_id,
+        }
+        state = {key: value for key, value in state.items() if value is not None}
+        self._publish_bytes(
+            MQTToTTopics.FOREGROUND_STATE,
+            compress_payload(b"\x00" + write_thrift_object(state, self.foreground_state_descriptors())),
+        )
+        return state
+
+    def _publish_direct_command(
+        self,
+        action: str,
+        thread_id: int | str,
+        data: Dict[str, Any],
+        client_context: str | None = None,
+    ) -> Dict[str, Any]:
+        payload = {"action": action, "thread_id": str(thread_id), **data}
+        if client_context:
+            payload["client_context"] = client_context
+        self._publish_bytes(
+            MQTToTTopics.SEND_MESSAGE,
+            compress_payload(json.dumps(payload, separators=(",", ":")).encode()),
+        )
+        state = {"thread_id": str(thread_id), "action": action}
+        if client_context:
+            state["client_context"] = client_context
+        return state
+
     def publish_json(self, topic: str, data: Dict[str, Any]) -> None:
+        self._publish_bytes(topic, compress_payload(json.dumps(data, separators=(",", ":")).encode()))
+
+    def _publish_bytes(self, topic: str, payload: bytes) -> None:
         self._packet_id += 1
         packet = write_publish_packet(
             topic,
-            compress_payload(json.dumps(data, separators=(",", ":")).encode()),
+            payload,
             qos=1,
             packet_id=self._packet_id,
         )
@@ -185,10 +288,14 @@ class RealtimeClient:
             except (UnicodeDecodeError, json.JSONDecodeError):
                 parsed = body
         self.emit("receive", {"topic": topic, "payload": parsed})
+        if topic == MQTToTTopics.SEND_MESSAGE_RESPONSE:
+            self.emit("send_response", parsed)
+        if topic == MQTToTTopics.IRIS_SUB_RESPONSE:
+            self.emit("iris_sub_response", parsed)
         if topic == MQTToTTopics.MESSAGE_SYNC:
             self.dispatch_message_sync(parsed)
         if topic == MQTToTTopics.REALTIME_SUB:
-            self.emit("realtime_sub", parsed)
+            self.dispatch_realtime_sub(parsed)
         return parsed
 
     def dispatch_message_sync(self, payload: Any) -> None:
@@ -230,6 +337,76 @@ class RealtimeClient:
                     self.emit("message", wrapper)
                 else:
                     self.emit("thread_update", wrapper)
+                self.dispatch_direct_realtime_event({"path": path, "op": patch.get("op"), "value": value})
+
+    def dispatch_realtime_sub(self, payload: Any) -> None:
+        self.emit("realtime_sub", payload)
+        if not isinstance(payload, dict):
+            return
+        message = payload.get("message")
+        if isinstance(message, str):
+            try:
+                self.dispatch_direct_realtime_payload(json.loads(message))
+            except json.JSONDecodeError:
+                return
+            return
+        if not isinstance(message, dict):
+            return
+        if message.get("topic") != "direct":
+            return
+        direct_payload = message.get("json") or message.get("payload")
+        if isinstance(direct_payload, str):
+            try:
+                direct_payload = json.loads(direct_payload)
+            except json.JSONDecodeError:
+                direct_payload = {"value": direct_payload}
+        self.dispatch_direct_realtime_payload(direct_payload)
+
+    def dispatch_direct_realtime_payload(self, payload: Any) -> None:
+        if not isinstance(payload, dict):
+            self.dispatch_direct_realtime_event({"value": payload})
+            return
+        data = payload.get("data")
+        if not isinstance(data, list):
+            self.dispatch_direct_realtime_event(payload)
+            return
+        meta = {key: value for key, value in payload.items() if key != "data"}
+        for item in data:
+            if isinstance(item, dict):
+                self.dispatch_direct_realtime_event({**meta, **item})
+            else:
+                self.dispatch_direct_realtime_event({**meta, "value": item})
+
+    def dispatch_direct_realtime_event(self, event: Dict[str, Any]) -> None:
+        event = dict(event)
+        value = event.get("value")
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                pass
+        event["value"] = value
+        path = event.get("path")
+        if path and "thread_id" not in event:
+            event["thread_id"] = self.thread_id_from_message_sync_path(path)
+        self.emit("direct", event)
+        kind = self.direct_realtime_event_kind(event)
+        if kind:
+            self.emit(kind, event)
+
+    @staticmethod
+    def direct_realtime_event_kind(event: Dict[str, Any]) -> str | None:
+        path = str(event.get("path") or "").lower()
+        action = str(event.get("action") or "").lower()
+        value = event.get("value")
+        value_text = json.dumps(value, sort_keys=True).lower() if isinstance(value, dict) else str(value).lower()
+        if "activity_status" in value_text or "activity_indicator" in path or "typing" in path:
+            return "typing"
+        if "presence" in path or "is_active" in value_text or "last_active" in value_text:
+            return "presence"
+        if action == "mark_seen" or "/seen" in path or "seen_" in path or "read" in path or "seen" in value_text:
+            return "seen"
+        return None
 
     @staticmethod
     def thread_id_from_message_sync_path(path: str) -> str | None:
@@ -244,6 +421,23 @@ class RealtimeClient:
     def client_app_version(self) -> str:
         device_settings = getattr(self.client, "device_settings", None) or {}
         return getattr(self.client, "app_version", None) or device_settings.get("app_version", "")
+
+    @staticmethod
+    def foreground_state_descriptors() -> List[ThriftDescriptor]:
+        return [
+            ThriftDescriptor("inForegroundApp", 1, ThriftTypes.BOOLEAN),
+            ThriftDescriptor("inForegroundDevice", 2, ThriftTypes.BOOLEAN),
+            ThriftDescriptor("keepAliveTimeout", 3, ThriftTypes.INT_32),
+            ThriftDescriptor("subscribeTopics", 4, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("subscribeGenericTopics", 5, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("unsubscribeTopics", 6, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("unsubscribeGenericTopics", 7, ThriftTypes.LIST_BINARY),
+            ThriftDescriptor("requestId", 8, ThriftTypes.INT_64),
+        ]
+
+    @staticmethod
+    def new_client_context() -> str:
+        return str(uuid.uuid4())
 
     def emit(self, event: str, payload: Any) -> None:
         for handler in self._handlers.get(event, []):

--- a/tests/live/test_realtime.py
+++ b/tests/live/test_realtime.py
@@ -41,6 +41,26 @@ class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
     def payload_contains_message(self, payload, text, sender_id):
         return self.payload_contains(payload, text) and self.payload_contains(payload, sender_id)
 
+    def direct_message_visible(self, client, thread_id, text, sender_id):
+        try:
+            messages = client.direct_messages(thread_id, amount=10)
+        except Exception:
+            messages = []
+        for message in messages:
+            if message.text == text and str(message.user_id) == str(sender_id):
+                return message
+        try:
+            request_threads = client.direct_requests(amount=10)
+        except Exception:
+            request_threads = []
+        for thread in request_threads:
+            if str(thread.id) != str(thread_id):
+                continue
+            for message in thread.messages:
+                if message.text == text and str(message.user_id) == str(sender_id):
+                    return message
+        return None
+
     def test_realtime_receives_direct_message_sync_live(self):
         receiver = self.cl
         try:
@@ -91,3 +111,61 @@ class ClientRealtimeLiveTestCase(_helpers.ClientPrivateTestCase):
                     receiver.direct_thread_hide(message.thread_id)
                 except Exception as exc:
                     logger.warning("Realtime Direct message cleanup receiver hide failed: %s", exc)
+
+    def test_realtime_direct_send_text_live(self):
+        sender = self.cl
+        try:
+            receiver = self.fresh_accounts(1, exclude_user_ids={sender.user_id})[0]
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        setup_message = None
+        mqtt_message = None
+        thread_id = None
+        transport = SocketMQTToTTransport(REALTIME_HOST, timeout=10, proxy=sender.proxy)
+        setup_text = f"instagrapi realtime setup {int(time.time())}"
+        text = f"instagrapi mqtt send live {int(time.time())}"
+
+        try:
+            setup_message = sender.direct_send(setup_text, user_ids=[receiver.user_id])
+            self.assertIsInstance(setup_message, DirectMessage)
+            thread_id = setup_message.thread_id
+
+            realtime = sender.realtime_connect(transport=transport)
+            self.assertTrue(realtime.connected)
+            self.assertTrue(sender.realtime_ping())
+
+            command = realtime.direct_send_text(thread_id, text)
+
+            deadline = time.time() + 45
+            while time.time() < deadline:
+                try:
+                    sender.realtime_read_once()
+                except TimeoutError:
+                    pass
+                mqtt_message = self.direct_message_visible(receiver, thread_id, text, sender.user_id)
+                if mqtt_message:
+                    self.assertEqual(command["thread_id"], str(thread_id))
+                    self.assertEqual(mqtt_message.text, text)
+                    return
+                time.sleep(2)
+
+            self.fail("Realtime MQTT direct_send_text did not create a visible Direct message")
+        finally:
+            sender.realtime_disconnect()
+            for message in (mqtt_message, setup_message):
+                if not message or not thread_id:
+                    continue
+                try:
+                    sender.direct_message_unsend(thread_id, message.id)
+                except Exception as exc:
+                    logger.warning("Realtime MQTT Direct send cleanup unsend failed: %s", exc)
+            if thread_id:
+                try:
+                    sender.direct_thread_hide(thread_id)
+                except Exception as exc:
+                    logger.warning("Realtime MQTT Direct send cleanup sender hide failed: %s", exc)
+                try:
+                    receiver.direct_thread_hide(thread_id)
+                except Exception as exc:
+                    logger.warning("Realtime MQTT Direct send cleanup receiver hide failed: %s", exc)

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -194,6 +194,114 @@ def test_realtime_client_direct_subscribe_fetches_inbox_and_subscribes_to_iris()
     assert state == {"seq_id": 123, "snapshot_at_ms": 456}
 
 
+def test_realtime_client_direct_send_text_publishes_mqtt_direct_command():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    realtime = RealtimeClient(client, transport=transport)
+
+    state = realtime.direct_send_text("thread-1", "hello", client_context="ctx-1")
+
+    packet = decode_packet(transport.send.call_args.args[0])
+    payload = json.loads(zlib.decompress(packet.payload))
+    assert packet.topic == MQTToTTopics.SEND_MESSAGE
+    assert payload == {
+        "action": "send_item",
+        "thread_id": "thread-1",
+        "client_context": "ctx-1",
+        "item_type": "text",
+        "text": "hello",
+    }
+    assert state == {"thread_id": "thread-1", "client_context": "ctx-1", "action": "send_item"}
+
+
+def test_realtime_client_direct_send_reaction_publishes_mqtt_direct_command():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    realtime = RealtimeClient(client, transport=transport)
+
+    realtime.direct_send_reaction("thread-1", "item-1", emoji="🔥", client_context="ctx-1")
+
+    packet = decode_packet(transport.send.call_args.args[0])
+    payload = json.loads(zlib.decompress(packet.payload))
+    assert packet.topic == MQTToTTopics.SEND_MESSAGE
+    assert payload == {
+        "action": "send_item",
+        "thread_id": "thread-1",
+        "client_context": "ctx-1",
+        "item_type": "reaction",
+        "item_id": "item-1",
+        "node_type": "item",
+        "reaction_type": "like",
+        "reaction_status": "created",
+        "target_item_type": "text",
+        "emoji": "🔥",
+    }
+
+
+def test_realtime_client_direct_indicate_activity_publishes_typing_command():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    realtime = RealtimeClient(client, transport=transport)
+
+    realtime.direct_indicate_activity("thread-1", is_active=False, client_context="ctx-1")
+
+    packet = decode_packet(transport.send.call_args.args[0])
+    payload = json.loads(zlib.decompress(packet.payload))
+    assert packet.topic == MQTToTTopics.SEND_MESSAGE
+    assert payload == {
+        "action": "indicate_activity",
+        "thread_id": "thread-1",
+        "client_context": "ctx-1",
+        "activity_status": "0",
+    }
+
+
+def test_realtime_client_direct_mark_seen_publishes_seen_command():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    realtime = RealtimeClient(client, transport=transport)
+
+    realtime.direct_mark_seen("thread-1", "item-1")
+
+    packet = decode_packet(transport.send.call_args.args[0])
+    payload = json.loads(zlib.decompress(packet.payload))
+    assert packet.topic == MQTToTTopics.SEND_MESSAGE
+    assert payload == {
+        "action": "mark_seen",
+        "thread_id": "thread-1",
+        "item_id": "item-1",
+    }
+
+
+def test_realtime_client_send_foreground_state_publishes_thrift_state():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    realtime = RealtimeClient(client, transport=transport)
+
+    realtime.send_foreground_state(keep_alive_timeout=60, subscribe_topics=["146"], request_id=99)
+
+    packet = decode_packet(transport.send.call_args.args[0])
+    payload = zlib.decompress(packet.payload)
+    assert packet.topic == MQTToTTopics.FOREGROUND_STATE
+    assert payload[0] == 0
+    state = read_thrift_object(payload[1:], realtime.foreground_state_descriptors())
+    assert state["keepAliveTimeout"] == 60
+    assert state["subscribeTopics"] == ["146"]
+    assert state["requestId"] == 99
+
+
+def test_realtime_client_dispatches_send_message_response_event():
+    client = _build_logged_in_client()
+    realtime = RealtimeClient(client, transport=mock.Mock())
+    handler = mock.Mock()
+    realtime.on("send_response", handler)
+    payload = {"status": "ok", "client_context": "ctx-1"}
+
+    realtime.dispatch_packet(MQTToTTopics.SEND_MESSAGE_RESPONSE, zlib.compress(json.dumps(payload).encode()))
+
+    handler.assert_called_once_with(payload)
+
+
 def test_message_sync_dispatch_emits_direct_message_wrapper():
     client = _build_logged_in_client()
     realtime = RealtimeClient(client, transport=mock.Mock())
@@ -222,6 +330,69 @@ def test_message_sync_dispatch_emits_direct_message_wrapper():
     assert message["op"] == "add"
     assert message["text"] == "hello"
     assert message["user_id"] == "55"
+
+
+def test_realtime_sub_dispatch_emits_direct_and_typing_events():
+    client = _build_logged_in_client()
+    realtime = RealtimeClient(client, transport=mock.Mock())
+    direct_handler = mock.Mock()
+    typing_handler = mock.Mock()
+    realtime.on("direct", direct_handler)
+    realtime.on("typing", typing_handler)
+    direct_payload = {
+        "message": {
+            "topic": "direct",
+            "json": {
+                "data": [
+                    {
+                        "path": "/direct_v2/threads/987/activity_indicator_id",
+                        "value": json.dumps({"activity_status": "1", "sender_id": "55"}),
+                    }
+                ]
+            },
+        }
+    }
+
+    realtime.dispatch_packet(MQTToTTopics.REALTIME_SUB, zlib.compress(json.dumps(direct_payload).encode()))
+
+    direct_handler.assert_called_once()
+    typing_handler.assert_called_once()
+    event = typing_handler.call_args.args[0]
+    assert event["thread_id"] == "987"
+    assert event["value"]["activity_status"] == "1"
+    assert event["value"]["sender_id"] == "55"
+
+
+def test_realtime_sub_dispatch_emits_seen_and_presence_events():
+    client = _build_logged_in_client()
+    realtime = RealtimeClient(client, transport=mock.Mock())
+    seen_handler = mock.Mock()
+    presence_handler = mock.Mock()
+    realtime.on("seen", seen_handler)
+    realtime.on("presence", presence_handler)
+    direct_payload = {
+        "message": json.dumps(
+            {
+                "data": [
+                    {
+                        "path": "/direct_v2/threads/987/seen_state",
+                        "value": json.dumps({"item_id": "item-1", "user_id": "55"}),
+                    },
+                    {
+                        "path": "/direct_v2/threads/987/presence",
+                        "value": json.dumps({"is_active": True, "user_id": "55"}),
+                    },
+                ]
+            }
+        )
+    }
+
+    realtime.dispatch_packet(MQTToTTopics.REALTIME_SUB, zlib.compress(json.dumps(direct_payload).encode()))
+
+    seen_handler.assert_called_once()
+    presence_handler.assert_called_once()
+    assert seen_handler.call_args.args[0]["thread_id"] == "987"
+    assert presence_handler.call_args.args[0]["value"]["is_active"] is True
 
 
 def test_realtime_connect_preserves_handlers_registered_before_connect():


### PR DESCRIPTION
## Summary
- add MQTT Direct command helpers for text, reactions, seen state, typing/activity state, and foreground state
- emit typed realtime events for Direct payloads: `direct`, `typing`, `seen`, `presence`, `send_response`, and `iris_sub_response`
- update README and the Realtime MQTT guide now that Direct MQTT is not receive-only
- add regression coverage for command payloads and realtime event classification
- add a two-account live test that sends a Direct text message over MQTT and verifies the receiver can see the created Direct message

## Scope
This completes the practical Direct MQTT portion of #2230. FBNS device registration is still not implemented as a separate mini-client; the shipped realtime path covers Direct sync and lightweight Direct MQTT actions.

## Tests
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_realtime.py -q`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression -q`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff check .`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff format --check instagrapi/realtime instagrapi/mixins/realtime.py tests/regression/test_realtime.py tests/live/test_realtime.py`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/mkdocs build --strict`
- `IG_PROXY=socks5://127.0.0.1:8888 /Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/live/test_realtime.py -s`