### PR TITLE
Add FBNS push MQTT client

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,36 @@ finally:
 See the full [Realtime MQTT guide](docs/usage-guide/realtime.md) for lower-level
 subscriptions and event details.
 
+### Receive Direct push notifications over FBNS
+
+FBNS uses Instagram's separate push MQTT connection and registers an Android
+push token for the logged-in session. It is useful when you need push payloads
+such as Direct notification callbacks.
+
+```python
+import json
+
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+
+def handle_push(payload):
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+cl.fbns_on("push", handle_push)
+fbns = cl.fbns_connect()
+
+try:
+    fbns.ping()
+    while True:
+        cl.fbns_read_once()
+finally:
+    cl.fbns_disconnect()
+```
+
 ## Features
 
 * Uses [Web API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) and [Mobile API](https://subzeroid.github.io/instagrapi/usage-guide/fundamentals.html) flows where available

--- a/docs/usage-guide/realtime.md
+++ b/docs/usage-guide/realtime.md
@@ -8,6 +8,9 @@ It is useful when you need callbacks for realtime payloads instead of polling HT
 It can also publish lightweight Direct actions over MQTT. Use the regular Direct methods for media sends
 and complete thread management.
 
+FBNS push notifications use a separate `mqtt-mini.facebook.com` device-auth connection. Use FBNS when you need
+Instagram push payloads, for example Direct message notification callbacks.
+
 | Method | Return | Description |
 | --- | --- | --- |
 | `realtime_connect(transport=None)` | `RealtimeClient` | Create and connect the stateful realtime client |
@@ -15,6 +18,11 @@ and complete thread management.
 | `realtime_on(event, handler)` | `None` | Register an event handler on the active realtime client |
 | `realtime_ping()` | `bool` | Send a keepalive ping and wait for `PINGRESP` |
 | `realtime_read_once()` | `Any` | Read one packet from the active realtime client |
+| `fbns_connect(transport=None, auth=None, register=True)` | `FbnsClient` | Create, connect, and register the stateful FBNS client |
+| `fbns_disconnect()` | `None` | Disconnect the active FBNS client |
+| `fbns_on(event, handler)` | `None` | Register an event handler on the active FBNS client |
+| `fbns_ping()` | `bool` | Send an FBNS keepalive ping and wait for `PINGRESP` |
+| `fbns_read_once()` | `Any` | Read one packet from the active FBNS client |
 
 `RealtimeClient` also exposes lower-level helpers:
 
@@ -99,6 +107,38 @@ For photos, videos, voice, thread creation, request approval, and other full Dir
 `direct_*` HTTP methods. The MQTT payload shape is private and can change server-side, so inspect received
 dictionaries before depending on nested keys.
 
+Receive FBNS push notifications:
+
+``` python
+import json
+
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+
+def handle_push(payload):
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+cl.fbns_on("push", handle_push)
+fbns = cl.fbns_connect()
+
+try:
+    fbns.ping()
+    while True:
+        cl.fbns_read_once()
+except KeyboardInterrupt:
+    pass
+finally:
+    cl.fbns_disconnect()
+```
+
+`fbns_connect()` registers the FBNS token with Instagram's private push register endpoint. The device-auth state
+returned by the broker is stored in `settings["fbns_auth"]`, so `dump_settings()` can persist it with the normal
+session data.
+
 Subscribe to raw realtime topics:
 
 ``` python
@@ -118,3 +158,6 @@ Events:
 * `send_response` is emitted for MQTT Direct command responses.
 * `iris_sub_response` is emitted for Iris subscription responses.
 * `realtime_sub` is emitted for realtime subscription payloads.
+* `push` is emitted for parsed FBNS `fbpushnotif` payloads.
+* FBNS also emits the notification `collapse_key` as an event name when present, for example `direct_v2_message`.
+* FBNS emits `reg_response`, `registered`, `logging`, and `pp` for registration and lower-level broker payloads.

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -903,7 +903,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         Dict
             Current session settings as a Dict
         """
-        return {
+        settings = {
             "uuids": {
                 "phone_id": self.phone_id,
                 "uuid": self.uuid,
@@ -938,6 +938,9 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "public_transport_impersonate": self.public_transport_impersonate,
             "tls_verify": self.tls_verify,
         }
+        if self.settings.get("fbns_auth"):
+            settings["fbns_auth"] = self.settings["fbns_auth"]
+        return settings
 
     def set_settings(self, settings: Dict) -> bool:
         """

--- a/instagrapi/mixins/realtime.py
+++ b/instagrapi/mixins/realtime.py
@@ -1,8 +1,9 @@
-from instagrapi.realtime import RealtimeClient
+from instagrapi.realtime import FbnsClient, FbnsDeviceAuth, RealtimeClient
 
 
 class RealtimeMixin:
     realtime = None
+    fbns = None
 
     def realtime_client(self, transport=None) -> RealtimeClient:
         return RealtimeClient(self, transport=transport)
@@ -34,3 +35,37 @@ class RealtimeMixin:
         if not self.realtime:
             raise RuntimeError("Realtime client is not connected")
         return self.realtime.ping()
+
+    def fbns_client(self, transport=None, auth: FbnsDeviceAuth = None) -> FbnsClient:
+        return FbnsClient(self, transport=transport, auth=auth)
+
+    def fbns_connect(self, transport=None, auth: FbnsDeviceAuth = None, register: bool = True) -> FbnsClient:
+        if not self.fbns:
+            self.fbns = self.fbns_client(transport=transport, auth=auth)
+        else:
+            if transport is not None:
+                self.fbns.transport = transport
+            if auth is not None:
+                self.fbns.auth = auth
+        self.fbns.connect(register=register)
+        return self.fbns
+
+    def fbns_disconnect(self) -> None:
+        if self.fbns:
+            self.fbns.disconnect()
+            self.fbns = None
+
+    def fbns_on(self, event: str, handler) -> None:
+        if not self.fbns:
+            self.fbns = self.fbns_client()
+        self.fbns.on(event, handler)
+
+    def fbns_read_once(self):
+        if not self.fbns:
+            raise RuntimeError("FBNS client is not connected")
+        return self.fbns.read_once()
+
+    def fbns_ping(self) -> bool:
+        if not self.fbns:
+            raise RuntimeError("FBNS client is not connected")
+        return self.fbns.ping()

--- a/instagrapi/realtime/__init__.py
+++ b/instagrapi/realtime/__init__.py
@@ -1,3 +1,4 @@
 from instagrapi.realtime.client import RealtimeClient
+from instagrapi.realtime.fbns import FbnsClient, FbnsDeviceAuth
 
-__all__ = ["RealtimeClient"]
+__all__ = ["FbnsClient", "FbnsDeviceAuth", "RealtimeClient"]

--- a/instagrapi/realtime/fbns.py
+++ b/instagrapi/realtime/fbns.py
@@ -1,0 +1,322 @@
+import json
+import time
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List
+
+from instagrapi.realtime.mqttot import (
+    MQTToTConnection,
+    SocketMQTToTTransport,
+    compress_payload,
+    decode_packet,
+    try_decompress_payload,
+    write_connect_packet,
+    write_disconnect_packet,
+    write_pingreq_packet,
+    write_publish_packet,
+    write_subscribe_packet,
+)
+
+FBNS_HOST = "mqtt-mini.facebook.com"
+IG_FBNS_APP_ID = 567310203415052
+FBNS_PACKAGE_NAME = "com.instagram.android"
+FBNS_SUBSCRIBE_TOPICS = [76, 80, 231]
+
+
+class FBNSTopics:
+    MESSAGE = "76"
+    REG_REQUEST = "79"
+    REG_RESPONSE = "80"
+    EXP_LOGGING = "231"
+    PP = "34"
+
+
+@dataclass
+class FbnsDeviceAuth:
+    client_id: str = ""
+    user_id: int = 0
+    password: str = ""
+    device_id: str = ""
+    device_secret: str = ""
+    server_region: str = ""
+    region_hint: str = ""
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_client(cls, client) -> "FbnsDeviceAuth":
+        settings = getattr(client, "settings", None) or {}
+        stored = settings.get("fbns_auth") or {}
+        phone_id = getattr(client, "phone_id", "") or ""
+        return cls(
+            client_id=stored.get("client_id") or phone_id[:20],
+            user_id=int(stored.get("user_id") or 0),
+            password=stored.get("password") or "",
+            device_id=stored.get("device_id") or "",
+            device_secret=stored.get("device_secret") or "",
+            server_region=stored.get("server_region") or "",
+            region_hint=stored.get("region_hint") or "",
+            raw=stored.get("raw") or {},
+        )
+
+    def read(self, payload: bytes | str | Dict[str, Any]) -> Dict[str, Any]:
+        if isinstance(payload, bytes):
+            if not payload:
+                data = {}
+            else:
+                data = json.loads(_strip_length_prefixed_json(payload).decode())
+        elif isinstance(payload, str):
+            data = json.loads(payload) if payload else {}
+        else:
+            data = dict(payload)
+        self.raw.update(data)
+        if "ck" in data:
+            self.user_id = _optional_int(data.get("ck")) or self.user_id
+        if "cs" in data:
+            self.password = str(data.get("cs") or "")
+        if "di" in data:
+            self.device_id = str(data.get("di") or "")
+            self.client_id = self.device_id[:20]
+        if "ds" in data:
+            self.device_secret = str(data.get("ds") or "")
+        if "sr" in data:
+            self.server_region = str(data.get("sr") or "")
+        if "rc" in data:
+            self.region_hint = str(data.get("rc") or "")
+        return data
+
+    def save(self, client) -> None:
+        settings = getattr(client, "settings", None)
+        if settings is not None:
+            settings["fbns_auth"] = self.to_settings()
+
+    def to_settings(self) -> Dict[str, Any]:
+        return {
+            "client_id": self.client_id,
+            "user_id": self.user_id,
+            "password": self.password,
+            "device_id": self.device_id,
+            "device_secret": self.device_secret,
+            "server_region": self.server_region,
+            "region_hint": self.region_hint,
+            "raw": self.raw,
+        }
+
+
+class FbnsClient:
+    def __init__(self, client, transport=None, auth: FbnsDeviceAuth | None = None):
+        self.client = client
+        self.transport = transport or SocketMQTToTTransport(FBNS_HOST, proxy=getattr(client, "proxy", None))
+        self.auth = auth or FbnsDeviceAuth.from_client(client)
+        self.connected = False
+        self._handlers: Dict[str, List[Callable[[Any], None]]] = defaultdict(list)
+        self._packet_id = 0
+
+    def on(self, event: str, handler: Callable[[Any], None]) -> None:
+        self._handlers[event].append(handler)
+
+    def connect(self, register: bool = True) -> None:
+        self.transport.connect()
+        self.transport.send(self.connect_packet())
+        packet = decode_packet(self.transport.recv_packet())
+        if packet.packet_type != "connack" or packet.return_code != 0:
+            raise ConnectionError(f"FBNS MQTT connect failed: {packet.return_code}")
+        self.auth.read(packet.payload)
+        self.auth.save(self.client)
+        self.emit("auth", self.auth.to_settings())
+        self.connected = True
+        if register:
+            self.subscribe(FBNSTopics.MESSAGE)
+            token = self.register_token()
+            response = self.register_push_token(token)
+            self.emit("registered", {"token": token, "response": response})
+
+    def disconnect(self) -> None:
+        if self.connected:
+            self.transport.send(write_disconnect_packet())
+        self.transport.disconnect()
+        self.connected = False
+
+    def build_connection(self) -> MQTToTConnection:
+        phone_id = getattr(self.client, "phone_id", "") or ""
+        client_id = self.auth.client_id or phone_id[:20]
+        assert client_id, "Client phone_id is required"
+        user_agent = getattr(self.client, "user_agent", "")
+        client_info = {
+            "userId": int(self.auth.user_id),
+            "userAgent": user_agent,
+            "clientCapabilities": 183,
+            "endpointCapabilities": 128,
+            "publishFormat": 1,
+            "noAutomaticForeground": True,
+            "makeUserAvailableInForeground": False,
+            "deviceId": self.auth.device_id,
+            "isInitiallyForeground": False,
+            "networkType": 1,
+            "networkSubtype": 0,
+            "clientMqttSessionId": int(time.time() * 1000) & 0xFFFFFFFF,
+            "subscribeTopics": FBNS_SUBSCRIBE_TOPICS,
+            "clientType": "device_auth",
+            "appId": IG_FBNS_APP_ID,
+            "deviceSecret": self.auth.device_secret,
+            "clientStack": 3,
+            "anotherUnknown": -1,
+        }
+        if self.auth.password:
+            client_info["fbnsConnectionSecret"] = self.auth.password
+        if self.auth.device_id:
+            client_info["fbnsDeviceId"] = self.auth.device_id
+        if self.auth.device_secret:
+            client_info["fbnsDeviceSecret"] = self.auth.device_secret
+        return MQTToTConnection(
+            client_identifier=client_id,
+            client_info=client_info,
+            password=self.auth.password,
+        )
+
+    def connect_packet(self) -> bytes:
+        return write_connect_packet(self.build_connection(), keep_alive=60)
+
+    def subscribe(self, topic: str) -> None:
+        self._packet_id += 1
+        self.transport.send(write_subscribe_packet(topic, packet_id=self._packet_id))
+
+    def register_token(self, max_packets: int = 10) -> str:
+        self._publish_bytes(
+            FBNSTopics.REG_REQUEST,
+            json.dumps(
+                {
+                    "pkg_name": FBNS_PACKAGE_NAME,
+                    "appid": IG_FBNS_APP_ID,
+                },
+                separators=(",", ":"),
+            ).encode(),
+        )
+        for _ in range(max_packets):
+            packet = decode_packet(self.transport.recv_packet())
+            if packet.packet_type != "publish":
+                continue
+            if packet.topic == FBNSTopics.REG_RESPONSE:
+                response = self.parse_packet_payload(packet.payload)
+                self._ack(packet)
+                self.emit("reg_response", response)
+                error = response.get("error") if isinstance(response, dict) else None
+                if error:
+                    raise RuntimeError(f"FBNS registration failed: {error}")
+                token = response.get("token") if isinstance(response, dict) else None
+                if not token:
+                    raise RuntimeError("FBNS registration response did not include token")
+                return str(token)
+            self.dispatch_packet(packet.topic, packet.payload)
+            self._ack(packet)
+        raise TimeoutError("FBNS registration response was not received")
+
+    def register_push_token(self, token: str) -> Dict[str, Any]:
+        data = {
+            "device_type": "android_mqtt",
+            "is_main_push_channel": True,
+            "device_sub_type": 2,
+            "device_token": token,
+            "_csrftoken": self.client.token,
+            "guid": self.client.uuid,
+            "uuid": self.client.uuid,
+            "users": str(self.client.user_id),
+            "family_device_id": str(uuid.uuid4()),
+        }
+        return self.client.private_request("push/register/", data, with_signature=False)
+
+    def read_once(self) -> Any:
+        packet = decode_packet(self.transport.recv_packet())
+        if packet.packet_type != "publish" or packet.topic is None:
+            return packet
+        payload = self.dispatch_packet(packet.topic, packet.payload)
+        self._ack(packet)
+        return payload
+
+    def ping(self, max_packets: int = 5) -> bool:
+        if not self.connected:
+            raise RuntimeError("FBNS client is not connected")
+        self.transport.send(write_pingreq_packet())
+        for _ in range(max_packets):
+            packet = decode_packet(self.transport.recv_packet())
+            if packet.packet_type == "pingresp":
+                return True
+            if packet.packet_type != "publish" or packet.topic is None:
+                return False
+            self.dispatch_packet(packet.topic, packet.payload)
+            self._ack(packet)
+        return False
+
+    def dispatch_packet(self, topic: str, payload: bytes) -> Any:
+        parsed = self.parse_packet_payload(payload)
+        if topic == FBNSTopics.MESSAGE:
+            parsed = self.dispatch_fbns_message(parsed)
+        elif topic == FBNSTopics.REG_RESPONSE:
+            self.emit("reg_response", parsed)
+        elif topic == FBNSTopics.EXP_LOGGING:
+            self.emit("logging", parsed)
+        elif topic == FBNSTopics.PP:
+            self.emit("pp", parsed)
+        else:
+            self.emit("message", parsed)
+        self.emit("receive", {"topic": topic, "payload": parsed})
+        return parsed
+
+    def dispatch_fbns_message(self, payload: Any) -> Any:
+        if not isinstance(payload, dict):
+            self.emit("message", payload)
+            return payload
+        push = payload.get("fbpushnotif")
+        if push is None:
+            self.emit("message", payload)
+            return payload
+        if isinstance(push, str):
+            try:
+                push = json.loads(push)
+            except json.JSONDecodeError:
+                push = {"value": push}
+        self.emit("push", push)
+        if isinstance(push, dict):
+            collapse_key = push.get("collapse_key")
+            if collapse_key:
+                self.emit(str(collapse_key), push)
+        return push
+
+    @staticmethod
+    def parse_packet_payload(payload: bytes) -> Any:
+        body = _strip_length_prefixed_json(payload)
+        try:
+            return json.loads(body.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return body
+
+    def _publish_bytes(self, topic: str, payload: bytes) -> None:
+        self._packet_id += 1
+        self.transport.send(write_publish_packet(topic, compress_payload(payload), qos=1, packet_id=self._packet_id))
+
+    def _ack(self, packet) -> None:
+        if packet.qos == 1 and packet.packet_id is not None:
+            self.transport.send(b"\x40\x02" + packet.packet_id.to_bytes(2, "big"))
+
+    def emit(self, event: str, payload: Any) -> None:
+        for handler in self._handlers.get(event, []):
+            handler(payload)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _strip_length_prefixed_json(payload: bytes) -> bytes:
+    body = try_decompress_payload(payload)
+    if len(body) < 3:
+        return body
+    size = int.from_bytes(body[:2], "big")
+    if size == len(body) - 2 and body[2:3] in {b"{", b"["}:
+        return body[2:]
+    return body

--- a/tests/live/test_fbns.py
+++ b/tests/live/test_fbns.py
@@ -1,0 +1,117 @@
+import os
+
+from instagrapi.realtime.fbns import FBNS_HOST
+from instagrapi.realtime.mqttot import SocketMQTToTTransport
+from tests import helpers as _helpers
+from tests.helpers import *
+
+
+class ClientFbnsLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for FBNS live tests")
+        try:
+            self.cl = self.fresh_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def payload_contains(self, payload, expected):
+        if isinstance(payload, dict):
+            return any(self.payload_contains(value, expected) for value in payload.values())
+        if isinstance(payload, (list, tuple)):
+            return any(self.payload_contains(value, expected) for value in payload)
+        return str(expected) in str(payload)
+
+    def payload_contains_push(self, payload, text, sender_id):
+        return self.payload_contains(payload, text) and self.payload_contains(payload, sender_id)
+
+    def test_fbns_connect_register_and_ping_live(self):
+        registered = []
+        auth_events = []
+        transport = SocketMQTToTTransport(FBNS_HOST, timeout=15, proxy=self.cl.proxy)
+
+        self.cl.set_push_disabled(False)
+        self.cl.fbns_on("auth", auth_events.append)
+        self.cl.fbns_on("registered", registered.append)
+
+        try:
+            fbns = self.cl.fbns_connect(transport=transport)
+
+            self.assertTrue(fbns.connected)
+            self.assertTrue(auth_events)
+            self.assertTrue(fbns.auth.password)
+            self.assertTrue(fbns.auth.device_id)
+            self.assertTrue(registered)
+            self.assertTrue(registered[0]["token"])
+            self.assertTrue(self.cl.fbns_ping())
+        finally:
+            self.cl.fbns_disconnect()
+
+    @unittest.skipUnless(
+        os.getenv("IG_RUN_FBNS_PUSH_LIVE") == "1",
+        "IG_RUN_FBNS_PUSH_LIVE=1 is required for the nondeterministic FBNS Direct push test",
+    )
+    def test_fbns_receives_direct_push_live(self):
+        receiver = self.cl
+        try:
+            sender = self.fresh_accounts(1, exclude_user_ids={receiver.user_id})[0]
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+        registered = []
+        pushes = []
+        received = []
+        message = None
+        transport = SocketMQTToTTransport(FBNS_HOST, timeout=10, proxy=receiver.proxy)
+        text = f"instagrapi fbns push live {int(time.time())}"
+
+        receiver.set_push_disabled(False)
+        receiver.fbns_on("registered", registered.append)
+        receiver.fbns_on("push", pushes.append)
+        receiver.fbns_on("receive", received.append)
+
+        try:
+            fbns = receiver.fbns_connect(transport=transport)
+            self.assertTrue(fbns.connected)
+            self.assertTrue(registered)
+            self.assertTrue(receiver.fbns_ping())
+
+            message = sender.direct_send(text, user_ids=[receiver.user_id])
+            self.assertIsInstance(message, DirectMessage)
+
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                try:
+                    receiver.fbns_read_once()
+                except TimeoutError:
+                    continue
+                for payload in pushes:
+                    if self.payload_contains_push(payload, text, sender.user_id):
+                        return
+
+            self.fail(
+                "FBNS did not deliver a Direct push payload for the live Direct message "
+                f"(received={len(received)}, pushes={len(pushes)})"
+            )
+        finally:
+            receiver.fbns_disconnect()
+            if message:
+                try:
+                    sender.direct_message_unsend(message.thread_id, message.id)
+                except Exception as exc:
+                    logger.warning("FBNS Direct push cleanup unsend failed: %s", exc)
+                try:
+                    sender.direct_thread_hide(message.thread_id)
+                except Exception as exc:
+                    logger.warning("FBNS Direct push cleanup sender hide failed: %s", exc)
+                try:
+                    receiver.direct_thread_hide(message.thread_id)
+                except Exception as exc:
+                    logger.warning("FBNS Direct push cleanup receiver hide failed: %s", exc)

--- a/tests/regression/test_fbns.py
+++ b/tests/regression/test_fbns.py
@@ -1,0 +1,250 @@
+import json
+import zlib
+from unittest import mock
+
+from instagrapi import Client
+from instagrapi.realtime import FbnsClient, FbnsDeviceAuth
+from instagrapi.realtime.fbns import FBNS_HOST, FBNS_SUBSCRIBE_TOPICS, FBNSTopics
+from instagrapi.realtime.mqttot import MQTToTConnection, decode_packet, read_thrift_object, write_publish_packet
+
+
+def _build_logged_in_client():
+    client = Client()
+    client.authorization_data = {"ds_user_id": "12345", "sessionid": "12345:session"}
+    client.phone_id = "phone-id-12345678901234567890"
+    client.uuid = "uuid-1"
+    client.user_agent = "Instagram 428.0.0.47.67 Android"
+    client.app_version = "428.0.0.47.67"
+    client.capabilities = "3brTvw=="
+    client.locale = "en_US"
+    return client
+
+
+def _packet(packet_type: int, body: bytes) -> bytes:
+    remaining = bytearray()
+    value = len(body)
+    while True:
+        byte = value % 128
+        value //= 128
+        if value:
+            byte |= 0x80
+        remaining.append(byte)
+        if not value:
+            break
+    return bytes([packet_type << 4]) + bytes(remaining) + body
+
+
+def _connack(payload: dict) -> bytes:
+    return _packet(2, b"\x00\x00" + json.dumps(payload, separators=(",", ":")).encode())
+
+
+def _publish(topic: str, payload: dict, packet_id: int = 7) -> bytes:
+    return write_publish_packet(topic, json.dumps(payload, separators=(",", ":")).encode(), packet_id=packet_id)
+
+
+def _suback(packet_id: int = 2) -> bytes:
+    return _packet(9, packet_id.to_bytes(2, "big") + b"\x01")
+
+
+def test_fbns_device_auth_reads_connack_payload_and_updates_settings():
+    client = _build_logged_in_client()
+    auth = FbnsDeviceAuth.from_client(client)
+
+    auth.read(
+        {
+            "ck": 123456,
+            "cs": "connection-secret",
+            "di": "fbns-device-id",
+            "ds": "fbns-device-secret",
+            "sr": "odn",
+            "rc": "ATN",
+        }
+    )
+    auth.save(client)
+
+    assert auth.user_id == 123456
+    assert auth.password == "connection-secret"
+    assert auth.device_id == "fbns-device-id"
+    assert auth.device_secret == "fbns-device-secret"
+    assert client.settings["fbns_auth"]["device_id"] == "fbns-device-id"
+    assert client.settings["fbns_auth"]["user_id"] == 123456
+
+
+def test_fbns_device_auth_reads_length_prefixed_connack_payload():
+    auth = FbnsDeviceAuth()
+    payload = json.dumps({"ck": 123456, "cs": "secret"}, separators=(",", ":")).encode()
+
+    auth.read(len(payload).to_bytes(2, "big") + payload)
+
+    assert auth.user_id == 123456
+    assert auth.password == "secret"
+
+
+def test_fbns_initial_device_auth_connection_uses_zero_fbns_user_id():
+    client = _build_logged_in_client()
+    fbns = FbnsClient(client)
+
+    connection = fbns.build_connection()
+
+    assert connection.client_info["userId"] == 0
+
+
+def test_fbns_client_builds_device_auth_connection():
+    client = _build_logged_in_client()
+    auth = FbnsDeviceAuth(
+        client_id="phone-id-12345678901",
+        user_id=12345,
+        password="connection-secret",
+        device_id="fbns-device-id",
+        device_secret="fbns-device-secret",
+    )
+    fbns = FbnsClient(client, auth=auth)
+
+    connection = fbns.build_connection()
+
+    assert connection.client_identifier == "phone-id-12345678901"
+    assert connection.password == "connection-secret"
+    assert connection.client_info["userId"] == 12345
+    assert connection.client_info["clientType"] == "device_auth"
+    assert connection.client_info["endpointCapabilities"] == 128
+    assert connection.client_info["subscribeTopics"] == FBNS_SUBSCRIBE_TOPICS
+    assert connection.client_info["deviceId"] == "fbns-device-id"
+    assert connection.client_info["deviceSecret"] == "fbns-device-secret"
+    assert connection.client_info["fbnsDeviceId"] == "fbns-device-id"
+
+    decoded = decode_packet(fbns.connect_packet())
+    assert decoded.keep_alive == 60
+    thrift = read_thrift_object(zlib.decompress(decoded.payload), MQTToTConnection.thrift_descriptors())
+    assert thrift["clientInfo"]["clientType"] == "device_auth"
+    assert thrift["clientInfo"]["subscribeTopics"] == FBNS_SUBSCRIBE_TOPICS
+
+
+def test_fbns_register_token_publishes_registration_request_and_reads_token():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    transport.recv_packet.return_value = _publish(FBNSTopics.REG_RESPONSE, {"token": "fbns-token-1"})
+    fbns = FbnsClient(client, transport=transport)
+
+    token = fbns.register_token()
+
+    sent = decode_packet(transport.send.call_args_list[0].args[0])
+    assert token == "fbns-token-1"
+    assert sent.topic == FBNSTopics.REG_REQUEST
+    assert json.loads(zlib.decompress(sent.payload)) == {
+        "pkg_name": "com.instagram.android",
+        "appid": 567310203415052,
+    }
+
+
+def test_fbns_connect_reads_device_auth_and_registers_push_token():
+    client = _build_logged_in_client()
+    client.private_request = mock.Mock(return_value={"status": "ok"})
+    transport = mock.Mock()
+    transport.recv_packet.side_effect = [
+        _connack(
+            {
+                "ck": 123456,
+                "cs": "connection-secret",
+                "di": "fbns-device-id",
+                "ds": "fbns-device-secret",
+            }
+        ),
+        _suback(),
+        _publish(FBNSTopics.REG_RESPONSE, {"token": "fbns-token-1"}),
+    ]
+    registered = []
+    fbns = FbnsClient(client, transport=transport)
+    fbns.on("registered", registered.append)
+
+    fbns.connect()
+
+    assert fbns.connected
+    assert fbns.auth.password == "connection-secret"
+    assert client.settings["fbns_auth"]["device_secret"] == "fbns-device-secret"
+    client.private_request.assert_called_once()
+    endpoint, data = client.private_request.call_args.args[:2]
+    assert endpoint == "push/register/"
+    assert data["device_type"] == "android_mqtt"
+    assert data["is_main_push_channel"] is True
+    assert data["device_sub_type"] == 2
+    assert data["device_token"] == "fbns-token-1"
+    assert data["users"] == "12345"
+    assert client.private_request.call_args.kwargs == {"with_signature": False}
+    assert registered == [{"token": "fbns-token-1", "response": {"status": "ok"}}]
+
+
+def test_fbns_connect_subscribes_to_message_topic_before_waiting_for_registration_response():
+    client = _build_logged_in_client()
+    client.private_request = mock.Mock(return_value={"status": "ok"})
+    transport = mock.Mock()
+    transport.recv_packet.side_effect = [_connack({}), _suback(), _publish(FBNSTopics.REG_RESPONSE, {"token": "x"})]
+    fbns = FbnsClient(client, transport=transport)
+
+    fbns.connect()
+
+    subscribe_packet = transport.send.call_args_list[1].args[0]
+    assert subscribe_packet[0] == 0x82
+    assert b"\x00\x0276" in subscribe_packet
+
+
+def test_fbns_dispatches_push_notification_payloads():
+    client = _build_logged_in_client()
+    fbns = FbnsClient(client, transport=mock.Mock())
+    push_events = []
+    direct_push_events = []
+    received_events = []
+    fbns.on("push", push_events.append)
+    fbns.on("direct_v2_message", direct_push_events.append)
+    fbns.on("receive", received_events.append)
+
+    payload = fbns.dispatch_packet(
+        FBNSTopics.MESSAGE,
+        json.dumps(
+            {
+                "fbpushnotif": json.dumps(
+                    {
+                        "collapse_key": "direct_v2_message",
+                        "message": "hello",
+                        "ig": "payload",
+                    },
+                    separators=(",", ":"),
+                )
+            },
+            separators=(",", ":"),
+        ).encode(),
+    )
+
+    assert payload["collapse_key"] == "direct_v2_message"
+    assert push_events == [payload]
+    assert direct_push_events == [payload]
+    assert received_events == [{"topic": FBNSTopics.MESSAGE, "payload": payload}]
+
+
+def test_client_exposes_stateful_fbns_helpers():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    transport.recv_packet.side_effect = [
+        _connack({}),
+        _suback(),
+        _publish(FBNSTopics.REG_RESPONSE, {"token": "fbns-token-1"}),
+    ]
+    client.private_request = mock.Mock(return_value={"status": "ok"})
+
+    fbns = client.fbns_connect(transport=transport)
+
+    assert isinstance(fbns, FbnsClient)
+    assert fbns.transport is transport
+    assert fbns.transport.connect.called
+
+    client.fbns_disconnect()
+    transport.disconnect.assert_called_once()
+
+
+def test_fbns_default_transport_uses_mqtt_mini_and_client_proxy():
+    client = _build_logged_in_client()
+    client.proxy = "socks5://127.0.0.1:8888"
+
+    fbns = FbnsClient(client)
+
+    assert fbns.transport.host == FBNS_HOST
+    assert fbns.transport.proxy == "socks5://127.0.0.1:8888"


### PR DESCRIPTION
## Summary
- add a separate FBNS MQTT client for mqtt-mini.facebook.com with device-auth state
- register FBNS tokens through push/register/ and persist fbns_auth in client settings
- dispatch /fbns_msg payloads into push/collapse-key events and expose Client.fbns_* helpers
- document FBNS usage in README and the realtime guide

Closes #2579

## Tests
- ruff check .
- python -m pytest -q tests/regression
- mkdocs build --strict
- python -m pytest -q tests/live/test_fbns.py -s (1 passed, 1 skipped; Direct push delivery test is opt-in with IG_RUN_FBNS_PUSH_LIVE=1)