### PR TITLE
Add coverage for hashtag search numeric IDs

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -159,44 +159,107 @@ class BaseClientMixin:
         return True
 
 
+def build_test_accounts_url(count=None):
+    parts = urlsplit(TEST_ACCOUNTS_URL)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    if count is None:
+        query["count"] = "5"
+    else:
+        query["count"] = str(count)
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query),
+            parts.fragment,
+        )
+    )
+
+
+def client_from_test_account(acc):
+    settings = dict(acc["client_settings"])
+    totp_seed = settings.pop("totp_seed", None)
+    cl = Client(settings=settings, proxy=os.getenv("IG_PROXY") or acc["proxy"])
+    login_kwargs = {
+        "username": acc["username"],
+        "password": acc["password"],
+        "relogin": True,
+    }
+    if totp_seed:
+        totp_code = cl.totp_generate_code(totp_seed)
+        cl.totp_seed = totp_seed
+        cl.totp_code = totp_code
+        login_kwargs["verification_code"] = totp_code
+    cl.login(**login_kwargs)
+    cl._user_id = acc.get("user_id")
+    return cl
+
+
+def fetch_test_accounts(count=None, timeout=None):
+    test_accounts_url = build_test_accounts_url(count=count)
+    print("TEST_ACCOUNTS_URL: configured")
+    request_kwargs = {"verify": False}
+    if timeout is not None:
+        request_kwargs["timeout"] = timeout
+    try:
+        resp = requests.get(test_accounts_url, **request_kwargs)
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Could not fetch TEST_ACCOUNTS_URL: {exc.__class__.__name__}") from None
+    print("TEST_ACCOUNTS_URL response code: ", resp.status_code)
+    if not 200 <= resp.status_code < 300:
+        raise RuntimeError(f"TEST_ACCOUNTS_URL returned HTTP {resp.status_code}")
+    return resp.json()
+
+
+def fresh_test_account(count=5, attempts=5, timeout=None):
+    last_exc = None
+    for attempt, acc in enumerate(fetch_test_accounts(count=count, timeout=timeout)[:attempts], start=1):
+        print(f"Fresh account attempt {attempt}: %(username)r" % acc)
+        try:
+            return client_from_test_account(acc)
+        except Exception as exc:
+            last_exc = exc
+            print(f"Fresh account attempt {attempt} failed for {acc['username']}: {exc.__class__.__name__} {exc}")
+            continue
+    if last_exc:
+        raise RuntimeError(f"No usable fresh account returned: {last_exc}") from last_exc
+    raise RuntimeError("No usable fresh account returned")
+
+
+def fresh_test_accounts(count: int, exclude_user_ids=None, timeout=None):
+    exclude_user_ids = {str(user_id) for user_id in (exclude_user_ids or set())}
+    request_count = count + len(exclude_user_ids) + 3
+    accounts = []
+    seen_user_ids = set(exclude_user_ids)
+    last_exc = None
+    for attempt, acc in enumerate(fetch_test_accounts(count=request_count, timeout=timeout), start=1):
+        print(f"Fresh account attempt {attempt}: %(username)r" % acc)
+        try:
+            cl = client_from_test_account(acc)
+        except Exception as exc:
+            last_exc = exc
+            print(f"Fresh account attempt {attempt} failed for {acc['username']}: {exc.__class__.__name__} {exc}")
+            continue
+        user_id = str(cl.user_id)
+        if user_id in seen_user_ids:
+            continue
+        seen_user_ids.add(user_id)
+        accounts.append(cl)
+        if len(accounts) == count:
+            return accounts
+    raise RuntimeError(f"Could not get {count} usable fresh accounts" + (f": {last_exc}" if last_exc else ""))
+
+
 class ClientPrivateTestCase(BaseClientMixin, unittest.TestCase):
     cl = None
     _username_cache = {}
 
     def build_test_accounts_url(self, count=None):
-        parts = urlsplit(TEST_ACCOUNTS_URL)
-        query = dict(parse_qsl(parts.query, keep_blank_values=True))
-        if count is None:
-            query["count"] = "5"
-        else:
-            query["count"] = str(count)
-        return urlunsplit(
-            (
-                parts.scheme,
-                parts.netloc,
-                parts.path,
-                urlencode(query),
-                parts.fragment,
-            )
-        )
+        return build_test_accounts_url(count=count)
 
     def client_from_test_account(self, acc):
-        settings = dict(acc["client_settings"])
-        totp_seed = settings.pop("totp_seed", None)
-        cl = Client(settings=settings, proxy=os.getenv("IG_PROXY") or acc["proxy"])
-        login_kwargs = {
-            "username": acc["username"],
-            "password": acc["password"],
-            "relogin": True,
-        }
-        if totp_seed:
-            totp_code = cl.totp_generate_code(totp_seed)
-            cl.totp_seed = totp_seed
-            cl.totp_code = totp_code
-            login_kwargs["verification_code"] = totp_code
-        cl.login(**login_kwargs)
-        cl._user_id = acc.get("user_id")
-        return cl
+        return client_from_test_account(acc)
 
     def user_info_by_username(self, username):
         return self.cl.user_info_by_username_v1(username)
