### PR TITLE
docs: add Telegram support playbook guidance

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -114,6 +114,7 @@
 | DirectError              | PrivateError   | Base Direct Exception
 | DirectThreadNotFound     | DirectError    | Raises when thread not found
 | DirectMessageNotFound    | DirectError    | Raises when message in thread not found
+| DirectMessageRequestsDisabled | DirectError | Raises when recipient privacy settings reject a new Direct message request
 
 ## Photo Exceptions
 

--- a/docs/usage-guide/best-practices.md
+++ b/docs/usage-guide/best-practices.md
@@ -78,12 +78,15 @@ Instagram uses several different responses for throttling, suspicious behavior, 
 ### `ClientThrottledError` / HTTP 429
 
 This usually means the current IP or request pattern is too aggressive for that path right now.
+Public web endpoints can hit this independently from private mobile endpoints; a `429` on a public GraphQL/web path does not necessarily mean the logged-in mobile session is broken.
 
 Recommended response:
 
 * stop the current burst of requests
 * back off before retrying
 * reduce concurrency for that account
+* prefer authenticated/private helpers when a public web helper repeatedly fails
+* try the optional `public_transport="curl"` path only for public web endpoints, and treat it as a transport option, not a rate-limit bypass
 * if the same account keeps hitting `429`, pause it or move it to a cleaner proxy/IP
 
 ### `PleaseWaitFewMinutes`
@@ -136,6 +139,30 @@ Recommended response:
 * Freeze accounts that hit repeated anti-abuse responses instead of hammering them harder.
 * Track errors per account, per proxy, and per action type so you can see which variable is actually causing trouble.
 * Retry transport errors differently from account restrictions. A timeout may be retried; a challenge or feedback block needs cooldown and investigation.
