### PR TITLE
Add Reel Facebook unified config discovery

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -339,6 +339,8 @@ Upload medias to your feed. Common arguments:
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
+| clip_share_to_fb_unified_config() | dict | Get the Android cross-posting unified config used by the Reel composer
+| clip_share_to_fb_unified_destination(config: Dict = None) | dict | Resolve confirmed Reel Facebook destination fields from the unified cross-posting config
 | clip_share_to_fb_destination(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Resolve confirmed Reel Facebook destination fields without treating Account Center linking ids as publish destinations
 | clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: str = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
 | clip_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Reels music configure fields for manual `clip_upload(..., extra_data=...)`
@@ -371,7 +373,7 @@ configure, so keep upload-side error handling for backend eligibility decisions.
 
 Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as `share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
 
-`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but the preflight response has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. If neither the preflight/config data nor the caller provides a destination, instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
+`clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. When `clip_upload(..., share_to_facebook=True)` has no manual destination override, instagrapi now falls back to Android's `CrosspostingUnifiedConfigsQuery` via `clip_share_to_fb_unified_config()` and uses `clip_share_to_fb_unified_destination()` only if that response contains confirmed Reel-to-Facebook destination fields. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but automatic discovery still has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. If neither the preflight/unified config data nor the caller provides a destination, instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
 `bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram. Treat Account Center Bloks `fbid`, auth, and linking values as linking context, not as `fb_destination_id`; only use them as a Reel publish destination after verifying that the final Reel configure request sends the same value as `share_to_fb_destination_id`. See [#2556](https://github.com/subzeroid/instagrapi/issues/2556) for tracking automatic destination discovery.
 
 ### Example:
@@ -400,6 +402,12 @@ Facebook Reel sharing requires a Facebook account/page linked in the Instagram a
 >>> reel = cl.clip_upload(
 ...     "/app/reel.mp4",
 ...     "Cross-posting this Reel to Facebook",
+...     share_to_facebook=True,
+... )
+
+>>> reel = cl.clip_upload(
+...     "/app/reel.mp4",
+...     "Cross-posting with explicit Facebook destination",
 ...     share_to_facebook=True,
 ...     fb_destination_id="FACEBOOK_DESTINATION_ID",
 ...     fb_destination_type="USER",

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -32,6 +32,28 @@ def _make_tmp_path(suffix: str) -> str:
     return path
 
 
+CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_CLIENT_DOC_ID = "216179630714134719310007237117"
+CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_FRIENDLY_NAME = "CrosspostingUnifiedConfigsQuery"
+CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD = "xcxp_unified_crossposting_configs_root"
+CLIP_FB_CROSSPOSTING_SURFACES = [
+    {
+        "source_surface": "STORY",
+        "destination_app": "FB",
+        "destination_surface": "STORY",
+    },
+    {
+        "source_surface": "FEED",
+        "destination_app": "FB",
+        "destination_surface": "FEED",
+    },
+    {
+        "source_surface": "REELS",
+        "destination_app": "FB",
+        "destination_surface": "REELS",
+    },
+]
+
+
 class ClipMixin:
     """
     Helpers for CLIP/Reel actions
@@ -244,6 +266,112 @@ class UploadClipMixin:
             params={"device_status": json.dumps(device_status)},
         )
 
+    def clip_share_to_fb_unified_config(
+        self,
+        crosspost_app_surface_list: Optional[List[Dict[str, str]]] = None,
+    ) -> Dict:
+        """
+        Get the Android cross-posting unified config used by the Reel composer.
+
+        Returns
+        -------
+        Dict
+            A dictionary of response from the private GraphQL call
+        """
+        variables = {
+            "configs_request": {
+                "source_app": "IG",
+                "crosspost_app_surface_list": crosspost_app_surface_list or CLIP_FB_CROSSPOSTING_SURFACES,
+            }
+        }
+        return self.private_graphql_query_request(
+            friendly_name=CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_FRIENDLY_NAME,
+            root_field_name=CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD,
+            variables=variables,
+            client_doc_id=CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_CLIENT_DOC_ID,
+            priority="u=3, i",
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
+        )
+
+    def _clip_share_to_fb_unified_root(self, config: Dict[str, object]) -> object:
+        data = (config or {}).get("data")
+        if isinstance(data, dict):
+            root = data.get(CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD)
+            if root is not None:
+                return root
+            for key, value in data.items():
+                if CLIP_FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD in str(key):
+                    return value
+        return config or {}
+
+    def _clip_share_to_fb_iter_dicts(self, value):
+        if isinstance(value, dict):
+            yield value
+            for child in value.values():
+                yield from self._clip_share_to_fb_iter_dicts(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from self._clip_share_to_fb_iter_dicts(child)
+
+    def _clip_share_to_fb_candidate_value(self, config: Dict[str, object], keys) -> object:
+        for key in keys:
+            value = config.get(key)
+            if value not in (None, ""):
+                return value
+        return None
+
+    def _clip_share_to_fb_reels_fb_candidate(self, config: Dict[str, object]) -> bool:
+        source_surface = str(config.get("source_surface") or "").upper()
+        destination_surface = str(config.get("destination_surface") or "").upper()
+        destination_app = str(config.get("destination_app") or "").upper()
+        if source_surface and source_surface not in {"REELS", "CLIPS"}:
+            return False
+        if destination_surface and destination_surface not in {"REELS", "CLIPS"}:
+            return False
+        if destination_app and destination_app not in {"FB", "FACEBOOK"}:
+            return False
+        return bool(source_surface or destination_surface or destination_app)
+
+    def _clip_share_to_fb_unified_destination_candidates(self, config: Dict[str, object]):
+        for candidate in self._clip_share_to_fb_iter_dicts(self._clip_share_to_fb_unified_root(config)):
+            if not self._clip_share_to_fb_reels_fb_candidate(candidate):
+                continue
+            merged = dict(candidate)
+            for key in (
+                "destination",
+                "fb_destination",
+                "reels_destination",
+                "crosspost_destination",
+                "crossposting_destination",
+                "xpost_destination",
+            ):
+                nested = candidate.get(key)
+                if isinstance(nested, dict):
+                    merged.update(nested)
+            yield merged
+
+    def clip_share_to_fb_unified_destination(self, config: Optional[Dict[str, object]] = None) -> Dict[str, object]:
+        """
+        Resolve a confirmed Reel Facebook destination from unified config.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Response from :meth:`clip_share_to_fb_unified_config`.
+
+        Returns
+        -------
+        Dict[str, object]
+            Normalized destination fields.
+        """
+        unified_config = config if config is not None else self.clip_share_to_fb_unified_config()
+        for candidate in self._clip_share_to_fb_unified_destination_candidates(unified_config or {}):
+            try:
+                return self.clip_share_to_fb_destination(config=candidate, use_unified_config=False)
+            except ClientError:
+                continue
+        raise ClientError("Facebook Reel sharing unified config has no confirmed Reel Facebook destination")
+
     def clip_share_to_fb_destination(
         self,
         config: Optional[Dict[str, object]] = None,
@@ -251,6 +379,7 @@ class UploadClipMixin:
         destination_type: Optional[str] = None,
         destination_audience_type: Optional[str] = None,
         validation_check_bypass: Optional[bool] = None,
+        use_unified_config: bool = True,
     ) -> Dict[str, object]:
         """
         Resolve the Facebook Reel sharing destination from confirmed fields.
@@ -274,6 +403,9 @@ class UploadClipMixin:
             Explicit Facebook Reels audience type, e.g. ``PUBLIC``.
         validation_check_bypass: bool, optional
             Explicit validation bypass flag. Overrides config values.
+        use_unified_config: bool, optional
+            When config is omitted, fall back to the Android cross-posting
+            unified config if the lightweight Reel preflight has no destination.
 
         Returns
         -------
@@ -284,23 +416,37 @@ class UploadClipMixin:
         if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
             raise ClientError("Facebook Reel sharing is not enabled or no Facebook account is linked")
 
-        destination_id = (
-            destination_id
-            or fb_config.get("share_to_fb_destination_id")
-            or fb_config.get("reels_destination_id")
-            or fb_config.get("destination_id")
+        explicit_destination = bool(destination_id or destination_type)
+        destination_id = destination_id or self._clip_share_to_fb_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_id",
+                "reels_destination_id",
+                "crosspost_destination_id",
+                "crossposting_destination_id",
+                "xpost_destination_id",
+                "destination_id",
+            ),
         )
-        destination_type = (
-            destination_type
-            or fb_config.get("share_to_fb_destination_type")
-            or fb_config.get("destination_type")
-            or fb_config.get("posting_type")
+        destination_type = destination_type or self._clip_share_to_fb_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_type",
+                "crosspost_destination_type",
+                "crossposting_destination_type",
+                "xpost_destination_type",
+                "destination_type",
+                "posting_type",
+            ),
         )
-        destination_audience_type = (
-            destination_audience_type
-            or fb_config.get("share_to_fb_destination_audience_type")
-            or fb_config.get("reels_destination_audience_type")
-            or fb_config.get("audience_type")
+        destination_audience_type = destination_audience_type or self._clip_share_to_fb_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_audience_type",
+                "reels_destination_audience_type",
+                "destination_audience_type",
+                "audience_type",
+            ),
         )
         if validation_check_bypass is None:
             validation_check_bypass = fb_config.get(
@@ -309,6 +455,11 @@ class UploadClipMixin:
             )
 
         has_destination = bool(destination_id and destination_type)
