### PR TITLE
Prefer private API for authorized follower lookups

### DIFF
--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1149,12 +1149,20 @@ class UserMixin:
             return {user.pk: user for user in users}
         users = self._users_followers.get(user_id, {})
         if not use_cache or not users or (amount and len(users) < amount):
-            try:
-                users = self.user_followers_gql(user_id, amount)
-            except Exception as e:
-                if not isinstance(e, ClientError):
-                    self.logger.exception(e)
-                users = self.user_followers_v1(user_id, amount)
+            if self._has_private_auth():
+                try:
+                    users = self.user_followers_v1(user_id, amount)
+                except Exception as e:
+                    if not isinstance(e, ClientError):
+                        self.logger.exception(e)
+                    users = self.user_followers_gql(user_id, amount)
+            else:
+                try:
+                    users = self.user_followers_gql(user_id, amount)
+                except Exception as e:
+                    if not isinstance(e, ClientError):
+                        self.logger.exception(e)
+                    users = self.user_followers_v1(user_id, amount)
             self._users_followers[user_id] = {user.pk: user for user in users}
         followers = self._users_followers[user_id]
         if amount and len(followers) > amount:

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -50,6 +50,55 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(followers[0], UserShort)
 
 
+class ClientFollowersLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for followers live tests")
+        try:
+            self.cl = self.fresh_account()
+        except Exception as exc:
+            self.skipTest(str(exc))
+
+    def test_user_followers_uses_private_api_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        with mock.patch.object(
+            self.cl,
+            "user_followers_gql",
+            side_effect=AssertionError("authorized user_followers should not call public GraphQL first"),
+        ) as public_lookup:
+            followers = self.cl.user_followers(user_id, use_cache=False, amount=10)
+
+        self.assertTrue(len(followers) == 10)
+        self.assertIsInstance(list(followers.values())[0], UserShort)
+        public_lookup.assert_not_called()
+
+    def test_user_followers_gql_chunk_paginates_two_pages(self):
+        user_id = self.user_id_from_username("instagram")
+
+        first_page, end_cursor = self.cl.user_followers_gql_chunk(user_id, max_amount=12)
+        self.assertGreater(len(first_page), 0)
+        self.assertLessEqual(len(first_page), 12)
+        self.assertTrue(end_cursor)
+        self.assertIsInstance(first_page[0], UserShort)
+
+        next_page, _ = self.cl.user_followers_gql_chunk(user_id, max_amount=12, end_cursor=end_cursor)
+        self.assertGreater(len(next_page), 0)
+        self.assertLessEqual(len(next_page), 12)
+        self.assertIsInstance(next_page[0], UserShort)
+
+        first_ids = {user.pk for user in first_page}
+        next_ids = {user.pk for user in next_page}
+        self.assertTrue(first_ids.isdisjoint(next_ids), f"Duplicate followers across pages: {first_ids & next_ids}")
+
+
 class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
     def test_user_short_gql(self):
         user = self.cl.user_short_gql("25025320", use_cache=False)

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -521,6 +521,54 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(list(followers), ["new"])
         self.assertEqual(list(client._users_followers["123"]), ["old"])
 
+    def test_authorized_user_followers_uses_private_before_public(self):
+        client = self.build_private_client()
+        follower = UserShort(pk="456", username="follower")
+
+        with mock.patch.object(client, "user_followers_v1", return_value=[follower]) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_followers_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                followers = client.user_followers("123", use_cache=False, amount=1)
+
+        private_lookup.assert_called_once_with("123", 1)
+        public_lookup.assert_not_called()
+        self.assertEqual(list(followers), ["456"])
+
+    def test_authorized_user_followers_falls_back_to_public(self):
+        client = self.build_private_client()
+        follower = UserShort(pk="456", username="follower")
+
+        with mock.patch.object(
+            client,
+            "user_followers_v1",
+            side_effect=ClientError("private lookup failed"),
+        ) as private_lookup:
+            with mock.patch.object(client, "user_followers_gql", return_value=[follower]) as public_lookup:
+                followers = client.user_followers("123", use_cache=False, amount=1)
+
+        private_lookup.assert_called_once_with("123", 1)
+        public_lookup.assert_called_once_with("123", 1)
+        self.assertEqual(list(followers), ["456"])
+
+    def test_unauthorized_user_followers_keeps_public_first(self):
+        client = Client()
+        follower = UserShort(pk="456", username="follower")
+
+        with mock.patch.object(client, "user_followers_gql", return_value=[follower]) as public_lookup:
+            with mock.patch.object(
+                client,
+                "user_followers_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                followers = client.user_followers("123", use_cache=False, amount=1)
+
+        public_lookup.assert_called_once_with("123", 1)
+        private_lookup.assert_not_called()
+        self.assertEqual(list(followers), ["456"])
+
     def test_user_following_v1_chunk_omits_empty_max_id_on_first_page(self):
         client = self.build_private_client()
 


### PR DESCRIPTION
## Summary

- Make `user_followers()` use the private mobile follower list first when the client has authorization/session data, while keeping public GraphQL first for unauthenticated clients.
- Keep explicit `_gql` helpers as the public/web path.
- Add regression coverage for authorized private-first, authorized fallback to public, and unauthenticated public-first behavior.
- Add live coverage for high-level `user_followers()` returning results without calling the public helper, plus a two-page explicit `_gql` follower pagination check.

## Tests

- `.venv/bin/python -m pytest tests/regression/test_user.py -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`
- `timeout 300 .venv/bin/python -m pytest tests/live/test_user.py::ClientFollowersLiveTestCase -q`
