### PR TITLE
Handle Bloks redirect challenges clearly

### DIFF
--- a/docs/usage-guide/best-practices.md
+++ b/docs/usage-guide/best-practices.md
@@ -128,7 +128,7 @@ This means Instagram wants an additional verification step. Some flows can be au
 Recommended response:
 
 * call `challenge_resolve(...)` only if you have working handlers for codes/password changes
-* if you hit `/auth_platform/` or UFAC web flows, expect manual handling
+* if you hit `/auth_platform/`, UFAC web flows, or Bloks redirect checkpoints, expect manual handling in the official Instagram app or web flow
 * do not rotate identity aggressively in the middle of a challenge
 
 ### Practical Rules

--- a/docs/usage-guide/challenge_resolver.md
+++ b/docs/usage-guide/challenge_resolver.md
@@ -53,6 +53,7 @@ Notes:
 * Phone-only signup is supported with `signup(username, password, email="", phone_number="+15551234567")`. If both `email` and `phone_number` are provided, instagrapi keeps the email signup flow and uses the phone number only for signup challenges.
 * `signup(...)` uses Instagram's legacy account-create flow. On modern Instagram app versions this flow is often rejected with `SignupSpamError` / `feedback_required` because the official app uses additional signup checks that instagrapi does not currently generate. Treat this as a platform rejection, not as a malformed SMS/email code.
 * Current `master` raises a clearer `ChallengeRequired` for `/auth_platform/?apc=...` flows. That path is not yet supported automatically and still requires manual verification.
+* Bloks redirect checkpoints such as `bloks_action="com.bloks.www.ig.challenge.redirect.async"` or placeholder `step_name="STEP_NAME"` require manual confirmation in the official Instagram app or web flow on a trusted device; instagrapi raises `ChallengeRequired` with the sanitized challenge context instead of treating this as a legacy step.
 * For long-running automation, persist client settings around challenge handling so you can retry without rebuilding the entire device/session state.
 
 ## Selfie and manual review challenges

--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -488,6 +488,14 @@ class ChallengeResolveMixin:
             if self.last_json.get("step_name") == step_name:
                 raise ChallengeError(f"submit_phone challenge did not advance after phone submission: {self.last_json}")
             return self.challenge_resolve_simple(challenge_url)
+        elif self.last_json.get("bloks_action") == "com.bloks.www.ig.challenge.redirect.async":
+            raise ChallengeRequired(
+                "Manual verification required via Instagram Bloks redirect checkpoint. "
+                "Please confirm the login in the official Instagram app or web flow on a trusted device, "
+                "then retry with the same saved client settings, device identifiers, and proxy/IP. "
+                "This challenge flow is not currently resolved automatically by instagrapi.",
+                **{key: value for key, value in self.last_json.items() if key != "message"},
+            )
         elif step_name == "":
             assert self.last_json.get("action", "") == "close"
             assert self.last_json.get("status", "") == "ok"

--- a/tests/regression/test_challenge.py
+++ b/tests/regression/test_challenge.py
@@ -79,6 +79,27 @@ class ChallengeRegressionTestCase(unittest.TestCase):
 
         self.assertIn("UFAC web bloks checkpoint", str(cm.exception))
 
+    def test_challenge_resolve_simple_bloks_redirect_step_raises_clear_manual_error(self):
+        client = Client()
+        client.username = "example"
+        client.last_json = {
+            "message": "challenge_required",
+            "status": "ok",
+            "step_name": "STEP_NAME",
+            "flow_render_type": 3,
+            "bloks_action": "com.bloks.www.ig.challenge.redirect.async",
+            "challenge_context": "opaque-context",
+            "challenge_type_enum_str": "SUSPICIOUS_LOGIN",
+        }
+
+        with self.assertRaises(ChallengeRequired) as cm:
+            client.challenge_resolve_simple("challenge/test/")
+
+        self.assertIn("Bloks redirect checkpoint", str(cm.exception))
+        self.assertIn("official Instagram app", str(cm.exception))
+        self.assertEqual(cm.exception.step_name, "STEP_NAME")
+        self.assertEqual(cm.exception.bloks_action, "com.bloks.www.ig.challenge.redirect.async")
+
     def test_challenge_resolve_uses_default_context_when_missing(self):
         client = Client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- detect Instagram Bloks redirect checkpoints (`com.bloks.www.ig.challenge.redirect.async`) before the legacy unknown-step fallback
- raise a clear `ChallengeRequired` with the sanitized challenge context instead of `ChallengeUnknownStep` with a raw payload dump
- document that these checkpoints require manual confirmation in the official Instagram app/web flow and that 2FA is not a universal workaround

Fixes #2581

## Tests
- `.venv/bin/python -m pytest tests/regression/test_challenge.py -q`
- `.venv/bin/python -m ruff check instagrapi tests`
- `git diff --check`