+
+## Automation Warnings and Suspicious Login Screens
+
+Instagram can show in-app warning screens or suspicious-login prompts even when the account is not fully challenged. These are usually trust signals tied to the account, device/session, proxy/IP history, and action pattern. They are not reliable to "bypass" generically from the library.
+
+Recommended response:
+
+* stop the affected workflow and inspect the account in the official app
+* keep the same saved settings, device identifiers, locale, country, and proxy while investigating
+* avoid repeated fresh password logins, aggressive proxy rotation, or replaying the same failed action
+* capture sanitized diagnostics: method name, endpoint if visible, exception class, `client.last_json`, status code, and whether the same account works in the official app
+* open an issue only when the same payload is reproducible; without `last_json`, the project cannot safely add a named exception
+
+## Read-Only Monitoring Workloads
+
+For small jobs that only check whether selected users posted new media or stories, keep the workflow boring:
+
+* reuse one saved session with `dump_settings()` / `load_settings()`
+* poll a small target set with a moderate interval, for example several minutes rather than seconds
+* store the last seen media/story ids locally and compare new responses against that state
+* keep this account separate from write-heavy actions such as follows, likes, comments, uploads, and Direct messages
+* expect public/web paths to be opportunistic; reliable private-account story access requires that the logged-in account has permission to view the target
+
+See [`examples/monitor_user_content.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/monitor_user_content.py) for a minimal state-file based polling example.
 
 ## Common Anti-Patterns
 

--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -55,6 +55,12 @@ Notes:
 * Current `master` raises a clearer `ChallengeRequired` for `/auth_platform/?apc=...` flows. That path is not yet supported automatically and still requires manual verification.
 * For long-running automation, persist client settings around challenge handling so you can retry without rebuilding the entire device/session state.
 
+## Selfie and manual review challenges
+
+`ChallengeSelfieCaptcha` and selfie/manual-review style flows are account review decisions by Instagram. `instagrapi` does not provide a generic bypass for these challenges. When they appear repeatedly during signup or login, stop the automated flow, keep the same account/device/proxy context, and resolve the account manually in the official app if possible.
+
+For bug reports, include sanitized `client.last_json`, the exception class, and the flow that triggered it. Do not share cookies, session IDs, phone numbers, email addresses, passwords, or verification codes.
+
 For example, you can get the code through the IMAP of Gmail:
 
 ``` python

--- a/docs/usage-guide/examples.md
+++ b/docs/usage-guide/examples.md
@@ -19,6 +19,7 @@ Common scripts:
 | --- | --- |
 | [`public_lookup.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/public_lookup.py) | Public profile lookup with optional `public_transport="curl"`. |
 | [`download_user_media.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/download_user_media.py) | Login, list recent media for a username, and download photos/videos/albums. |
+| [`monitor_user_content.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/monitor_user_content.py) | Poll a small set of users for new posts and stories using a saved session. |
 | [`upload_media.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
 | [`upload_story.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
 | [`direct_message.py`](https://github.com/subzeroid/instagrapi/blob/master/examples/direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
@@ -30,6 +31,7 @@ Examples:
 python examples/public_lookup.py instagram
 IG_PUBLIC_TRANSPORT=curl python examples/public_lookup.py instagram
 python examples/download_user_media.py instagram --amount 5 --folder ./downloads
+python examples/monitor_user_content.py instagram --stories --interval 900
 python examples/upload_media.py reel ./reel.mp4 --thumbnail ./thumb.jpg --caption "Reel"
 python examples/upload_story.py photo ./story.jpg --caption "Story"
 python examples/direct_message.py --user-ids 123456789 --text "Hello"

--- a/docs/usage-guide/handle_exception.md
+++ b/docs/usage-guide/handle_exception.md
@@ -9,7 +9,7 @@ from instagrapi.exceptions import (
     BadPassword, ReloginAttemptExceeded, ChallengeRequired,
     SelectContactPointRecoveryForm, RecaptchaChallengeForm,
     FeedbackRequired, PleaseWaitFewMinutes, LoginRequired,
-    ClientThrottledError,
+    ClientThrottledError, DirectMessageRequestsDisabled,
 )
 from instagrapi.utils import json_value
 
@@ -49,6 +49,8 @@ def handle_exception(client: Client, e: Exception):
         logger.warning("HTTP 429 from Instagram, back off and review proxy/account pressure")
     elif isinstance(e, PleaseWaitFewMinutes):
         logger.warning("Please wait before retrying: %s", e)
+    elif isinstance(e, DirectMessageRequestsDisabled):
+        logger.warning("Recipient does not accept new Direct message requests: %s", e)
     raise e
 
 cl = Client()

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,7 @@ export IG_PUBLIC_TRANSPORT_IMPERSONATE="chrome136"
 | [`session_login.py`](session_login.py) | Minimal session persistence and `sessionid` login sample. |
 | [`public_lookup.py`](public_lookup.py) | Public profile lookup with optional `public_transport="curl"`. |
 | [`download_user_media.py`](download_user_media.py) | Login, list recent media for a username, and download photos/videos/albums. |
+| [`monitor_user_content.py`](monitor_user_content.py) | Poll a small set of users for new posts and stories using a saved session. |
 | [`upload_media.py`](upload_media.py) | Upload a feed photo, feed video, Reel, or Trial Reel. |
 | [`upload_story.py`](upload_story.py) | Upload a photo or video story, optionally with a link sticker. |
 | [`direct_message.py`](direct_message.py) | Send a Direct text message to user IDs or thread IDs. |
@@ -53,6 +54,7 @@ IG_PUBLIC_TRANSPORT=curl python examples/public_lookup.py instagram
 
 ```bash
 python examples/download_user_media.py instagram --amount 5 --folder ./downloads
+python examples/monitor_user_content.py instagram --stories --interval 900
 ```
 
 ## Upload media

--- a/examples/monitor_user_content.py
+++ b/examples/monitor_user_content.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from _common import env_int, make_client
+
+from instagrapi.exceptions import ClientError
+
+
+def load_state(path: Path) -> dict:
+    if not path.exists():
+        return {"users": {}}
+    return json.loads(path.read_text())
+
+
+def save_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+def post_url(code: str | None) -> str | None:
+    if not code:
+        return None
+    return f"https://www.instagram.com/p/{code}/"
+
+
+def story_url(username: str, story_pk: str | int | None) -> str | None:
+    if not story_pk:
+        return None
+    return f"https://www.instagram.com/stories/{username}/{story_pk}/"
+
+
+def monitor_user(cl, username: str, amount: int, state: dict, include_stories: bool) -> None:
+    user_state = state.setdefault("users", {}).setdefault(username, {})
+    known_media_ids = set(user_state.get("media_ids", []))
+    known_story_pks = set(user_state.get("story_pks", []))
+
+    user_id = cl.user_id_from_username(username)
+    medias = cl.user_medias(user_id, amount=amount)
+    media_ids = [str(media.id) for media in medias if media.id]
+
+    for media in reversed(medias):
+        media_id = str(media.id)
+        if known_media_ids and media_id not in known_media_ids:
+            print(f"new post @{username}: {post_url(media.code) or media_id}")
+
+    user_state["media_ids"] = media_ids
+
+    if include_stories:
+        stories = cl.user_stories(user_id)
+        story_pks = [str(story.pk) for story in stories if story.pk]
+        for story in reversed(stories):
+            story_pk = str(story.pk)
+            if known_story_pks and story_pk not in known_story_pks:
+                print(f"new story @{username}: {story_url(username, story.pk) or story_pk}")
+        user_state["story_pks"] = story_pks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Poll a small set of users for new posts and stories.")
+    parser.add_argument("usernames", nargs="+")
+    parser.add_argument("--amount", type=int, default=env_int("IG_AMOUNT", 12))
+    parser.add_argument("--state", type=Path, default=Path("monitor_state.json"))
+    parser.add_argument("--interval", type=int, default=env_int("IG_MONITOR_INTERVAL", 0))
+    parser.add_argument("--stories", action="store_true", help="Also check active stories.")
+    args = parser.parse_args()
+
+    cl = make_client()
+    state = load_state(args.state)
+
+    while True:
+        for username in args.usernames:
+            try:
+                monitor_user(cl, username, args.amount, state, args.stories)
+            except ClientError as exc:
+                print(f"skip @{username}: {exc}")
+            time.sleep(2)
+
+        save_state(args.state, state)
+        if args.interval <= 0:
+            break
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document practical responses for public-web 429s, automation warnings, suspicious login screens, and selfie/manual review challenges
- add a saved-session monitoring example for read-only post/story polling
- surface the new Direct message request privacy exception in exception handling docs

## Tests
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mkdocs build --strict`
- `python -m pytest -q tests/regression`