+        if not has_destination and use_unified_config and config is None and not explicit_destination:
+            try:
+                return self.clip_share_to_fb_unified_destination()
+            except ClientError:
+                pass
         if fb_config.get("share_to_fb_unavailable") and not has_destination:
             raise ClientError(
                 "Facebook Reel sharing is unavailable from the Reel preflight response. "

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -814,3 +814,32 @@ class ClientFacebookReelCrosspostLiveTestCase(_helpers.ClientPrivateTestCase):
         self.assertIn(destination["destination_type"], {"USER", "PAGE"})
         if destination.get("destination_audience_type"):
             self.assertIsInstance(destination["destination_audience_type"], str)
+
+    def test_clip_share_to_fb_unified_config_live(self):
+        config = self.cl.clip_share_to_fb_unified_config()
+
+        self.assertEqual(config.get("status"), "ok")
+        self.assertIsInstance(config.get("data"), dict)
+
+    def test_clip_upload_share_to_facebook_live(self):
+        try:
+            destination = self.cl.clip_share_to_fb_destination()
+        except ClientError as exc:
+            self.skipTest(f"No confirmed Facebook Reel destination available: {exc}")
+
+        self.assertTrue(destination["destination_id"])
+        self.assertIn(destination["destination_type"], {"USER", "PAGE"})
+        path = self.make_video_fixture(label="Facebook Reel crosspost fixture")
+        media = None
+        try:
+            caption_text = "Facebook Reel crosspost live test"
+            media = self.cl.clip_upload(path, caption_text, share_to_facebook=True)
+            self.assertUploadedMediaAccessible(
+                media,
+                media_type=2,
+                product_type="clips",
+                caption_text=caption_text,
+            )
+        finally:
+            if media:
+                self.assertTrue(self.cl.media_delete(media.id))

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -104,6 +104,47 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertFalse(device_status["hw_av1_dec"])
         self.assertEqual(result, expected)
 
+    def test_clip_share_to_fb_unified_config_requests_android_cxp_query(self):
+        client = self.build_client()
+        expected = {"status": "ok", "data": {"xcxp_unified_crossposting_configs_root": {}}}
+
+        with mock.patch.object(client, "private_graphql_query_request", return_value=expected) as graphql_request:
+            result = client.clip_share_to_fb_unified_config()
+
+        graphql_request.assert_called_once()
+        kwargs = graphql_request.call_args.kwargs
+        self.assertEqual(kwargs["friendly_name"], "CrosspostingUnifiedConfigsQuery")
+        self.assertEqual(kwargs["root_field_name"], "xcxp_unified_crossposting_configs_root")
+        self.assertEqual(kwargs["client_doc_id"], "216179630714134719310007237117")
+        self.assertEqual(kwargs["priority"], "u=3, i")
+        self.assertEqual(kwargs["extra_headers"], {"X-FB-RMD": "state=URL_ELIGIBLE"})
+        self.assertEqual(
+            kwargs["variables"],
+            {
+                "configs_request": {
+                    "source_app": "IG",
+                    "crosspost_app_surface_list": [
+                        {
+                            "source_surface": "STORY",
+                            "destination_app": "FB",
+                            "destination_surface": "STORY",
+                        },
+                        {
+                            "source_surface": "FEED",
+                            "destination_app": "FB",
+                            "destination_surface": "FEED",
+                        },
+                        {
+                            "source_surface": "REELS",
+                            "destination_app": "FB",
+                            "destination_surface": "REELS",
+                        },
+                    ],
+                }
+            },
+        )
+        self.assertEqual(result, expected)
+
     def test_clip_share_to_fb_destination_normalizes_current_reel_destination_fields(self):
         client = self.build_client()
 
@@ -157,6 +198,86 @@ class UploadRegressionTestCase(unittest.TestCase):
             )
 
         self.assertIn("no destination", str(ctx.exception))