@@ -332,60 +395,10 @@ class ClientPrivateTestCase(BaseClientMixin, unittest.TestCase):
             self.cl = self.fresh_account()
 
     def fresh_account(self):
-        test_accounts_url = self.build_test_accounts_url()
-        print("TEST_ACCOUNTS_URL: configured")
-        try:
-            resp = requests.get(test_accounts_url, verify=False)
-        except requests.RequestException as exc:
-            raise RuntimeError(f"Could not fetch TEST_ACCOUNTS_URL: {exc.__class__.__name__}") from None
-        print("TEST_ACCOUNTS_URL response code: ", resp.status_code)
-        if not 200 <= resp.status_code < 300:
-            raise RuntimeError(f"TEST_ACCOUNTS_URL returned HTTP {resp.status_code}")
-        last_exc = None
-        for attempt, acc in enumerate(resp.json()[:5], start=1):
-            print(f"Fresh account attempt {attempt}: %(username)r" % acc)
-            try:
-                return self.client_from_test_account(acc)
-            except Exception as exc:
-                last_exc = exc
-                print(f"Fresh account attempt {attempt} failed for {acc['username']}: {exc.__class__.__name__} {exc}")
-                continue
-        if last_exc:
-            raise RuntimeError(f"No usable fresh account returned: {last_exc}") from last_exc
-        raise RuntimeError("No usable fresh account returned")
+        return fresh_test_account()
 
     def fresh_accounts(self, count: int, exclude_user_ids=None):
-        exclude_user_ids = {str(user_id) for user_id in (exclude_user_ids or set())}
-        request_count = count + len(exclude_user_ids) + 3
-        test_accounts_url = self.build_test_accounts_url(count=request_count)
-        print("TEST_ACCOUNTS_URL: configured")
-        try:
-            resp = requests.get(test_accounts_url, verify=False)
-        except requests.RequestException as exc:
-            raise RuntimeError(f"Could not fetch TEST_ACCOUNTS_URL: {exc.__class__.__name__}") from None
-        print("TEST_ACCOUNTS_URL response code: ", resp.status_code)
-        if not 200 <= resp.status_code < 300:
-            raise RuntimeError(f"TEST_ACCOUNTS_URL returned HTTP {resp.status_code}")
-
-        accounts = []
-        seen_user_ids = set(exclude_user_ids)
-        last_exc = None
-        for attempt, acc in enumerate(resp.json(), start=1):
-            print(f"Fresh account attempt {attempt}: %(username)r" % acc)
-            try:
-                cl = self.client_from_test_account(acc)
-            except Exception as exc:
-                last_exc = exc
-                print(f"Fresh account attempt {attempt} failed for {acc['username']}: {exc.__class__.__name__} {exc}")
-                continue
-            user_id = str(cl.user_id)
-            if user_id in seen_user_ids:
-                continue
-            seen_user_ids.add(user_id)
-            accounts.append(cl)
-            if len(accounts) == count:
-                return accounts
-        raise RuntimeError(f"Could not get {count} usable fresh accounts" + (f": {last_exc}" if last_exc else ""))
+        return fresh_test_accounts(count, exclude_user_ids=exclude_user_ids)
 
     def __init__(self, *args, **kwargs):
         if TEST_ACCOUNTS_URL:

