### PR TITLE
Prefer private stream fallback for sessionid login

### DIFF
--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -77,6 +77,8 @@ print(cl.user_info(cl.user_id))
 
 `login_by_sessionid()` only works when Instagram accepts that `sessionid` for the private mobile API. A browser/web `sessionid` can be rejected with `login_required` or invalidated server-side; for long-lived automation, prefer `login()` once, then `dump_settings()` and reuse the saved settings.
 
+When `login_by_sessionid()` needs to recover the account username after a private profile lookup failure, it tries the private mobile profile stream before falling back to public/web GraphQL.
+
 You can pass settings to the Client (and save cookies), it has the following format:
 
 ```python

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -18,6 +18,7 @@ from instagrapi import config
 from instagrapi.exceptions import (
     BadCredentials,
     BadPassword,
+    ClientError,
     ClientThrottledError,
     PleaseWaitFewMinutes,
     PrivateError,
@@ -25,6 +26,7 @@ from instagrapi.exceptions import (
     TwoFactorRequired,
     UnknownError,
 )
+from instagrapi.types import UserShort
 from instagrapi.utils.auth import gen_token, generate_jazoest
 from instagrapi.utils.serialization import dumps
 
@@ -654,6 +656,17 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         self.private.headers.update(headers)
         return True
 
+    def _user_short_from_private_stream(self, user_id: str) -> UserShort:
+        user_id = str(user_id)
+        profile = self.user_stream_by_id_flat(user_id)
+        if not isinstance(profile, dict):
+            raise PrivateError("Missing private stream profile payload")
+        username = profile.get("username")
+        if not username:
+            raise PrivateError("Missing username in private stream profile")
+        pk = profile.get("pk") or profile.get("pk_id") or user_id
+        return UserShort(pk=str(pk), username=username)
+
     def login_by_sessionid(self, sessionid: str) -> bool:
         """
         Login using session id
@@ -682,7 +695,10 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         try:
             user = self.user_info_v1(int(user_id))
         except (PrivateError, ValidationError):
-            user = self.user_short_gql(int(user_id))
+            try:
+                user = self._user_short_from_private_stream(user_id)
+            except (ClientError, ValidationError, KeyError, TypeError, AttributeError):
+                user = self.user_short_gql(int(user_id))
         self.username = user.username
         self.authorization_data["ds_user_id"] = str(user.pk)
         self.private.cookies.set("ds_user_id", str(user.pk))

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1916,6 +1916,18 @@ class UserMixin:
         }
         try:
             return self.private_request(f"users/{user_id}/info_stream/", data=data)
+        except ClientJSONDecodeError:
+            response_text = getattr(getattr(self, "last_response", None), "text", "") or ""
+            for line in response_text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    return json.loads(line)
+                except JSONDecodeError:
+                    break
+            logger.exception("Unable to parse streamed user response for user_id %r", user_id)
+            raise UserNotFound("User not found")
         except (ClientNotFoundError, ClientError) as e:
             logger.exception(
                 "Client error user_stream_by_id_v1, exception: %r, user_id %r",
@@ -1934,6 +1946,8 @@ class UserMixin:
         (defensive behaviour matching observed IG quirks).
         """
         data = {}
+        if isinstance(resp.get("user"), dict):
+            data.update(resp["user"])
         for urow in resp.get("stream_rows", []):
             data.update(urow.get("user", {}))
         if data:

--- a/tests/live/test_sessionid.py
+++ b/tests/live/test_sessionid.py
@@ -13,3 +13,21 @@ class SessionIdLoginTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(cl.login_by_sessionid(sessionid))
         self.assertEqual(str(cl.account_info().pk), str(self.cl.user_id))
         self.assertIsInstance(cl.get_timeline_feed("cold_start_fetch"), dict)
+
+    def test_login_by_sessionid_uses_private_stream_fallback_live(self):
+        sessionid = self.cl.sessionid
+        if not sessionid:
+            self.skipTest("Logged-in test client did not expose sessionid")
+
+        cl = Client(proxy=self.cl.proxy)
+        cl.user_info_v1 = Mock(side_effect=PrivateError("force stream fallback"))
+
+        with mock.patch.object(
+            cl,
+            "user_short_gql",
+            side_effect=AssertionError("sessionid login should not call public GraphQL before private stream"),
+        ) as public_lookup:
+            self.assertTrue(cl.login_by_sessionid(sessionid))
+
+        public_lookup.assert_not_called()
+        self.assertEqual(str(cl.account_info().pk), str(self.cl.user_id))

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -403,20 +403,39 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_caa_login_send_request.assert_called_once_with("password", login_attempt_count=1)
         client.bloks_two_step_verification_verify_code.assert_not_called()
 
-    def test_login_by_sessionid_falls_back_to_user_short_gql(self):
+    def test_login_by_sessionid_falls_back_to_private_stream_before_public(self):
         client = Client()
         sessionid = "1234567890123456789012345678901%3Atoken"
         client.user_info_v1 = Mock(side_effect=PrivateError("boom"))
+        client.user_stream_by_id_flat = Mock(return_value={"pk": "1234567890123456789", "username": "example"})
+        client.user_short_gql = Mock(
+            side_effect=AssertionError("sessionid login should use private fallback before public")
+        )
+
+        result = client.login_by_sessionid(sessionid)
+
+        self.assertTrue(result)
+        client.user_info_v1.assert_called_once_with(1234567890123456789012345678901)
+        client.user_stream_by_id_flat.assert_called_once_with("1234567890123456789012345678901")
+        client.user_short_gql.assert_not_called()
+        self.assertEqual(client.username, "example")
+        self.assertEqual(client.authorization_data["sessionid"], sessionid)
+        self.assertEqual(client.cookie_dict["ds_user_id"], "1234567890123456789")
+
+    def test_login_by_sessionid_falls_back_to_public_after_private_stream_failure(self):
+        client = Client()
+        sessionid = "1234567890123456789012345678901%3Atoken"
+        client.user_info_v1 = Mock(side_effect=PrivateError("boom"))
+        client.user_stream_by_id_flat = Mock(side_effect=PrivateError("stream failed"))
         client.user_short_gql = Mock(return_value=UserShort(pk="1234567890123456789", username="example"))
 
         result = client.login_by_sessionid(sessionid)
 
         self.assertTrue(result)
         client.user_info_v1.assert_called_once_with(1234567890123456789012345678901)
+        client.user_stream_by_id_flat.assert_called_once_with("1234567890123456789012345678901")
         client.user_short_gql.assert_called_once_with(1234567890123456789012345678901)
         self.assertEqual(client.username, "example")
-        self.assertEqual(client.authorization_data["sessionid"], sessionid)
-        self.assertEqual(client.cookie_dict["ds_user_id"], "1234567890123456789")
 
     def test_login_by_sessionid_uses_user_info_v1_when_available(self):
         client = Client()
@@ -469,17 +488,21 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         self.assertEqual(client.private.headers.get("IG-INTENDED-USER-ID"), "1234567890123456789")
         self.assertEqual(client.private.headers.get("Authorization"), client.authorization)
 
-    def test_login_by_sessionid_falls_back_to_user_short_gql_on_validation_error(self):
+    def test_login_by_sessionid_falls_back_to_private_stream_on_validation_error(self):
         client = Client()
         sessionid = "1234567890123456789012345678901%3Atoken"
         client.user_info_v1 = Mock(side_effect=ValidationError.from_exception_data("User", []))
-        client.user_short_gql = Mock(return_value=UserShort(pk="1234567890123456789", username="example"))
+        client.user_stream_by_id_flat = Mock(return_value={"pk_id": "1234567890123456789", "username": "example"})
+        client.user_short_gql = Mock(
+            side_effect=AssertionError("sessionid login should use private fallback before public")
+        )
 
         result = client.login_by_sessionid(sessionid)
 
         self.assertTrue(result)
         client.user_info_v1.assert_called_once_with(1234567890123456789012345678901)
-        client.user_short_gql.assert_called_once_with(1234567890123456789012345678901)
+        client.user_stream_by_id_flat.assert_called_once_with("1234567890123456789012345678901")
+        client.user_short_gql.assert_not_called()
         self.assertEqual(client.username, "example")
 
     def test_login_by_sessionid_rejects_invalid_sessionid(self):

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -856,6 +856,25 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             with self.assertRaises(UserNotFound):
                 client.user_stream_by_id_v1("123")
 
+    def test_user_stream_by_id_v1_parses_first_json_line_from_stream_response(self):
+        from instagrapi.exceptions import ClientJSONDecodeError
+
+        client = Client()
+        client.last_json = {}
+
+        def private_request(*args, **kwargs):
+            client.last_response = Mock(
+                text='{"user":{"pk":123,"username":"example"},"status":"ok"}\n{"stream_tail":true}\n',
+                status_code=200,
+            )
+            raise ClientJSONDecodeError("stream response")
+
+        with mock.patch.object(client, "private_request", side_effect=private_request):
+            result = client.user_stream_by_id_v1("123")
+
+        self.assertEqual(result["user"]["username"], "example")
+        self.assertEqual(result["status"], "ok")
+
     def test_user_stream_by_username_v1_sends_expected_endpoint(self):
         client = Client()
         with mock.patch.object(client, "private_request", return_value={"stream_rows": []}) as private_request:
@@ -880,6 +899,16 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(user["full_name"], "Alice Example")
         self.assertEqual(user["pk"], "9")
         self.assertEqual(user["pk_id"], "9")
+
+    def test_user_stream_by_id_flat_accepts_top_level_user_payload(self):
+        client = Client()
+        envelope = {"user": {"pk": "9", "username": "alice"}}
+
+        with mock.patch.object(client, "user_stream_by_id_v1", return_value=envelope):
+            user = client.user_stream_by_id_flat("9")
+
+        self.assertEqual(user["pk"], "9")
+        self.assertEqual(user["username"], "alice")
 
     def test_user_stream_by_username_flat_falls_back_when_empty(self):
         client = Client()


### PR DESCRIPTION
## Summary
- Make `login_by_sessionid()` recover username/user id through the private mobile profile stream before falling back to public GraphQL.
- Parse first JSON line from `users/{id}/info_stream/` responses when Instagram returns streamed JSON chunks instead of one JSON document.
- Add regression and live coverage so sessionid login does not use public GraphQL before private stream fallback.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_auth_story.py tests/regression/test_user.py -q`
- `timeout 300 .venv/bin/python -m pytest tests/live/test_sessionid.py -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/auth.py instagrapi/mixins/user.py tests/regression/test_auth_story.py tests/regression/test_user.py tests/live/test_sessionid.py`
- `git diff --check`

## Notes
- Live test initially exposed Instagram returning newline-delimited stream data from `info_stream`; this PR handles that response shape.