### PR TITLE
Raise MediaError for missing media insights

### DIFF
--- a/docs/usage-guide/insight.md
+++ b/docs/usage-guide/insight.md
@@ -33,3 +33,4 @@ Notes:
 * These methods require an authenticated business/professional account. Personal accounts can raise `UserError`.
 * `insights_media_feed_all()` paginates internally and sleeps between pages; reduce `count` if you only need a small sample.
 * `insights_media()` raises `MediaError` when Instagram does not return insight data for the requested media.
+* If Instagram returns media metadata without `inline_insights_node`, `insights_media()` raises `MediaError` instead of returning partial counts with null insight metrics.

--- a/instagrapi/mixins/insights.py
+++ b/instagrapi/mixins/insights.py
@@ -208,6 +208,21 @@ class InsightsMixin:
                 "ads/graphql/",
                 self.with_query_params(data, query_params),
             )
-            return result["data"]["instagram_post_by_igid"]
+            media = json_value(result, "data", "instagram_post_by_igid", default=None)
+            if not media:
+                raise MediaError(
+                    "Instagram did not return insight data for media",
+                    media_pk=media_pk,
+                    **(self.last_json or {}),
+                )
+            if not media.get("inline_insights_node"):
+                raise MediaError(
+                    "Instagram returned media metadata without inline insights data",
+                    media_pk=media_pk,
+                    **(self.last_json or {}),
+                )
+            return media
+        except MediaError:
+            raise
         except ClientError as e:
-            raise MediaError(e.message, media_pk=media_pk, **self.last_json)
+            raise MediaError(e.message, media_pk=media_pk, **(self.last_json or {}))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,7 @@ from tests.live.test_direct import (
 )
 from tests.live.test_hashtag import ClientHashtagTestCase
 from tests.live.test_highlight import ClientHighlightTestCase