--- a/tests/live/test_hashtag_search.py
+++ b/tests/live/test_hashtag_search.py
@@ -1,0 +1,69 @@
+import multiprocessing
+import os
+import queue
+import traceback
+import unittest
+
+from tests.helpers import TEST_ACCOUNTS_URL, fresh_test_account
+
+
+def _run_search_hashtags_live(result_queue):
+    if not TEST_ACCOUNTS_URL:
+        result_queue.put({"status": "skip", "reason": "TEST_ACCOUNTS_URL is required for hashtag search live tests"})
+        return
+    try:
+        cl = fresh_test_account(count=3, attempts=3, timeout=30)
+        hashtags = cl.search_hashtags("restaurant")
+        if not hashtags:
+            result_queue.put({"status": "skip", "reason": "Instagram returned no hashtags for restaurant"})
+            return
+        first = hashtags[0]
+        raw_id = cl.last_json["results"][0]["id"]
+        result_queue.put(
+            {
+                "status": "ok",
+                "raw_id": raw_id,
+                "raw_id_type": type(raw_id).__name__,
+                "id": first.id,
+                "id_type": type(first.id).__name__,
+                "name": first.name,
+                "count": len(hashtags),
+            }
+        )
+    except Exception:
+        result_queue.put({"status": "error", "traceback": traceback.format_exc()})
+
+
+class ClientHashtagSearchLiveTestCase(unittest.TestCase):
+    def run_worker(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for hashtag search live tests")
+        ctx = multiprocessing.get_context("spawn")
+        result_queue = ctx.Queue()
+        process = ctx.Process(target=_run_search_hashtags_live, args=(result_queue,))
+        process.start()
+        timeout = int(os.getenv("INSTAGRAPI_HASHTAG_SEARCH_LIVE_TIMEOUT", "120"))
+        process.join(timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join(10)
+            self.skipTest(f"Hashtag search live workflow timed out after {timeout} seconds")
+        try:
+            return result_queue.get(timeout=5)
+        except queue.Empty:
+            if process.exitcode:
+                self.fail(f"Hashtag search live workflow exited with code {process.exitcode}")
+            self.fail("Hashtag search live workflow did not return a result")
+
+    def test_search_hashtags_accepts_private_numeric_ids_live(self):
+        result = self.run_worker()
+        if result["status"] == "skip":
+            self.skipTest(result["reason"])
+        if result["status"] == "error":
+            self.fail(result["traceback"])
+        self.assertEqual(result["raw_id_type"], "int")
+        self.assertEqual(result["id_type"], "str")
+        self.assertEqual(result["id"], str(result["raw_id"]))
+        self.assertTrue(result["id"])
+        self.assertTrue(result["name"])
+        self.assertGreater(result["count"], 0)

--- a/tests/regression/test_fbsearch.py
+++ b/tests/regression/test_fbsearch.py
@@ -128,6 +128,28 @@ class FbSearchRegressionTestCase(unittest.TestCase):
 
         self.assertEqual([hashtag.name for hashtag in hashtags], ["python"])
 
+    def test_search_hashtags_accepts_numeric_private_id(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={
+                "results": [
+                    {
+                        "id": 17843915557058484,
+                        "name": "restaurant",
+                        "media_count": 65043150,
+                        "profile_pic_url": None,
+                    }
+                ]
+            },
+        ):
+            hashtags = client.search_hashtags("restaurant")
+
+        self.assertEqual(hashtags[0].id, "17843915557058484")
+        self.assertEqual(hashtags[0].name, "restaurant")
+        self.assertEqual(hashtags[0].media_count, 65043150)
+
     def test_search_music_skips_non_track_items(self):
         client = self._build_client()
         with mock.patch.object(

--- a/tests/regression/test_helpers.py
+++ b/tests/regression/test_helpers.py
@@ -24,3 +24,24 @@ class LiveAccountHelperRegressionTestCase(unittest.TestCase):
             url = case.build_test_accounts_url(count=8)
 
         self.assertEqual(url, "https://accounts.example.test/take?pool=live&count=8")
+
+    def test_client_private_fresh_account_uses_shared_helper(self):
+        case = object.__new__(helper_module.ClientPrivateTestCase)
+        client = object()
+
+        with mock.patch.object(helper_module, "fresh_test_account", return_value=client) as fresh_test_account:
+            result = case.fresh_account()
+
+        self.assertIs(result, client)
+        fresh_test_account.assert_called_once_with()
+
+    def test_client_private_fresh_accounts_uses_shared_helper(self):
+        case = object.__new__(helper_module.ClientPrivateTestCase)
+        clients = [object()]
+        exclude_user_ids = {"123"}
+
+        with mock.patch.object(helper_module, "fresh_test_accounts", return_value=clients) as fresh_test_accounts:
+            result = case.fresh_accounts(1, exclude_user_ids=exclude_user_ids)
+
+        self.assertIs(result, clients)
+        fresh_test_accounts.assert_called_once_with(1, exclude_user_ids=exclude_user_ids)


### PR DESCRIPTION
Fixes #1805.

## Summary
- add an offline regression test for `search_hashtags()` with a private `/tags/search/` payload where `id` is numeric
- add a guarded live test that calls `search_hashtags("restaurant")`, verifies the raw private payload contains an integer hashtag id, and verifies the extracted `Hashtag.id` is the matching string
- move reusable `TEST_ACCOUNTS_URL` account/client setup into shared `tests.helpers` functions and keep `ClientPrivateTestCase` methods as compatibility wrappers
- keep production code unchanged because current `TypesBaseModel` already enables `coerce_numbers_to_str=True`, so `Hashtag.id: str` now accepts private numeric IDs

## Tests
- `.venv/bin/python -m pytest tests/regression/test_fbsearch.py tests/regression/test_helpers.py -q` -> 18 passed
- `INSTAGRAPI_HASHTAG_SEARCH_LIVE_TIMEOUT=30 .venv/bin/python -m pytest tests/live/test_hashtag_search.py -q -s` -> 1 passed
- `.venv/bin/ruff check tests/helpers.py tests/regression/test_helpers.py tests/regression/test_fbsearch.py tests/live/test_hashtag_search.py && .venv/bin/ruff format --check tests/helpers.py tests/regression/test_helpers.py tests/regression/test_fbsearch.py tests/live/test_hashtag_search.py` -> passed
