### PR TITLE
Prefer private API for authorized story lookups

### DIFF
--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 from instagrapi import config
 from instagrapi.exceptions import (
+    ClientError,
     ClientGraphqlError,
     ClientNotFoundError,
     StoryNotFound,
@@ -175,6 +176,14 @@ class StoryMixin:
             stories = stories[:amount]
         return stories
 
+    def _user_stories_public(self, user_id: str, amount: int = None) -> List[Story]:
+        try:
+            return self.user_stories_gql(user_id, amount)
+        except ClientNotFoundError as e:
+            raise UserNotFound(e, user_id=user_id, **self.last_json)
+        except IndexError:
+            return []
+
     def user_stories_v1(self, user_id: str, amount: int = None) -> List[Story]:
         """
         Get a user's stories (Private API)
@@ -215,12 +224,17 @@ class StoryMixin:
         List[Story]
             A list of objects of STory
         """
+        if self._has_private_auth():
+            try:
+                return self.user_stories_v1(user_id, amount)
+            except Exception as e:
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                return self._user_stories_public(user_id, amount)
         try:
-            return self.user_stories_gql(user_id, amount)
-        except ClientNotFoundError as e:
-            raise UserNotFound(e, user_id=user_id, **self.last_json)
-        except IndexError:
-            return []
+            return self._user_stories_public(user_id, amount)
+        except UserNotFound:
+            raise
         except Exception as e:
             if not self.user_id:
                 if isinstance(e, ClientGraphqlError):

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -211,6 +211,37 @@ class ClientStoryTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(self.cl.story_seen([story.pk]))
 
 
+class ClientUserStoriesLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for user stories live tests")
+        try:
+            self.cl = self.fresh_account()
+        except Exception as exc:
+            self.skipTest(str(exc))
+
+    def test_user_stories_uses_private_api_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        with mock.patch.object(
+            self.cl,
+            "user_stories_gql",
+            side_effect=AssertionError("authorized user_stories should not call public GraphQL first"),
+        ) as public_lookup:
+            stories = self.cl.user_stories(user_id, amount=1)
+
+        self.assertGreater(len(stories), 0)
+        self.assertIsInstance(stories[0], Story)
+        public_lookup.assert_not_called()
+
+
 class ClientStoryLocationStickerLiveTestCase(_helpers.ClientPrivateTestCase):
     photo_path = Path("examples/background.png")
 

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -1,0 +1,66 @@
+from instagrapi.exceptions import ClientNotFoundError, UserNotFound
+from tests.helpers import *
+
+
+class StoryMixinRegressionTestCase(unittest.TestCase):
+    def build_private_client(self):
+        client = Client()
+        client.settings = {}
+        client.authorization_data = {"ds_user_id": "1"}
+        return client
+
+    def test_authorized_user_stories_uses_private_before_public(self):
+        client = self.build_private_client()
+        stories = [object()]
+
+        with mock.patch.object(client, "user_stories_v1", return_value=stories) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_stories_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                result = client.user_stories("123", amount=1)
+
+        self.assertEqual(result, stories)
+        private_lookup.assert_called_once_with("123", 1)
+        public_lookup.assert_not_called()
+
+    def test_authorized_user_stories_falls_back_to_public(self):
+        client = self.build_private_client()
+        stories = [object()]
+
+        with mock.patch.object(
+            client,
+            "user_stories_v1",
+            side_effect=ClientGraphqlError("private lookup failed"),
+        ) as private_lookup:
+            with mock.patch.object(client, "user_stories_gql", return_value=stories) as public_lookup:
+                result = client.user_stories("123", amount=1)
+
+        self.assertEqual(result, stories)
+        private_lookup.assert_called_once_with("123", 1)
+        public_lookup.assert_called_once_with("123", 1)
+
+    def test_unauthorized_user_stories_keeps_public_first(self):
+        client = Client()
+        stories = [object()]
+
+        with mock.patch.object(client, "user_stories_gql", return_value=stories) as public_lookup:
+            with mock.patch.object(
+                client,
+                "user_stories_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                result = client.user_stories("123", amount=1)
+
+        self.assertEqual(result, stories)
+        public_lookup.assert_called_once_with("123", 1)
+        private_lookup.assert_not_called()
+
+    def test_unauthorized_user_stories_keeps_public_not_found_mapping(self):
+        client = Client()
+        client.last_json = {"status": "fail"}
+
+        with mock.patch.object(client, "user_stories_gql", side_effect=ClientNotFoundError("missing")):
+            with self.assertRaises(UserNotFound):
+                client.user_stories("123")


### PR DESCRIPTION
## Summary

- Make `user_stories()` use the private mobile story endpoint first when the client has authorization/session data.
- Keep unauthenticated `user_stories()` public-first and keep explicit `user_stories_gql()` as the public/web helper.
- Preserve existing public not-found and empty-result behavior through a small public lookup helper.
- Add regression coverage for authorized private-first, authorized fallback to public, unauthenticated public-first, and public not-found mapping.
- Add a live test that verifies authorized `user_stories()` returns stories without calling the public GraphQL helper.

## Tests

- `.venv/bin/python -m pytest tests/regression/test_story.py tests/regression/test_auth_story.py tests/regression/test_story_configure.py -q`
- `timeout 300 .venv/bin/python -m pytest tests/live/test_story.py::ClientUserStoriesLiveTestCase -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/story.py tests/regression/test_story.py tests/live/test_story.py`
