### PR TITLE
Add Reel Facebook destination helper

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -337,6 +337,7 @@ Upload medias to your feed. Common arguments:
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
+| clip_share_to_fb_destination(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Resolve confirmed Reel Facebook destination fields without treating Account Center linking ids as publish destinations
 | clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
 | clip_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Reels music configure fields for manual `clip_upload(..., extra_data=...)`
 | clip_upload_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Media | Upload a Reel with music metadata without local audio muxing
@@ -366,17 +367,9 @@ Reel composer does not report Trial Reels enabled. Instagram can still reject Tr
 configure, so keep upload-side error handling for backend eligibility decisions. When `trial=True`, `clip_upload` sends
 `trial_params={"graduation_strategy": "manual"}` by default and disables feed preview for the upload.
 
-Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer
-use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as
-`share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
+Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as `share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
 
-`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response
-contains availability flags, not the full Account Center destination state, and some linked accounts can still return
-`share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. For those accounts, pass
-`fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually
-with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination,
-instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated
-automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
+`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but the preflight response has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination, instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
 `bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram. Treat Account Center Bloks `fbid`, auth, and linking values as linking context, not as `fb_destination_id`; only use them as a Reel publish destination after verifying that the final Reel configure request sends the same value as `share_to_fb_destination_id`. See [#2556](https://github.com/subzeroid/instagrapi/issues/2556) for tracking automatic destination discovery.
 
 ### Example:

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -221,6 +221,103 @@ class UploadClipMixin:
             params={"device_status": json.dumps(device_status)},
         )
 
+    def clip_share_to_fb_destination(
+        self,
+        config: Optional[Dict[str, object]] = None,
+        destination_id: Optional[str] = None,
+        destination_type: Optional[str] = None,
+        destination_audience_type: Optional[str] = None,
+        validation_check_bypass: Optional[bool] = None,
+    ) -> Dict[str, object]:
+        """
+        Resolve the Facebook Reel sharing destination from confirmed fields.
+
+        This helper reads only destination-shaped fields that are known to map
+        to Reel configure payload fields. It intentionally does not treat
+        generic Account Center/linking identifiers such as ``account_id`` as
+        ``share_to_fb_destination_id``.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Facebook cross-posting config. When omitted, this calls
+            :meth:`clip_share_to_fb_config`.
+        destination_id: str, optional
+            Explicit Facebook destination id. Overrides config values.
+        destination_type: str, optional
+            Explicit Facebook destination type, ``USER`` or ``PAGE``.
+            Overrides config values.
+        destination_audience_type: str, optional
+            Explicit Facebook Reels audience type, e.g. ``PUBLIC``.
+        validation_check_bypass: bool, optional
+            Explicit validation bypass flag. Overrides config values.
+
+        Returns
+        -------
+        Dict[str, object]
+            Normalized destination fields.
+        """
+        fb_config = (config if config is not None else self.clip_share_to_fb_config()) or {}
+        if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
+            raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
+
+        destination_id = (
+            destination_id
+            or fb_config.get("share_to_fb_destination_id")
+            or fb_config.get("reels_destination_id")
+            or fb_config.get("destination_id")
+        )
+        destination_type = (
+            destination_type
+            or fb_config.get("share_to_fb_destination_type")
+            or fb_config.get("destination_type")
+            or fb_config.get("posting_type")
+        )
+        destination_audience_type = (
+            destination_audience_type
+            or fb_config.get("share_to_fb_destination_audience_type")
+            or fb_config.get("reels_destination_audience_type")
+            or fb_config.get("audience_type")
+        )
+        if validation_check_bypass is None:
+            validation_check_bypass = fb_config.get(
+                "reels_cross_app_share_fb_validation_check_bypass",
+                fb_config.get("cross_app_share_fb_validation_check_bypass"),
+            )
+
+        has_destination = bool(destination_id and destination_type)
+        if fb_config.get("share_to_fb_unavailable") and not has_destination:
+            raise ClientError(
+                "Facebook Reel sharing is unavailable from the Reel preflight response. "
+                "If the Instagram app can still cross-post manually, pass destination_id "
+                "and destination_type explicitly."
+            )
+        if not destination_id:
+            raise ClientError(
+                "Facebook Reel sharing configuration has no destination. "
+                "Link a Facebook account/page in the Instagram app or pass destination_id."
+            )
+        if not destination_type:
+            raise ClientError(
+                "Facebook Reel sharing configuration has no destination type. Pass destination_type as USER or PAGE."
+            )
+        destination_type = str(destination_type).upper()
+        if destination_type not in {"USER", "PAGE"}:
+            raise ClientError(
+                "Facebook Reel sharing destination type must be USER or PAGE. "
+                "Do not pass reels_cross_app_share_type here."
+            )
+
+        destination = {
+            "destination_id": str(destination_id),
+            "destination_type": destination_type,
+        }
+        if destination_audience_type:
+            destination["destination_audience_type"] = str(destination_audience_type)
+        if validation_check_bypass is not None:
+            destination["validation_check_bypass"] = bool(validation_check_bypass)
+        return destination
+
     def clip_share_to_fb_extra_data(
         self,
         config: Optional[Dict[str, object]] = None,
@@ -263,73 +360,29 @@ class UploadClipMixin:
         Dict
             Extra configure data for ``clip_upload(..., extra_data=...)``.
         """
-        fb_config = (config if config is not None else self.clip_share_to_fb_config()) or {}
-        if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
-            raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
-
-        destination_id = (
-            destination_id
-            or fb_config.get("share_to_fb_destination_id")
-            or fb_config.get("reels_destination_id")
-            or fb_config.get("destination_id")
-            or fb_config.get("account_id")
+        destination = self.clip_share_to_fb_destination(
+            config=config,
+            destination_id=destination_id,
+            destination_type=destination_type,
+            destination_audience_type=destination_audience_type,
+            validation_check_bypass=validation_check_bypass,
         )
-        destination_type = (
-            destination_type
-            or fb_config.get("share_to_fb_destination_type")
-            or fb_config.get("destination_type")
-            or fb_config.get("posting_type")
-        )
-        destination_audience_type = (
-            destination_audience_type
-            or fb_config.get("share_to_fb_destination_audience_type")
-            or fb_config.get("reels_destination_audience_type")
-            or fb_config.get("audience_type")
-        )
-        if validation_check_bypass is None:
-            validation_check_bypass = fb_config.get(
-                "reels_cross_app_share_fb_validation_check_bypass",
-                fb_config.get("cross_app_share_fb_validation_check_bypass"),
-            )
-
-        has_destination = bool(destination_id and destination_type)
-        if fb_config.get("share_to_fb_unavailable") and not has_destination:
-            raise ClientError(
-                "Facebook Reel sharing is unavailable from the Reel preflight response. "
-                "If the Instagram app can still cross-post manually, pass destination_id "
-                "and destination_type explicitly."
-            )
-        if not destination_id:
-            raise ClientError(
-                "Facebook Reel sharing configuration has no destination. "
-                "Link a Facebook account/page in the Instagram app or pass destination_id."
-            )
-        if not destination_type:
-            raise ClientError(
-                "Facebook Reel sharing configuration has no destination type. Pass destination_type as USER or PAGE."
-            )
-        destination_type = str(destination_type).upper()
-        if destination_type not in {"USER", "PAGE"}:
-            raise ClientError(
-                "Facebook Reel sharing destination type must be USER or PAGE. "
-                "Do not pass reels_cross_app_share_type here."
-            )
         attempt_id = attempt_id or str(uuid4())
 
         data = {
             "share_to_facebook": "1",
             "is_reel_shared_to_fb": True,
             "share_to_facebook_reels": True,
-            "share_to_fb_destination_id": destination_id,
-            "share_to_fb_destination_type": destination_type,
+            "share_to_fb_destination_id": destination["destination_id"],
+            "share_to_fb_destination_type": destination["destination_type"],
             "xpost_surface": xpost_surface,
             "no_token_crosspost": "1",  # nosec B105
             "attempt_id": attempt_id,
         }
-        if destination_audience_type:
-            data["share_to_fb_destination_audience_type"] = destination_audience_type
-        if validation_check_bypass is not None:
-            data["cross_app_share_fb_validation_check_bypass"] = bool(validation_check_bypass)
+        if destination.get("destination_audience_type"):
+            data["share_to_fb_destination_audience_type"] = destination["destination_audience_type"]
+        if destination.get("validation_check_bypass") is not None:
+            data["cross_app_share_fb_validation_check_bypass"] = bool(destination["validation_check_bypass"])
         return data
 
     def clip_upload(

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -753,3 +753,16 @@ class ClientFacebookReelCrosspostLiveTestCase(_helpers.ClientPrivateTestCase):
         self.assertEqual(extra_data["xpost_surface"], "IG_REELS_COMPOSER")
         self.assertEqual(extra_data["no_token_crosspost"], "1")
         self.assertTrue(extra_data["attempt_id"])
+
+    def test_clip_share_to_fb_destination_live(self):
+        config = self.cl.clip_share_to_fb_config()
+        self.assertEqual(config.get("status"), "ok")
+        try:
+            destination = self.cl.clip_share_to_fb_destination(config=config)
+        except ClientError as exc:
+            self.skipTest(f"No confirmed Facebook Reel destination available: {exc}")
+
+        self.assertTrue(destination["destination_id"])
+        self.assertIn(destination["destination_type"], {"USER", "PAGE"})
+        if destination.get("destination_audience_type"):
+            self.assertIsInstance(destination["destination_audience_type"], str)

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -104,6 +104,60 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertFalse(device_status["hw_av1_dec"])
         self.assertEqual(result, expected)
 
+    def test_clip_share_to_fb_destination_normalizes_current_reel_destination_fields(self):
+        client = self.build_client()
+
+        result = client.clip_share_to_fb_destination(
+            config={
+                "enabled": True,
+                "is_account_linked": True,
+                "share_to_fb_destination_id": "fb-destination-id",
+                "share_to_fb_destination_type": "page",
+                "share_to_fb_destination_audience_type": "PUBLIC",
+                "reels_cross_app_share_fb_validation_check_bypass": True,
+                "status": "ok",
+            }
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "destination_id": "fb-destination-id",
+                "destination_type": "PAGE",
+                "destination_audience_type": "PUBLIC",
+                "validation_check_bypass": True,
+            },
+        )
+
+    def test_clip_share_to_fb_destination_rejects_unavailable_config_without_destination(self):
+        client = self.build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            client.clip_share_to_fb_destination(
+                config={
+                    "share_to_fb_unavailable": True,
+                    "status": "ok",
+                }
+            )
+
+        self.assertIn("unavailable", str(ctx.exception))
+
+    def test_clip_share_to_fb_destination_does_not_use_account_id_as_destination(self):
+        client = self.build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            client.clip_share_to_fb_destination(
+                config={
+                    "enabled": True,
+                    "is_account_linked": True,
+                    "account_id": "account-center-or-linking-id",
+                    "posting_type": "USER",
+                    "status": "ok",
+                }
+            )
+
+        self.assertIn("no destination", str(ctx.exception))
+
     def test_clip_share_to_fb_extra_data_builds_current_reel_crosspost_payload(self):
         client = self.build_client()
         config = {


### PR DESCRIPTION
## Summary
- add `clip_share_to_fb_destination(...)` to normalize confirmed Facebook Reel destination fields before building configure payloads
- stop treating generic `account_id` as a publish destination, keeping explicit `fb_destination_id` / `fb_destination_type` overrides as the fallback
- route `clip_share_to_fb_extra_data(...)` through the destination helper and document the helper
- add regression coverage plus a live discovery test that skips cleanly when the test pool has no confirmed destination

## Tests
- `.venv/bin/python -m pytest tests/regression/test_upload.py -q -k "clip_share_to_fb"`
- `.venv/bin/python -m pytest tests/regression/test_upload.py -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py`
- `.venv/bin/mkdocs build --strict`
- `.venv/bin/python -m pytest tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_share_to_fb_destination_live -q -rs` (skipped: current pool returns `share_to_fb_unavailable=True` without confirmed destination)

Refs #2556