+
+    def test_clip_share_to_fb_destination_falls_back_to_unified_reels_fb_destination(self):
+        client = self.build_client()
+        unified_config = {
+            "data": {
+                "1$xcxp_unified_crossposting_configs_root(configs_request:$configs_request)": {
+                    "configs": [
+                        {
+                            "source_surface": "FEED",
+                            "destination_app": "FB",
+                            "destination_surface": "FEED",
+                            "destination": {
+                                "destination_id": "feed-destination-id",
+                                "destination_type": "USER",
+                            },
+                        },
+                        {
+                            "source_surface": "REELS",
+                            "destination_app": "FB",
+                            "destination_surface": "REELS",
+                            "destination": {
+                                "destination_id": "reels-destination-id",
+                                "destination_type": "page",
+                                "destination_audience_type": "PUBLIC",
+                            },
+                            "cross_app_share_fb_validation_check_bypass": True,
+                        },
+                    ]
+                }
+            },
+            "status": "ok",
+        }
+
+        with (
+            mock.patch.object(
+                client,
+                "clip_share_to_fb_config",
+                return_value={"share_to_fb_unavailable": True, "status": "ok"},
+            ) as share_to_fb_config,
+            mock.patch.object(client, "clip_share_to_fb_unified_config", return_value=unified_config) as unified,
+        ):
+            result = client.clip_share_to_fb_destination()
+
+        share_to_fb_config.assert_called_once()
+        unified.assert_called_once()
+        self.assertEqual(
+            result,
+            {
+                "destination_id": "reels-destination-id",
+                "destination_type": "PAGE",
+                "destination_audience_type": "PUBLIC",
+                "validation_check_bypass": True,
+            },
+        )
+
+    def test_clip_share_to_fb_unified_destination_ignores_generic_account_center_ids(self):
+        client = self.build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            client.clip_share_to_fb_unified_destination(
+                config={
+                    "data": {
+                        "xcxp_unified_crossposting_configs_root": {
+                            "configs": [
+                                {
+                                    "source_surface": "REELS",
+                                    "destination_app": "FB",
+                                    "destination_surface": "REELS",
+                                    "account_id": "account-center-id",
+                                    "fbid": "facebook-linking-id",
+                                    "posting_type": "USER",
+                                }
+                            ]
+                        }
+                    },
+                    "status": "ok",
+                }
+            )
+
+        self.assertIn("no confirmed Reel Facebook destination", str(ctx.exception))
 
     def test_clip_share_to_fb_extra_data_builds_current_reel_crosspost_payload(self):
         client = self.build_client()


