### PR TITLE
Prefer private API for authorized usertag media lookups

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -257,6 +257,7 @@ True
 Notes:
 
 * `media_info()` uses private/mobile lookup first when the client has authorization data or a saved `sessionid`, then falls back to public/web lookup. Without authorization, it keeps public/web-first behavior. Explicit `media_info_gql()` still calls the public/web path directly.
+* `usertag_medias()` and `usertag_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -1718,10 +1718,18 @@ class MediaMixin:
         """
         amount = int(amount)
         user_id = int(user_id)
-        try:
-            medias, end_cursor = self.usertag_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
-        except ClientError:
-            medias, end_cursor = self.usertag_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
+        if self._has_private_auth():
+            try:
+                medias, end_cursor = self.usertag_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
+            except Exception as e:
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                medias, end_cursor = self.usertag_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
+        else:
+            try:
+                medias, end_cursor = self.usertag_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
+            except ClientError:
+                medias, end_cursor = self.usertag_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
         return medias, end_cursor
 
     def usertag_medias(self, user_id: str, amount: int = 0) -> List[Media]:
@@ -1741,10 +1749,18 @@ class MediaMixin:
         """
         amount = int(amount)
         user_id = int(user_id)
-        try:
-            medias = self.usertag_medias_gql(user_id, amount)
-        except ClientError:
-            medias = self.usertag_medias_v1(user_id, amount)
+        if self._has_private_auth():
+            try:
+                medias = self.usertag_medias_v1(user_id, amount)
+            except Exception as e:
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                medias = self.usertag_medias_gql(user_id, amount)
+        else:
+            try:
+                medias = self.usertag_medias_gql(user_id, amount)
+            except ClientError:
+                medias = self.usertag_medias_v1(user_id, amount)
         return medias
 
     def media_configure_to_cutout_sticker(

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -202,6 +202,131 @@ class MediaInfoPrivateFirstRegressionTestCase(unittest.TestCase):
         private_lookup.assert_not_called()
 
 
+class UsertagMediasPrivateFirstRegressionTestCase(unittest.TestCase):
+    def build_private_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        return client
+
+    def build_media(self, pk="123"):
+        return Media(
+            pk=pk,
+            id=f"{pk}_456",
+            code="abc",
+            taken_at=datetime.now(UTC()),
+            media_type=1,
+            user=UserShort(pk="456", username="example", profile_pic_url="https://example.com/profile.jpg"),
+            like_count=0,
+            caption_text="",
+            usertags=[],
+            sponsor_tags=[],
+        )
+
+    def test_authorized_usertag_medias_paginated_uses_private_before_public(self):
+        client = self.build_private_client()
+        page = [self.build_media()]
+
+        with mock.patch.object(client, "usertag_medias_paginated_v1", return_value=(page, "cursor")) as private_lookup:
+            with mock.patch.object(
+                client,
+                "usertag_medias_paginated_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                medias, end_cursor = client.usertag_medias_paginated("456", amount=2)
+
+        self.assertEqual(medias, page)
+        self.assertEqual(end_cursor, "cursor")
+        private_lookup.assert_called_once_with(456, 2, end_cursor="")
+        public_lookup.assert_not_called()
+
+    def test_authorized_usertag_medias_paginated_falls_back_to_public(self):
+        client = self.build_private_client()
+        page = [self.build_media()]
+
+        with mock.patch.object(
+            client,
+            "usertag_medias_paginated_v1",
+            side_effect=ClientError("private lookup failed"),
+        ) as private_lookup:
+            with mock.patch.object(
+                client, "usertag_medias_paginated_gql", return_value=(page, "web-cursor")
+            ) as public_lookup:
+                medias, end_cursor = client.usertag_medias_paginated("456", amount=2)
+
+        self.assertEqual(medias, page)
+        self.assertEqual(end_cursor, "web-cursor")
+        private_lookup.assert_called_once_with(456, 2, end_cursor="")
+        public_lookup.assert_called_once_with(456, 2, end_cursor="")
+
+    def test_unauthorized_usertag_medias_paginated_keeps_public_first(self):
+        client = Client()
+        page = [self.build_media()]
+
+        with mock.patch.object(
+            client, "usertag_medias_paginated_gql", return_value=(page, "web-cursor")
+        ) as public_lookup:
+            with mock.patch.object(
+                client,
+                "usertag_medias_paginated_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                medias, end_cursor = client.usertag_medias_paginated("456", amount=2)
+
+        self.assertEqual(medias, page)
+        self.assertEqual(end_cursor, "web-cursor")
+        public_lookup.assert_called_once_with(456, 2, end_cursor="")
+        private_lookup.assert_not_called()
+
+    def test_authorized_usertag_medias_uses_private_before_public(self):
+        client = self.build_private_client()
+        medias = [self.build_media()]
+
+        with mock.patch.object(client, "usertag_medias_v1", return_value=medias) as private_lookup:
+            with mock.patch.object(
+                client,
+                "usertag_medias_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                result = client.usertag_medias("456", amount=2)
+
+        self.assertEqual(result, medias)
+        private_lookup.assert_called_once_with(456, 2)
+        public_lookup.assert_not_called()
+
+    def test_cookie_session_usertag_medias_uses_private_before_public(self):
+        client = Client()
+        client.private.cookies.set("sessionid", "1" * 40)
+        medias = [self.build_media()]
+
+        with mock.patch.object(client, "usertag_medias_v1", return_value=medias) as private_lookup:
+            with mock.patch.object(
+                client,
+                "usertag_medias_gql",
+                side_effect=AssertionError("cookie session lookup should use private API first"),
+            ) as public_lookup:
+                result = client.usertag_medias("456", amount=2)
+
+        self.assertEqual(result, medias)
+        private_lookup.assert_called_once_with(456, 2)
+        public_lookup.assert_not_called()
+
+    def test_unauthorized_usertag_medias_keeps_public_first(self):
+        client = Client()
+        medias = [self.build_media()]
+
+        with mock.patch.object(client, "usertag_medias_gql", return_value=medias) as public_lookup:
+            with mock.patch.object(
+                client,
+                "usertag_medias_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                result = client.usertag_medias("456", amount=2)
+
+        self.assertEqual(result, medias)
+        public_lookup.assert_called_once_with(456, 2)
+        private_lookup.assert_not_called()
+
+
 class MediaShareToStoryRegressionTestCase(unittest.TestCase):
     def test_media_share_to_story_uses_existing_media_as_story_sticker(self):
         client = Client()


### PR DESCRIPTION
## Summary
- Make high-level `usertag_medias()` and `usertag_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`.
- Keep unauthenticated high-level usertag media lookups public/web-first and leave explicit `_gql` methods as public/web paths.
- Document the lookup order and add regression coverage for authorized, cookie-session, fallback, and unauthenticated paths.

## Test Coverage
All new code paths have focused regression coverage in `UsertagMediasPrivateFirstRegressionTestCase`.

## Pre-Landing Review
No issues found in the scoped diff.

## Test plan
- `.venv/bin/python -m pytest -q tests/regression/test_media.py::UsertagMediasPrivateFirstRegressionTestCase` (RED before implementation: 4 failed, 2 passed)
- `.venv/bin/python -m pytest -q tests/regression` -> 463 passed, 2 skipped, 5 subtests passed
- `.venv/bin/python -m ruff check .` -> All checks passed
- `.venv/bin/python -m ruff format --check .` -> 138 files already formatted
- `.venv/bin/python -m mkdocs build --strict` -> built successfully
- `.venv/bin/python -m bandit -c pyproject.toml -r instagrapi` -> No issues identified
- `/opt/homebrew/bin/timeout 360 .venv/bin/python -m pytest -q -s --full-trace -o faulthandler_timeout=120 -o faulthandler_exit_on_timeout=true tests/live/test_user.py::ClientUsertagPaginationLiveTestCase::test_usertag_medias_paginated_live` -> 1 passed, 1 warning