### PR TITLE
Add Reel cover change helper

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -55,6 +55,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_template_v1(media_id: str) | dict | Fetch a clip template payload for a Reel/clip media |
 | clip_pin(media_pk: str) | bool | Pin Reel to the Reels tab/profile Reels grid |
 | clip_unpin(media_pk: str) | bool | Unpin Reel from the Reels tab/profile Reels grid |
+| clip_change_cover(media_pk: str, cover_path: Path) | bool | Change the cover image for a published Reel |
 | media_create_livestream(title: str = "Instagram Live") | dict | Create a new livestream and return stream metadata |
 | media_start_livestream(broadcast_id: str) | dict | Start an existing livestream |
 | media_end_livestream(broadcast_id: str) | dict | End an existing livestream |
@@ -334,6 +335,7 @@ Upload medias to your feed. Common arguments:
 | album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None)                      | Media   | Upload Album (Support JPG/MP4 files)
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
 | clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual", share_to_facebook: bool = False) | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts. Set `share_to_facebook=True` to cross-post to a linked Facebook destination
+| clip_change_cover(media_pk: str, cover_path: Path) | bool | Change the cover image for a published Reel
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
@@ -376,6 +378,7 @@ Facebook Reel sharing requires a Facebook account/page linked in the Instagram a
 
 ``` python
 >>> import time
+>>> from pathlib import Path
 >>> from instagrapi import Client
 
 >>> cl = Client()
@@ -411,6 +414,13 @@ Facebook Reel sharing requires a Facebook account/page linked in the Instagram a
 ...     "Cross-posting with explicit Facebook destination",
 ...     extra_data=fb_extra,
 ... )
+
+>>> reel = cl.clip_upload(
+...     "/app/reel.mp4",
+...     "Reel with an updated cover",
+...     thumbnail=Path("/app/cover-a.jpg"),
+... )
+>>> cl.clip_change_cover(reel.pk, Path("/app/cover-b.jpg"))
 
 >>> media = cl.photo_upload(
     "/app/image.jpg",

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -98,6 +98,29 @@ class ClipMixin:
         """
         return self.clip_pin(media_pk, True)
 
+    def clip_change_cover(self, media_pk: str, cover_path: Path) -> bool:
+        """
+        Change cover image for a published Reel
+
+        Parameters
+        ----------
+        media_pk: str
+            PK for the Reel
+        cover_path: Path
+            Path to the new cover image
+
+        Returns
+        -------
+        bool
+        A boolean value
+        """
+        upload_id, _, _ = self.photo_rupload(Path(cover_path))
+        result = self.private_request(
+            "media/configure_to_clips_cover_image/",
+            data={"upload_id": str(upload_id), "clips_media_id": str(media_pk)},
+        )
+        return bool(result.get("success")) or result.get("status") == "ok"
+
 
 class DownloadClipMixin:
     """

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -1,3 +1,5 @@
+import io
+
 from instagrapi.exceptions import ClientNotFoundError, ClipNotUpload, MediaNotFound
 from tests import helpers as _helpers
 from tests.helpers import *
@@ -68,6 +70,26 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
         self.assertIsInstance(location, Location)
         self.assertTrue(location.pk)
         self.assertTrue(location.name)
+
+    def make_cover_fixture(self, color):
+        try:
+            from PIL import Image
+        except ImportError:
+            self.skipTest("Pillow is required to generate a cover fixture")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jpg") as tmp:
+            path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        Image.new("RGB", (720, 1280), color).save(path, quality=95)
+        return path
+
+    def thumbnail_average_rgb(self, url):
+        response = requests.get(str(url), timeout=20)
+        response.raise_for_status()
+        from PIL import Image
+
+        with Image.open(io.BytesIO(response.content)) as image:
+            return image.convert("RGB").resize((1, 1)).getpixel((0, 0))
 
     def assertAlbumResourceUsertagsAccessible(self, media, expected_usertags, attempts=8, delay=5):
         last_resources = []
@@ -367,6 +389,32 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             )
             self.assertTrue(payload.get("video_versions"))
             self.assertEqual((payload.get("caption") or {}).get("text"), caption_text)
+        finally:
+            if media:
+                self.assertTrue(self.cl.media_delete(media.id))
+
+    def test_clip_change_cover_live(self):
+        path = self.make_video_fixture(label="clip cover fixture")
+        cover_a = self.make_cover_fixture((220, 20, 20))
+        cover_b = self.make_cover_fixture((20, 220, 20))
+        media = None
+        try:
+            media = self.cl.clip_upload(path, "Clip cover live test", thumbnail=cover_a)
+            before = self.thumbnail_average_rgb(self.cl.media_info_v1(media.pk).thumbnail_url)
+            self.assertGreater(before[0], before[1])
+            self.assertGreater(before[0], before[2])
+
+            self.assertTrue(self.cl.clip_change_cover(media.pk, cover_b))
+
+            last_rgb = None
+            for attempt in range(12):
+                if attempt:
+                    time.sleep(5)
+                last_rgb = self.thumbnail_average_rgb(self.cl.media_info_v1(media.pk).thumbnail_url)
+                if last_rgb[1] > last_rgb[0] and last_rgb[1] > last_rgb[2]:
+                    break
+            else:
+                self.fail(f"Reel cover thumbnail did not change to the new cover: last rgb={last_rgb}")
         finally:
             if media:
                 self.assertTrue(self.cl.media_delete(media.id))

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -64,3 +64,20 @@ class ClipPinRegressionTestCase(unittest.TestCase):
             "users/unpin_timeline_media/",
             data={"post_id": "3894040329476845448", "profile_grid": "clips"},
         )
+
+    def test_clip_change_cover_uploads_photo_and_configures_reel_cover(self):
+        client = Client()
+        with mock.patch.object(client, "photo_rupload", return_value=("1778346423000", 720, 1280)) as photo_rupload:
+            with mock.patch.object(
+                client,
+                "private_request",
+                return_value={"success": True, "status": "ok"},
+            ) as private_request:
+                result = client.clip_change_cover("3914574283211484216", Path("cover.jpg"))
+
+        self.assertTrue(result)
+        photo_rupload.assert_called_once_with(Path("cover.jpg"))
+        private_request.assert_called_once_with(
+            "media/configure_to_clips_cover_image/",
+            data={"upload_id": "1778346423000", "clips_media_id": "3914574283211484216"},
+        )


### PR DESCRIPTION
## Summary
- Add `clip_change_cover(media_pk, cover_path)` for updating a published Reel cover image.
- Use the current Android app endpoint `media/configure_to_clips_cover_image/` after uploading the new cover via `photo_rupload`.
- Document the helper and add regression plus live coverage.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_clip.py tests/regression/test_upload.py -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/clip.py tests/regression/test_clip.py tests/live/test_upload.py`
- `.venv/bin/python -m pytest tests/live/test_upload.py::ClienUploadTestCase::test_clip_change_cover_live -q -s` (passed twice; uploads a Reel, changes the cover, verifies the thumbnail RGB changed, then deletes the Reel)

Fixes #2597