### PR TITLE
Prefer private API for authorized user media lookups

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -257,6 +257,7 @@ True
 Notes:
 
 * `media_info()` uses private/mobile lookup first when the client has authorization data or a saved `sessionid`, then falls back to public/web lookup. Without authorization, it keeps public/web-first behavior. Explicit `media_info_gql()` still calls the public/web path directly.
+* `user_medias()` and `user_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * `usertag_medias()` and `usertag_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -1166,27 +1166,36 @@ class MediaMixin:
             A tuple containing a list of medias and the next end_cursor value
         """
 
-        class EndCursorIsV1(Exception):
-            pass
-
-        try:
-            if end_cursor and "_" in end_cursor:
-                # end_cursor is a v1 next_max_id, so we need to use v1 API
-                raise EndCursorIsV1
+        def public_lookup():
             try:
-                medias, end_cursor = self.user_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
+                medias, next_cursor = self.user_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
             except ClientLoginRequired as e:
                 if not self.inject_sessionid_to_public():
                     raise e
-                medias, end_cursor = self.user_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
-        except PrivateError as e:
-            raise e
-        except Exception as e:
-            if isinstance(e, EndCursorIsV1):
-                pass
-            elif not isinstance(e, ClientError):
-                self.logger.exception(e)
-            medias, end_cursor = self.user_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
+                medias, next_cursor = self.user_medias_paginated_gql(user_id, amount, end_cursor=end_cursor)
+            return medias, next_cursor
+
+        end_cursor_is_v1 = bool(end_cursor and "_" in end_cursor)
+        if self._has_private_auth() or end_cursor_is_v1:
+            try:
+                medias, end_cursor = self.user_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
+            except PrivateError as e:
+                raise e
+            except Exception as e:
+                if end_cursor_is_v1:
+                    raise e
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                medias, end_cursor = public_lookup()
+        else:
+            try:
+                medias, end_cursor = public_lookup()
+            except PrivateError as e:
+                raise e
+            except Exception as e:
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                medias, end_cursor = self.user_medias_paginated_v1(user_id, amount, end_cursor=end_cursor)
         return medias, end_cursor
 
     def user_medias_chunk(self, user_id: str, end_cursor: str = "") -> Tuple[List[Media], str]:
@@ -1246,22 +1255,37 @@ class MediaMixin:
         amount = int(amount)
         user_id = int(user_id)
         sleep = int(sleep)
-        try:
+
+        def public_lookup():
             try:
                 medias = self.user_medias_gql(user_id, amount, sleep)
             except ClientLoginRequired as e:
                 if not self.inject_sessionid_to_public():
                     raise e
                 medias = self.user_medias_gql(user_id, amount, sleep)  # retry
-        except PrivateError as e:
-            raise e
-        except Exception as e:
-            if not isinstance(e, ClientError):
-                self.logger.exception(e)
-            # User may been private, attempt via Private API
-            # (You can check is_private, but there may be other reasons,
-            #  it is better to try through a Private API)
-            medias = self.user_medias_v1(user_id, amount)
+            return medias
+
+        if self._has_private_auth():
+            try:
+                medias = self.user_medias_v1(user_id, amount)
+            except PrivateError as e:
+                raise e
+            except Exception as e:
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                medias = public_lookup()
+        else:
+            try:
+                medias = public_lookup()
+            except PrivateError as e:
+                raise e
+            except Exception as e:
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                # User may been private, attempt via Private API
+                # (You can check is_private, but there may be other reasons,
+                #  it is better to try through a Private API)
+                medias = self.user_medias_v1(user_id, amount)
         return medias
 
     def user_clips_paginated_v1(self, user_id: str, amount: int = 50, end_cursor: str = "") -> Tuple[List[Media], str]:

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -70,6 +70,47 @@ class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(hasattr(media, field))
 
 
+class ClientUserMediasPaginationLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for user media pagination live tests")
+        try:
+            self.cl = self.fresh_account()
+        except Exception as exc:
+            self.skipTest(str(exc))
+
+    def assertMediaPage(self, medias, amount):
+        self.assertGreater(len(medias), 0)
+        self.assertLessEqual(len(medias), amount)
+        media = medias[0]
+        self.assertIsInstance(media, Media)
+        for field in REQUIRED_MEDIA_FIELDS:
+            self.assertTrue(hasattr(media, field))
+
+    def assertNoDuplicateMediasAcrossPages(self, first_page, next_page):
+        first_ids = {media.pk for media in first_page}
+        next_ids = {media.pk for media in next_page}
+        self.assertTrue(first_ids.isdisjoint(next_ids), f"Duplicate medias across pages: {first_ids & next_ids}")
+
+    def test_user_medias_paginated_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        first_page, end_cursor = self.cl.user_medias_paginated(user_id, amount=2)
+        self.assertMediaPage(first_page, 2)
+        self.assertTrue(end_cursor)
+
+        next_page, _ = self.cl.user_medias_paginated(user_id, amount=2, end_cursor=end_cursor)
+        self.assertMediaPage(next_page, 2)
+        self.assertNoDuplicateMediasAcrossPages(first_page, next_page)
+
+
 class ClientUsertagPaginationLiveTestCase(_helpers.ClientPrivateTestCase):
     def __init__(self, *args, **kwargs):
         self.cl = None

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -327,6 +327,179 @@ class UsertagMediasPrivateFirstRegressionTestCase(unittest.TestCase):
         private_lookup.assert_not_called()
 
 
+class UserMediasPrivateFirstRegressionTestCase(unittest.TestCase):
+    def build_private_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        return client
+
+    def build_media(self, pk="123"):
+        return Media(
+            pk=pk,
+            id=f"{pk}_456",
+            code="abc",
+            taken_at=datetime.now(UTC()),
+            media_type=1,
+            user=UserShort(pk="456", username="example", profile_pic_url="https://example.com/profile.jpg"),
+            like_count=0,
+            caption_text="",
+            usertags=[],
+            sponsor_tags=[],
+        )
+
+    def test_authorized_user_medias_paginated_uses_private_before_public(self):
+        client = self.build_private_client()
+        page = [self.build_media()]
+
+        with mock.patch.object(client, "user_medias_paginated_v1", return_value=(page, "v1-cursor")) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_medias_paginated_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                medias, end_cursor = client.user_medias_paginated("456", amount=2)
+
+        self.assertEqual(medias, page)
+        self.assertEqual(end_cursor, "v1-cursor")
+        private_lookup.assert_called_once_with("456", 2, end_cursor="")
+        public_lookup.assert_not_called()
+
+    def test_authorized_user_medias_paginated_falls_back_to_public(self):
+        client = self.build_private_client()
+        page = [self.build_media()]
+
+        with mock.patch.object(
+            client,
+            "user_medias_paginated_v1",
+            side_effect=ClientError("private lookup failed"),
+        ) as private_lookup:
+            with mock.patch.object(
+                client, "user_medias_paginated_gql", return_value=(page, "web-cursor")
+            ) as public_lookup:
+                medias, end_cursor = client.user_medias_paginated("456", amount=2)
+
+        self.assertEqual(medias, page)
+        self.assertEqual(end_cursor, "web-cursor")
+        private_lookup.assert_called_once_with("456", 2, end_cursor="")
+        public_lookup.assert_called_once_with("456", 2, end_cursor="")
+
+    def test_unauthorized_user_medias_paginated_keeps_public_first(self):
+        client = Client()
+        page = [self.build_media()]
+
+        with mock.patch.object(client, "user_medias_paginated_gql", return_value=(page, "web-cursor")) as public_lookup:
+            with mock.patch.object(
+                client,
+                "user_medias_paginated_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                medias, end_cursor = client.user_medias_paginated("456", amount=2)
+
+        self.assertEqual(medias, page)
+        self.assertEqual(end_cursor, "web-cursor")
+        public_lookup.assert_called_once_with("456", 2, end_cursor="")
+        private_lookup.assert_not_called()
+
+    def test_v1_cursor_user_medias_paginated_uses_private_even_without_auth(self):
+        client = Client()
+        page = [self.build_media()]
+
+        with mock.patch.object(client, "user_medias_paginated_v1", return_value=(page, "")) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_medias_paginated_gql",
+                side_effect=AssertionError("v1 cursor should continue through private API"),
+            ) as public_lookup:
+                medias, end_cursor = client.user_medias_paginated("456", amount=2, end_cursor="123_456")
+
+        self.assertEqual(medias, page)
+        self.assertEqual(end_cursor, "")
+        private_lookup.assert_called_once_with("456", 2, end_cursor="123_456")
+        public_lookup.assert_not_called()
+
+    def test_v1_cursor_user_medias_paginated_does_not_fall_back_to_public(self):
+        client = self.build_private_client()
+
+        with mock.patch.object(
+            client,
+            "user_medias_paginated_v1",
+            side_effect=ClientError("private cursor lookup failed"),
+        ) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_medias_paginated_gql",
+                side_effect=AssertionError("v1 cursor should not be retried through public API"),
+            ) as public_lookup:
+                with self.assertRaises(ClientError):
+                    client.user_medias_paginated("456", amount=2, end_cursor="123_456")
+
+        private_lookup.assert_called_once_with("456", 2, end_cursor="123_456")
+        public_lookup.assert_not_called()
+
+    def test_authorized_user_medias_uses_private_before_public(self):
+        client = self.build_private_client()
+        medias = [self.build_media()]
+
+        with mock.patch.object(client, "user_medias_v1", return_value=medias) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_medias_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                result = client.user_medias("456", amount=2)
+
+        self.assertEqual(result, medias)
+        private_lookup.assert_called_once_with(456, 2)
+        public_lookup.assert_not_called()
+
+    def test_cookie_session_user_medias_uses_private_before_public(self):
+        client = Client()
+        client.private.cookies.set("sessionid", "1" * 40)
+        medias = [self.build_media()]
+
+        with mock.patch.object(client, "user_medias_v1", return_value=medias) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_medias_gql",
+                side_effect=AssertionError("cookie session lookup should use private API first"),
+            ) as public_lookup:
+                result = client.user_medias("456", amount=2)
+
+        self.assertEqual(result, medias)
+        private_lookup.assert_called_once_with(456, 2)
+        public_lookup.assert_not_called()
+
+    def test_authorized_user_medias_falls_back_to_public(self):
+        client = self.build_private_client()
+        medias = [self.build_media()]
+
+        with mock.patch.object(
+            client, "user_medias_v1", side_effect=ClientError("private lookup failed")
+        ) as private_lookup:
+            with mock.patch.object(client, "user_medias_gql", return_value=medias) as public_lookup:
+                result = client.user_medias("456", amount=2)
+
+        self.assertEqual(result, medias)
+        private_lookup.assert_called_once_with(456, 2)
+        public_lookup.assert_called_once_with(456, 2, 0)
+
+    def test_unauthorized_user_medias_keeps_public_first(self):
+        client = Client()
+        medias = [self.build_media()]
+
+        with mock.patch.object(client, "user_medias_gql", return_value=medias) as public_lookup:
+            with mock.patch.object(
+                client,
+                "user_medias_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                result = client.user_medias("456", amount=2)
+
+        self.assertEqual(result, medias)
+        public_lookup.assert_called_once_with(456, 2, 0)
+        private_lookup.assert_not_called()
+
+
 class MediaShareToStoryRegressionTestCase(unittest.TestCase):
     def test_media_share_to_story_uses_existing_media_as_story_sticker(self):
         client = Client()


### PR DESCRIPTION
## Summary
- Make high-level `user_medias()` and `user_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`.
- Keep unauthenticated high-level user media lookups public/web-first and leave explicit `_gql` methods as public/web paths.
- Preserve v1 cursor handling for `user_medias_paginated()` so v1 `next_max_id` cursors are not retried through public GraphQL.
- Document the lookup order and add regression plus live coverage for the high-level media paths.

## Test Coverage
All new code paths have focused regression coverage in `UserMediasPrivateFirstRegressionTestCase`: authorized, cookie-session, private-to-public fallback, unauthenticated public-first, and v1 cursor handling.

## Pre-Landing Review
No issues found in the scoped diff.

## Test plan
- `.venv/bin/python -m pytest -q tests/regression/test_media.py::UserMediasPrivateFirstRegressionTestCase` (RED before implementation: 5 failed, 3 passed)
- `.venv/bin/python -m pytest -q tests/regression/test_media.py::UserMediasPrivateFirstRegressionTestCase::test_v1_cursor_user_medias_paginated_does_not_fall_back_to_public` (RED for cursor guard: 1 failed)
- `.venv/bin/python -m pytest -q tests/regression/test_media.py::UserMediasPrivateFirstRegressionTestCase` -> 9 passed
- `.venv/bin/python -m pytest -q tests/regression` -> 472 passed, 2 skipped, 5 subtests passed
- `.venv/bin/python -m ruff check .` -> All checks passed
- `.venv/bin/python -m ruff format --check .` -> 138 files already formatted
- `.venv/bin/python -m mkdocs build --strict` -> built successfully
- `.venv/bin/python -m bandit -c pyproject.toml -r instagrapi` -> No issues identified
- `PYTHONUNBUFFERED=1 /opt/homebrew/bin/timeout 420 .venv/bin/python -m pytest -q -s --full-trace -o faulthandler_timeout=180 -o faulthandler_exit_on_timeout=true tests/live/test_user.py::ClientUserExtendTestCase::test_user_medias` -> 1 passed, 1 warning
- `PYTHONUNBUFFERED=1 /opt/homebrew/bin/timeout 420 .venv/bin/python -m pytest -q -s --full-trace -o faulthandler_timeout=180 -o faulthandler_exit_on_timeout=true tests/live/test_user.py::ClientUserMediasPaginationLiveTestCase::test_user_medias_paginated_live` -> 1 passed, 1 warning