### PR TITLE
Prefer private API for authorized media info

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -256,7 +256,7 @@ True
 
 Notes:
 
-* High-level `media_info()` prefers public paths and falls back to private/mobile when needed.
+* `media_info()` uses private/mobile lookup first when the client has authorization data or a saved `sessionid`, then falls back to public/web lookup. Without authorization, it keeps public/web-first behavior. Explicit `media_info_gql()` still calls the public/web path directly.
 * For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -556,6 +556,14 @@ class MediaMixin:
             ).dict()
         return extract_media_gql(data["shortcode_media"])
 
+    def _media_info_public(self, media_pk: str) -> Media:
+        try:
+            return self.media_info_gql(media_pk)
+        except ClientLoginRequired as e:
+            if not self.inject_sessionid_to_public():
+                raise e
+            return self.media_info_gql(media_pk)
+
     def media_info_v1(self, media_pk: str) -> Media:
         """
         Get Media from PK by Private Mobile API
@@ -631,19 +639,22 @@ class MediaMixin:
         """
         media_pk = self.media_pk(media_pk)
         if not use_cache or media_pk not in self._medias_cache:
-            try:
+            if self._has_private_auth():
                 try:
-                    media = self.media_info_gql(media_pk)
-                except ClientLoginRequired as e:
-                    if not self.inject_sessionid_to_public():
-                        raise e
-                    media = self.media_info_gql(media_pk)  # retry
-            except Exception as e:
-                if not isinstance(e, ClientError):
-                    self.logger.exception(e)  # Register unknown error
-                # Restricted Video: This video is not available in your country.
-                # Or private account
-                media = self.media_info_v1(media_pk)
+                    media = self.media_info_v1(media_pk)
+                except Exception as e:
+                    if not isinstance(e, ClientError):
+                        self.logger.exception(e)  # Register unknown error
+                    media = self._media_info_public(media_pk)
+            else:
+                try:
+                    media = self._media_info_public(media_pk)
+                except Exception as e:
+                    if not isinstance(e, ClientError):
+                        self.logger.exception(e)  # Register unknown error
+                    # Restricted Video: This video is not available in your country.
+                    # Or private account
+                    media = self.media_info_v1(media_pk)
             self._medias_cache[media_pk] = media
         return deepcopy(self._medias_cache[media_pk])  # return copy of cache (dict changes protection)
 

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -6,6 +6,15 @@ class ClientMediaTestCase(_helpers.ClientPrivateTestCase):
     def test_media_id(self):
         self.assertEqual(self.cl.media_id(3258619191829745894), "3258619191829745894_25025320")
 
+    def test_media_info(self):
+        media = self.cl.media_info(3258619191829745894)
+        self.assertIsInstance(media, Media)
+        self.assertEqual(str(media.pk), "3258619191829745894")
+        self.assertEqual(media.id, "3258619191829745894_25025320")
+        self.assertEqual(media.user.pk, "25025320")
+        self.assertEqual(media.user.username, "instagram")
+        self.assertTrue(str(media.thumbnail_url).startswith("https://"))
+
     def test_media_pk(self):
         self.assertEqual(self.cl.media_pk("2154602296692269830_25025320"), "2154602296692269830")
 

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -115,6 +115,93 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         self.assertEqual(media.resources[1].usertags[0].y, 0.5)
 
 
+class MediaInfoPrivateFirstRegressionTestCase(unittest.TestCase):
+    def build_private_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        client._medias_cache = {}
+        return client
+
+    def build_media(self):
+        return Media(
+            pk="123",
+            id="123_456",
+            code="abc",
+            taken_at=datetime.now(UTC()),
+            media_type=1,
+            user=UserShort(pk="456", username="example", profile_pic_url="https://example.com/profile.jpg"),
+            like_count=0,
+            caption_text="",
+            usertags=[],
+            sponsor_tags=[],
+        )
+
+    def test_authorized_media_info_uses_private_before_public(self):
+        client = self.build_private_client()
+        media = self.build_media()
+
+        with mock.patch.object(client, "media_info_v1", return_value=media) as private_lookup:
+            with mock.patch.object(
+                client,
+                "media_info_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                result = client.media_info("123", use_cache=False)
+
+        self.assertEqual(result.pk, "123")
+        private_lookup.assert_called_once_with("123")
+        public_lookup.assert_not_called()
+
+    def test_cookie_session_media_info_uses_private_before_public(self):
+        client = Client()
+        client.private.cookies.set("sessionid", "1" * 40)
+        client._medias_cache = {}
+        media = self.build_media()
+
+        with mock.patch.object(client, "media_info_v1", return_value=media) as private_lookup:
+            with mock.patch.object(
+                client,
+                "media_info_gql",
+                side_effect=AssertionError("cookie session lookup should use private API first"),
+            ) as public_lookup:
+                result = client.media_info("123", use_cache=False)
+
+        self.assertEqual(result.pk, "123")
+        private_lookup.assert_called_once_with("123")
+        public_lookup.assert_not_called()
+
+    def test_authorized_media_info_falls_back_to_public(self):
+        client = self.build_private_client()
+        media = self.build_media()
+
+        with mock.patch.object(
+            client, "media_info_v1", side_effect=ClientError("private lookup failed")
+        ) as private_lookup:
+            with mock.patch.object(client, "media_info_gql", return_value=media) as public_lookup:
+                result = client.media_info("123", use_cache=False)
+
+        self.assertEqual(result.pk, "123")
+        private_lookup.assert_called_once_with("123")
+        public_lookup.assert_called_once_with("123")
+
+    def test_unauthorized_media_info_keeps_public_first(self):
+        client = Client()
+        client._medias_cache = {}
+        media = self.build_media()
+
+        with mock.patch.object(client, "media_info_gql", return_value=media) as public_lookup:
+            with mock.patch.object(
+                client,
+                "media_info_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                result = client.media_info("123", use_cache=False)
+
+        self.assertEqual(result.pk, "123")
+        public_lookup.assert_called_once_with("123")
+        private_lookup.assert_not_called()
+
+
 class MediaShareToStoryRegressionTestCase(unittest.TestCase):
     def test_media_share_to_story_uses_existing_media_as_story_sticker(self):
         client = Client()


### PR DESCRIPTION
## Summary
- Make high-level media_info() use private/mobile lookup first when the client has authorization data or a saved sessionid
- Keep unauthenticated media_info() public/web-first and leave explicit media_info_gql() as the public/web path
- Document the media_info() lookup order and add regression + live coverage

## Tests
- .venv/bin/python -m pytest -q tests/regression/test_media.py::MediaInfoPrivateFirstRegressionTestCase (RED before implementation: 3 failed, 1 passed)
- .venv/bin/python -m pytest -q tests/regression/test_media.py
- .venv/bin/python -m pytest -q tests/regression
- .venv/bin/python -m ruff check .
- .venv/bin/python -m ruff format --check .
- .venv/bin/python -m mkdocs build --strict
- .venv/bin/python -m bandit -c pyproject.toml -r instagrapi
- /opt/homebrew/bin/timeout 300 .venv/bin/python -m pytest -q -s --full-trace -o faulthandler_timeout=120 -o faulthandler_exit_on_timeout=true tests/live/test_media.py::ClientMediaTestCase::test_media_info