+from tests.live.test_insights import ClientInsightsLiveTestCase
 from tests.live.test_location import ClientLocationTestCase
 from tests.live.test_media import (
     ClientCompareExtractTestCase,
@@ -53,6 +54,7 @@ from tests.regression.test_extractors import (
 )
 from tests.regression.test_fbsearch import FbSearchRegressionTestCase
 from tests.regression.test_hardening import HardeningRegressionTestCase
+from tests.regression.test_insights import InsightsRegressionTestCase
 from tests.regression.test_location import LocationMixinRegressionTestCase
 from tests.regression.test_media import (
     CheckOffensiveCommentV2RegressionTestCase,

--- a/tests/live/test_insights.py
+++ b/tests/live/test_insights.py
@@ -1,0 +1,178 @@
+import multiprocessing
+import os
+import queue
+import time
+import traceback
+import unittest
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
+
+from instagrapi import Client
+from instagrapi.exceptions import MediaError
+from tests.helpers import TEST_ACCOUNTS_URL
+
+
+def _insights_test_accounts_url(count=3):
+    parts = urlsplit(TEST_ACCOUNTS_URL)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["count"] = str(count)
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query),
+            parts.fragment,
+        )
+    )
+
+
+def _insights_client_from_test_account(acc):
+    settings = dict(acc["client_settings"])
+    totp_seed = settings.pop("totp_seed", None)
+    cl = Client(settings=settings, proxy=os.getenv("IG_PROXY") or acc["proxy"])
+    login_kwargs = {
+        "username": acc["username"],
+        "password": acc["password"],
+        "relogin": True,
+    }
+    if totp_seed:
+        totp_code = cl.totp_generate_code(totp_seed)
+        cl.totp_seed = totp_seed
+        cl.totp_code = totp_code
+        login_kwargs["verification_code"] = totp_code
+    cl.login(**login_kwargs)
+    cl._user_id = acc.get("user_id")
+    return cl
+
+
+def _insights_fresh_account():
+    response = requests.get(_insights_test_accounts_url(), verify=False, timeout=30)
+    response.raise_for_status()
+    last_exc = None
+    for acc in response.json()[:3]:
+        try:
+            return _insights_client_from_test_account(acc)
+        except Exception as exc:
+            last_exc = exc
+            continue
+    if last_exc:
+        raise RuntimeError(f"No usable fresh account returned: {last_exc}") from last_exc
+    raise RuntimeError("No usable fresh account returned")
+
+
+def _ensure_creator_account(cl):
+    account = cl.account_info()
+    if account.account_type == 3:
+        return
+    account = cl.account_convert_to_creator(
+        category_id="2347428775505624",
+        should_show_category=True,
+        should_show_public_contacts=False,
+    )
+    if account.account_type != 3:
+        raise AssertionError(f"Expected creator account type 3, got {account.account_type}")
+
+
+def _uploaded_media_payload(cl, media, attempts=5, delay=3):
+    last_result = None
+    for attempt in range(attempts):
+        if attempt:
+            time.sleep(delay)
+        result = cl.private_request(f"media/{media.pk}/info/")
+        last_result = result
+        items = result.get("items") or []
+        if items:
+            return items[0]
+    raise AssertionError(f"Uploaded media was not accessible: {last_result}")
+
+
+def _wait_for_media_insights(cl, media, attempts=6, delay=5):
+    last_error = None
+    for attempt in range(attempts):
+        if attempt:
+            time.sleep(delay)
+        try:
+            result = cl.insights_media(media.pk)
+        except MediaError as exc:
+            last_error = exc
+            continue
+        inline_insights = result.get("inline_insights_node")
+        if not isinstance(inline_insights, dict):
+            raise AssertionError(f"inline_insights_node is not a dict: {inline_insights!r}")
+        if not inline_insights.get("state"):
+            raise AssertionError(f"inline insights state is empty: {inline_insights!r}")
+        if not isinstance(inline_insights.get("metrics"), dict):
+            raise AssertionError(f"inline insights metrics are missing: {inline_insights!r}")
+        return result
+    raise MediaError(f"Instagram did not expose inline insights for uploaded media: {last_error}")
+
+
+def _run_insights_media_owned_photo_live(result_queue):
+    if not TEST_ACCOUNTS_URL:
+        result_queue.put({"status": "skip", "reason": "TEST_ACCOUNTS_URL is required for insights live tests"})
+        return
+
+    cl = None
+    media = None
+    try:
+        cl = _insights_fresh_account()
+        _ensure_creator_account(cl)
+        media = cl.photo_upload(Path("examples/kanada.jpg"), "Insights media live test")
+        payload = _uploaded_media_payload(cl, media)
+        if str(payload.get("pk")) != str(media.pk):
+            raise AssertionError(f"Uploaded media payload pk mismatch: {payload.get('pk')} != {media.pk}")
+        result = _wait_for_media_insights(cl, media)
+        result_queue.put(
+            {
+                "status": "ok",
+                "instagram_media_id": str(result.get("instagram_media_id")),
+                "media_pk": str(media.pk),
+                "has_like_count": "like_count" in result,
+                "has_comment_count": "comment_count" in result,
+            }
+        )
+    except MediaError as exc:
+        result_queue.put({"status": "skip", "reason": str(exc)})
+    except Exception:
+        result_queue.put({"status": "error", "traceback": traceback.format_exc()})
+    finally:
+        if cl and media:
+            try:
+                cl.media_delete(media.id)
+            except Exception:
+                pass
+
+
+class ClientInsightsLiveTestCase(unittest.TestCase):
+    def run_insights_worker(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for insights live tests")
+        ctx = multiprocessing.get_context("spawn")
+        result_queue = ctx.Queue()
+        process = ctx.Process(target=_run_insights_media_owned_photo_live, args=(result_queue,))
+        process.start()
+        timeout = int(os.getenv("INSTAGRAPI_INSIGHTS_LIVE_TIMEOUT", "180"))
+        process.join(timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join(10)
+            self.skipTest(f"Insights live workflow timed out after {timeout} seconds")
+        try:
+            return result_queue.get(timeout=5)
+        except queue.Empty:
+            if process.exitcode:
+                self.fail(f"Insights live workflow exited with code {process.exitcode}")
+            self.fail("Insights live workflow did not return a result")
+
+    def test_insights_media_owned_photo_live(self):
+        result = self.run_insights_worker()
+        if result["status"] == "skip":
+            self.skipTest(result["reason"])
+        if result["status"] == "error":
+            self.fail(result["traceback"])
+        self.assertEqual(result["instagram_media_id"], result["media_pk"])
+        self.assertTrue(result["has_like_count"])
+        self.assertTrue(result["has_comment_count"])

--- a/tests/regression/test_insights.py
+++ b/tests/regression/test_insights.py
@@ -1,0 +1,67 @@
+from instagrapi.exceptions import MediaError
+from tests.helpers import *
+
+
+class InsightsRegressionTestCase(unittest.TestCase):
+    def build_client(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "1"}
+        return client
+
+    def test_insights_media_returns_available_payload(self):
+        client = self.build_client()
+        payload = {
+            "data": {
+                "instagram_post_by_igid": {
+                    "id": "18000000000000000",
+                    "instagram_media_id": "123",
+                    "inline_insights_node": {
+                        "state": "AVAILABLE",
+                        "metrics": {
+                            "like_count": {"value": 1},
+                        },
+                    },
+                    "like_count": 1,
+                    "save_count": 0,
+                },
+            },
+        }
+
+        with mock.patch.object(client, "private_request", return_value=payload):
+            result = client.insights_media("123")
+
+        self.assertEqual(result["instagram_media_id"], "123")
+        self.assertEqual(result["inline_insights_node"]["state"], "AVAILABLE")
+
+    def test_insights_media_raises_media_error_when_inline_insights_missing(self):
+        client = self.build_client()
+        client.last_json = {}
+        payload = {
+            "data": {
+                "instagram_post_by_igid": {
+                    "id": "18000000000000000",
+                    "instagram_media_id": "123",
+                    "inline_insights_node": None,
+                    "like_count": None,
+                    "save_count": None,
+                },
+            },
+        }
+
+        with mock.patch.object(client, "private_request", return_value=payload):
+            with self.assertRaises(MediaError) as cm:
+                client.insights_media("123")
+
+        self.assertEqual(cm.exception.media_pk, "123")
+        self.assertIn("inline insights", cm.exception.message)
+
+    def test_insights_media_raises_media_error_when_post_missing(self):
+        client = self.build_client()
+        client.last_json = {}
+
+        with mock.patch.object(client, "private_request", return_value={"data": {"instagram_post_by_igid": None}}):
+            with self.assertRaises(MediaError) as cm:
+                client.insights_media("123")
+
+        self.assertEqual(cm.exception.media_pk, "123")
+        self.assertIn("insight data", cm.exception.message)


### PR DESCRIPTION
## Summary

Fixes #1946.

`insights_media()` now validates the GraphQL response before returning it. When Instagram returns `instagram_post_by_igid` without `inline_insights_node`, the method raises `MediaError` instead of returning partial media metadata with null insight metrics.

## Changes

- Raise `MediaError` when `instagram_post_by_igid` is missing.
- Raise `MediaError` when `inline_insights_node` is missing or null.
- Keep returning the original media insight payload when inline insights are available.
- Document the missing-inline-insights behavior.
- Add regression coverage for available, missing-post, and missing-inline-insights responses.
- Add a live owned-photo upload insights test with a subprocess timeout guard so bad fresh-account login/proxy state cannot hang pytest.

## Verification

- `.venv/bin/python -m pytest tests/regression/test_insights.py -q` -> 3 passed
- `INSTAGRAPI_INSIGHTS_LIVE_TIMEOUT=20 .venv/bin/python -m pytest tests/live/test_insights.py -q -s` -> 1 skipped in current fresh-account environment after controlled timeout
- `.venv/bin/python -m ruff check instagrapi tests docs` -> passed
- `.venv/bin/python -m mkdocs build --strict` -> passed
