### PR TITLE
Handle Direct message request privacy errors

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -54,6 +54,17 @@ Notes:
 * Disappearing direct photos and videos with `item_type == "raven_media"` are exposed through `message.visual_media`.
 * Media-changing direct endpoints are more sensitive to session quality than read-only inbox calls. Stable sessions loaded via `dump_settings()/load_settings()` are more reliable than browser-only `sessionid` reuse.
 
+Handling disabled message requests:
+
+``` python
+from instagrapi.exceptions import DirectMessageRequestsDisabled
+
+try:
+    cl.direct_send("Hello", user_ids=[user_id])
+except DirectMessageRequestsDisabled:
+    print("The recipient does not accept new Direct message requests.")
+```
+
 Example of basic actions:
 
 ``` python

--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -227,6 +227,10 @@ class DirectMessageNotFound(NotFoundError, DirectError):
     pass
 
 
+class DirectMessageRequestsDisabled(DirectError):
+    """Raised when recipient privacy settings reject a new Direct message request."""
+
+
 class VideoTooLongException(PrivateError):
     pass
 

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -21,6 +21,7 @@ from instagrapi.exceptions import (
     ClientRequestTimeout,
     ClientThrottledError,
     ClientUnauthorizedError,
+    DirectMessageRequestsDisabled,
     FeedbackRequired,
     InvalidMediaId,
     InvalidTargetUser,
@@ -40,6 +41,21 @@ from instagrapi.utils.auth import generate_signature
 from instagrapi.utils.logging import truncate_log_text
 from instagrapi.utils.serialization import dumps
 from instagrapi.utils.timing import random_delay
+
+_DIRECT_MESSAGE_REQUESTS_DISABLED_MARKERS = (
+    "can't message this account unless they follow you",
+    "can't receive your message because they don't allow new message requests",
+    "doesn't allow new message requests",
+    "don't allow new message requests",
+    "does not allow new message requests",
+)
+
+
+def _is_direct_message_requests_disabled(endpoint: str, message: str) -> bool:
+    if not endpoint or not message or "direct_v2/" not in endpoint:
+        return False
+    normalized = str(message).casefold().replace("’", "'")
+    return any(marker in normalized for marker in _DIRECT_MESSAGE_REQUESTS_DISABLED_MARKERS)
 
 
 def manual_input_code(self, username: str, choice=None):
@@ -476,6 +492,8 @@ class PrivateRequestMixin:
                     if not last_json["message"]:
                         last_json["message"] = "Two-factor authentication required"
                     raise TwoFactorRequired(**last_json)
+                elif _is_direct_message_requests_disabled(endpoint, message):
+                    raise DirectMessageRequestsDisabled(e, response=e.response, **last_json)
                 elif "VideoTooLongException" in message:
                     raise VideoTooLongException(e, response=e.response, **last_json)
                 elif "Not authorized to view user" in message:
@@ -532,6 +550,9 @@ class PrivateRequestMixin:
         except requests.ConnectionError as e:
             raise ClientConnectionError("{e.__class__.__name__} {e}".format(e=e))
         if last_json.get("status") == "fail":
+            message = last_json.get("message", "")
+            if _is_direct_message_requests_disabled(endpoint, message):
+                raise DirectMessageRequestsDisabled(response=response, **last_json)
             raise ClientError(response=response, **last_json)
         elif "error_title" in last_json:
             """Example: {

--- a/tests/regression/test_hardening.py
+++ b/tests/regression/test_hardening.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import DirectMessageRequestsDisabled
 from tests.helpers import *
 
 
@@ -76,6 +77,18 @@ class HardeningRegressionTestCase(unittest.TestCase):
         response.raise_for_status.side_effect = error
         return response
 
+    def _make_json_response(self, json_body, status_code=200):
+        response = Mock()
+        response.status_code = status_code
+        response.content = json.dumps(json_body).encode()
+        response.headers = {}
+        response.url = "https://i.instagram.com/api/v1/test/"
+        response.text = response.content.decode("utf-8")
+        response.request = Mock(method="POST")
+        response.json.return_value = json_body
+        response.raise_for_status.return_value = None
+        return response
+
     def _build_private_client(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "1"}
@@ -113,6 +126,40 @@ class HardeningRegressionTestCase(unittest.TestCase):
         with mock.patch.object(client.private, "get", return_value=response):
             with self.assertRaises(ClientNotFoundError):
                 client._send_private_request("nonexistent/")
+
+    def test_send_private_request_promotes_direct_message_requests_disabled_http_error(self):
+        client = self._build_private_client()
+        payload = {
+            "message": "You can't message this account unless they follow you.",
+            "status": "fail",
+        }
+        response = self._make_http_error_response(
+            400,
+            content=json.dumps(payload).encode(),
+            json_body=payload,
+        )
+
+        with mock.patch.object(client.private, "post", return_value=response):
+            with self.assertRaises(DirectMessageRequestsDisabled) as cm:
+                client._send_private_request("direct_v2/threads/broadcast/text/", data={"text": "hi"})
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
+
+    def test_send_private_request_promotes_direct_message_requests_disabled_status_fail(self):
+        client = self._build_private_client()
+        payload = {
+            "message": "This account can't receive your message because they don't allow new message requests from everyone.",
+            "status": "fail",
+        }
+        response = self._make_json_response(payload)
+
+        with mock.patch.object(client.private, "post", return_value=response):
+            with self.assertRaises(DirectMessageRequestsDisabled) as cm:
+                client._send_private_request("direct_v2/threads/broadcast/text/", data={"text": "hi"})
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
 
     # --- hashtag chunk: skip malformed nodes ---
 


### PR DESCRIPTION
## Summary
- add `DirectMessageRequestsDisabled` for Direct privacy/message-request rejections
- classify common Instagram Direct errors such as "can't message this account unless they follow you"
- document how to catch this error when sending Direct messages

## Tests
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest -q tests/regression` -> `445 passed, 2 skipped, 5 subtests passed`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff check .` -> pass
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff format --check .` -> `137 files already formatted`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m mkdocs build --strict` -> pass
