### PR TITLE
Prefer private API for authorized following lookups

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -168,3 +168,4 @@ for user_id in followers.keys():
 Tip:
 
 * `user_info()`, `user_info_by_username()`, `user_id_from_username()`, and `username_from_user_id()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, these high-level helpers keep the public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
+* `user_followers()` and `user_following()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, these high-level helpers keep the public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -838,15 +838,20 @@ class UserMixin:
         user_id = str(user_id)
         users = self._users_following.get(user_id, {})
         if not use_cache or not users or (amount and len(users) < amount):
-            # Temporary: Instagram Required Login for GQL request
-            # You can inject sessionid from private to public session
-            # try:
-            #     users = self.user_following_gql(user_id, amount)
-            # except Exception as e:
-            #     if not isinstance(e, ClientError):
-            #         self.logger.exception(e)
-            #     users = self.user_following_v1(user_id, amount)
-            users = self.user_following_v1(user_id, amount)
+            if self._has_private_auth():
+                try:
+                    users = self.user_following_v1(user_id, amount)
+                except Exception as e:
+                    if not isinstance(e, ClientError):
+                        self.logger.exception(e)
+                    users = self.user_following_gql(user_id, amount)
+            else:
+                try:
+                    users = self.user_following_gql(user_id, amount)
+                except Exception as e:
+                    if not isinstance(e, ClientError):
+                        self.logger.exception(e)
+                    users = self.user_following_v1(user_id, amount)
             self._users_following[user_id] = {user.pk: user for user in users}
         following = self._users_following[user_id]
         if amount and len(following) > amount:

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -99,6 +99,53 @@ class ClientFollowersLiveTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(first_ids.isdisjoint(next_ids), f"Duplicate followers across pages: {first_ids & next_ids}")
 
 
+class ClientFollowingLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for following live tests")
+        try:
+            self.cl = self.fresh_account()
+        except Exception as exc:
+            self.skipTest(str(exc))
+
+    def test_user_following_uses_private_api_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        with mock.patch.object(
+            self.cl,
+            "user_following_gql",
+            side_effect=AssertionError("authorized user_following should not call public GraphQL first"),
+        ) as public_lookup:
+            following = self.cl.user_following(user_id, use_cache=False, amount=10)
+
+        self.assertTrue(len(following) == 10)
+        self.assertIsInstance(list(following.values())[0], UserShort)
+        public_lookup.assert_not_called()
+
+    def test_user_following_v1_chunk_paginates_two_pages(self):
+        user_id = self.user_id_from_username("instagram")
+
+        first_page, max_id = self.cl.user_following_v1_chunk(user_id, max_amount=10)
+        self.assertEqual(len(first_page), 10)
+        self.assertTrue(max_id)
+        self.assertIsInstance(first_page[0], UserShort)
+
+        next_page, _ = self.cl.user_following_v1_chunk(user_id, max_amount=10, max_id=max_id)
+        self.assertEqual(len(next_page), 10)
+        self.assertIsInstance(next_page[0], UserShort)
+
+        first_ids = {user.pk for user in first_page}
+        next_ids = {user.pk for user in next_page}
+        self.assertTrue(first_ids.isdisjoint(next_ids), f"Duplicate following across pages: {first_ids & next_ids}")
+
+
 class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
     def test_user_short_gql(self):
         user = self.cl.user_short_gql("25025320", use_cache=False)

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -569,6 +569,54 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         private_lookup.assert_not_called()
         self.assertEqual(list(followers), ["456"])
 
+    def test_authorized_user_following_uses_private_before_public(self):
+        client = self.build_private_client()
+        following_user = UserShort(pk="456", username="following")
+
+        with mock.patch.object(client, "user_following_v1", return_value=[following_user]) as private_lookup:
+            with mock.patch.object(
+                client,
+                "user_following_gql",
+                side_effect=AssertionError("authorized lookup should use private API first"),
+            ) as public_lookup:
+                following = client.user_following("123", use_cache=False, amount=1)
+
+        private_lookup.assert_called_once_with("123", 1)
+        public_lookup.assert_not_called()
+        self.assertEqual(list(following), ["456"])
+
+    def test_authorized_user_following_falls_back_to_public(self):
+        client = self.build_private_client()
+        following_user = UserShort(pk="456", username="following")
+
+        with mock.patch.object(
+            client,
+            "user_following_v1",
+            side_effect=ClientError("private lookup failed"),
+        ) as private_lookup:
+            with mock.patch.object(client, "user_following_gql", return_value=[following_user]) as public_lookup:
+                following = client.user_following("123", use_cache=False, amount=1)
+
+        private_lookup.assert_called_once_with("123", 1)
+        public_lookup.assert_called_once_with("123", 1)
+        self.assertEqual(list(following), ["456"])
+
+    def test_unauthorized_user_following_keeps_public_first(self):
+        client = Client()
+        following_user = UserShort(pk="456", username="following")
+
+        with mock.patch.object(client, "user_following_gql", return_value=[following_user]) as public_lookup:
+            with mock.patch.object(
+                client,
+                "user_following_v1",
+                side_effect=AssertionError("unauthorized lookup should use public API first"),
+            ) as private_lookup:
+                following = client.user_following("123", use_cache=False, amount=1)
+
+        public_lookup.assert_called_once_with("123", 1)
+        private_lookup.assert_not_called()
+        self.assertEqual(list(following), ["456"])
+
     def test_user_following_v1_chunk_omits_empty_max_id_on_first_page(self):
         client = self.build_private_client()
 


### PR DESCRIPTION
## Summary
- Make `user_following()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`.
- Keep public/web-first behavior for unauthenticated clients, with private fallback matching `user_followers()`.
- Add regression coverage plus live checks for private-first behavior and two-page private pagination.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_user.py -q`
- `timeout 300 .venv/bin/python -m pytest tests/live/test_user.py::ClientFollowingLiveTestCase -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`
- `git diff --check`