### PR DESCRIPTION
## Summary
- add `clip_share_to_fb_unified_config()` for Android `CrosspostingUnifiedConfigsQuery` discovery
- add `clip_share_to_fb_unified_destination()` and conservative fallback from `clip_share_to_fb_destination()` when the lightweight Reel preflight has no confirmed destination
- keep manual `fb_destination_id` / `fb_destination_type` overrides and continue ignoring generic Account Center linking ids as publish destinations
- document automatic discovery and add regression/live coverage

## Tests
- `.venv/bin/python -m pytest tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_share_to_fb_unified_config_requests_android_cxp_query tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_share_to_fb_destination_falls_back_to_unified_reels_fb_destination tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_share_to_fb_unified_destination_ignores_generic_account_center_ids -q`
- `.venv/bin/python -m pytest tests/regression/test_clip.py tests/regression/test_upload.py -q`
- `.venv/bin/python -m ruff check instagrapi/mixins/clip.py tests/regression/test_upload.py tests/live/test_upload.py`
- `PATH="$PWD/.venv/bin:$PATH" mkdocs build --strict`
- `.venv/bin/python -m pytest tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_share_to_fb_unified_config_live tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_upload_share_to_facebook_live -q -s` (unified config passed; upload cross-post skipped because the current fresh account pool has no confirmed Facebook Reel destination)

Refs #2556