### PR TITLE
Add Direct media share to existing threads

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -26,7 +26,7 @@
 | direct_thread_add_users(thread_id: int, user_ids: List[int])              | bool                    | Add users to a group thread
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
 | direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a group thread title
-| direct_media_share(media_id: str, user_ids: List[int])                    | DirectMessage           | Share a media to list of users
+| direct_media_share(media_id: str, user_ids: List[int] = [], thread_ids: List[int] = []) | DirectMessage | Share a media to users or existing threads
 | direct_story_share(story_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage       | Share a story to list of users
 | direct_profile_share(user_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage      | Share a user profile to list of users
 | direct_thread_mark_unread(thread_id: int)                                 | bool                    | Mark a thread as unread
@@ -43,7 +43,7 @@
 
 Notes:
 
-* For `direct_send()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
+* For `direct_send()`, `direct_media_share()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
 * Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_pending_requests_preview()` is the lightweight Android-app preview for request counters; use `direct_requests()` when you need the actual threads.
@@ -144,6 +144,9 @@ True
 True
 
 >>> cl.direct_media_share(media.pk, user_ids=[cl.user_id])
+DirectMessage(id=3007629312312312312312300374016, user_id=None, thread_id=340282366812313212334410641298762, timestamp=datetime.datetime(2021, 8, 31, 19, 45, 20, 708276, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
+
+>>> cl.direct_media_share(media.pk, thread_ids=[thread.id])
 DirectMessage(id=3007629312312312312312300374016, user_id=None, thread_id=340282366812313212334410641298762, timestamp=datetime.datetime(2021, 8, 31, 19, 45, 20, 708276, tzinfo=datetime.timezone.utc), item_type=None, is_shh_mode=None, reactions=None, text=None, animated_media=None, media=None, media_share=None, reel_share=None, story_share=None, felix_share=None, clip=None, placeholder=None)
 
 >>> cl.direct_story_share(media.pk, user_ids=[cl.user_id])

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1682,7 +1682,8 @@ class DirectMixin:
     def direct_media_share(
         self,
         media_id: str,
-        user_ids: List[int],
+        user_ids: List[int] = [],
+        thread_ids: List[int] = [],
         send_attribute: SEND_ATTRIBUTES_MEDIA = "feed_timeline",
         media_type: str = "photo",
     ) -> DirectMessage:
@@ -1694,7 +1695,9 @@ class DirectMixin:
         media_id: str
             Unique Media ID
         user_ids: List[int]
-            List of unique identifier of Users id
+            List of unique identifier of Users id (recipients)
+        thread_ids: List[int]
+            List of unique identifier of Direct thread id
         send_attribute: str, optional
             Sending option. Default is "feed_timeline"
         media_type: str, optional
@@ -1707,11 +1710,13 @@ class DirectMixin:
         """
         assert self.user_id, "Login required"
         token = self.generate_mutation_token()
-        media_id = self.media_id(media_id)
         user_ids = _direct_id_list(user_ids)
-        recipient_users = dumps([[int(uid) for uid in user_ids]])
+        thread_ids = _direct_id_list(thread_ids)
+        assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
+            "Specify user_ids or thread_ids, but not both"
+        )
+        media_id = self.media_id(media_id)
         kwargs = {
-            "recipient_users": recipient_users,
             "action": "send_item",
             "is_shh_mode": "0",
             "send_attribution": send_attribute,
@@ -1728,6 +1733,10 @@ class DirectMixin:
             "is_ae_dual_send": "false",
             "offline_threading_id": token,
         }
+        if user_ids:
+            kwargs["recipient_users"] = dumps([[int(uid) for uid in user_ids]])
+        if thread_ids:
+            kwargs["thread_ids"] = dumps([int(tid) for tid in thread_ids])
         if send_attribute in ["feed_contextual_chain", "feed_short_url"]:
             kwargs["inventory_source"] = "recommended_explore_grid_cover_model"
         if send_attribute == "feed_timeline":

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -409,6 +409,49 @@ class ClientDirectThreadLiveTestCase(_helpers.ClientPrivateTestCase):
                 except Exception as exc:
                     logger.warning("Direct thread cleanup failed: %s", exc)
 
+    def test_direct_media_share_to_group_thread_live(self):
+        title = f"instagrapi-media-share-{int(time.time())}"
+        thread_id = None
+        dm = None
+
+        try:
+            thread_id = self.cl.direct_thread_create(
+                [int(client.user_id) for client in self.recipient_clients],
+                title=title,
+            )
+            self.assertTrue(thread_id)
+
+            instagram = self.user_id_from_username("instagram")
+            media = next(media for media in self.cl.user_medias(instagram, amount=5) if media.id)
+            media_type = "video" if media.media_type == 2 else "photo"
+
+            dm = self.cl.direct_media_share(media.id, thread_ids=[thread_id], media_type=media_type)
+            self.assertIsInstance(dm, DirectMessage)
+            self.assertTrue(dm.id)
+            self.assertEqual(str(dm.thread_id), str(thread_id))
+
+            shared = None
+            for _ in range(6):
+                try:
+                    shared = self.cl.direct_message(thread_id, dm.id, amount=10)
+                except DirectMessageNotFound:
+                    time.sleep(2)
+                    continue
+                if shared.media_share or shared.xma_share or shared.raw_xma:
+                    break
+                time.sleep(2)
+
+            self.assertIsNotNone(shared)
+            self.assertTrue(shared.media_share or shared.xma_share or shared.raw_xma)
+        finally:
+            if thread_id:
+                try:
+                    if dm and dm.id:
+                        self.cl.direct_message_unsend(thread_id, dm.id)
+                    self.cl.direct_thread_hide(thread_id)
+                except Exception as exc:
+                    logger.warning("Direct media share group cleanup failed: %s", exc)
+
 
 class ClientDirectMessageTypesTestCase(_helpers.ClientPrivateTestCase):
     """Test that DirectMessage and DirectThread fields use structured Pydantic models instead of raw dictionaries"""

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -378,6 +378,40 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         data = private.call_args.kwargs["data"]
         self.assertEqual(json.loads(data["recipient_users"]), [[42]])
 
+    def test_direct_media_share_posts_thread_ids(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+
+        with (
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch.object(client, "media_id", return_value="123_1"),
+            mock.patch.object(
+                client, "private_request", return_value=self.direct_payload() | {"status": "ok"}
+            ) as private,
+        ):
+            client.direct_media_share("123", thread_ids=[340282366841710300949128149448121770626])
+
+        private.assert_called_once_with(
+            "direct_v2/threads/broadcast/media_share/",
+            params={"media_type": "photo"},
+            data=mock.ANY,
+            with_signature=False,
+        )
+        data = private.call_args.kwargs["data"]
+        self.assertNotIn("recipient_users", data)
+        self.assertEqual(json.loads(data["thread_ids"]), [340282366841710300949128149448121770626])
+        self.assertEqual(data["client_context"], "mutation-token")
+        self.assertEqual(data["media_id"], "123_1")
+
+    def test_direct_media_share_rejects_user_ids_and_thread_ids_together(self):
+        client = self.build_client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+
+        with self.assertRaises(AssertionError):
+            client.direct_media_share("123", user_ids=[42], thread_ids=[123])
+
     def test_direct_send_reaction_posts_reaction_payload(self):
         client = self.build_client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- allow `direct_media_share()` to target existing Direct threads via `thread_ids`
- keep `user_ids` and `thread_ids` mutually exclusive, matching other Direct helpers
- document group-thread media sharing and add regression/live coverage

## Tests
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/regression/test_direct.py -k "direct_media_share"` -> `3 passed, 37 deselected`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/regression/test_direct.py` -> `40 passed`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/regression` -> `443 passed, 2 skipped, 5 subtests passed`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/live/test_direct.py::ClientDirectThreadLiveTestCase::test_direct_media_share_to_group_thread_live -s` -> `1 passed` in 176.69s
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff check .` -> pass
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff format --check .` -> `137 files already formatted`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m mkdocs build --strict` -> pass
