### PR TITLE
Add coverage for story interactive metadata uploads

### DIFF
--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -1,3 +1,9 @@
+import multiprocessing
+import os
+import queue
+import traceback
+from urllib.parse import parse_qs, urlparse
+
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -326,6 +332,126 @@ class ClientStoryLocationStickerLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(info.locations[0].location.name)
         finally:
             self.cleanup_uploaded_story(story)
+
+
+def _run_photo_story_interactive_metadata_live(result_queue):
+    if not TEST_ACCOUNTS_URL:
+        result_queue.put({"status": "skip", "reason": "TEST_ACCOUNTS_URL is required for story metadata live tests"})
+        return
+
+    cl = None
+    story = None
+    try:
+        cl = fresh_test_account(count=3, attempts=3, timeout=30)
+        account = cl.account_info()
+        user = UserShort(
+            pk=account.pk,
+            username=account.username,
+            full_name=account.full_name,
+            profile_pic_url=account.profile_pic_url,
+            is_private=account.is_private,
+        )
+        locations = cl.location_search(lat=59.939095, lng=30.315868)
+        if not locations:
+            result_queue.put({"status": "skip", "reason": "location_search returned no locations"})
+            return
+        hashtag = cl.hashtag_info("instagram")
+        existing_story_ids = {item.id for item in cl.user_stories_v1(cl.user_id, amount=20)}
+
+        story = cl.photo_upload_to_story(
+            Path("examples/background.png"),
+            "Story interactive metadata live test",
+            mentions=[StoryMention(user=user, x=0.5, y=0.35, width=0.5, height=0.1)],
+            links=[StoryLink(webUri="https://github.com/subzeroid/instagrapi")],
+            hashtags=[StoryHashtag(hashtag=hashtag, x=0.5, y=0.45, width=0.4, height=0.1)],
+            locations=[StoryLocation(location=locations[0], x=0.5, y=0.55, width=0.5, height=0.1)],
+        )
+
+        uploaded_story = None
+        for attempt in range(8):
+            if attempt:
+                time.sleep(3)
+            for candidate in cl.user_stories_v1(cl.user_id, amount=20):
+                if candidate.id == story.id or candidate.id not in existing_story_ids:
+                    uploaded_story = candidate
+                    break
+            if uploaded_story and (
+                uploaded_story.mentions
+                and uploaded_story.links
+                and uploaded_story.hashtags
+                and uploaded_story.locations
+            ):
+                break
+
+        result_queue.put(
+            {
+                "status": "ok",
+                "story_id": story.id,
+                "uploaded_story_id": uploaded_story.id if uploaded_story else None,
+                "mention_users": [mention.user.username for mention in uploaded_story.mentions]
+                if uploaded_story
+                else [],
+                "link_urls": [str(link.webUri) for link in uploaded_story.links] if uploaded_story else [],
+                "hashtag_names": [item.hashtag.name for item in uploaded_story.hashtags] if uploaded_story else [],
+                "location_names": [item.location.name for item in uploaded_story.locations] if uploaded_story else [],
+            }
+        )
+    except Exception:
+        result_queue.put({"status": "error", "traceback": traceback.format_exc()})
+    finally:
+        if cl and story:
+            try:
+                cl.story_delete(story.id)
+            except Exception as exc:
+                print(f"Story metadata live cleanup story_delete failed: {exc.__class__.__name__} {exc}")
+
+
+def _is_instagrapi_github_link(url):
+    parsed = urlparse(url)
+    if parsed.netloc == "github.com" and parsed.path == "/subzeroid/instagrapi":
+        return True
+    target_urls = parse_qs(parsed.query).get("u") or []
+    for target_url in target_urls:
+        target = urlparse(target_url)
+        if target.netloc == "github.com" and target.path == "/subzeroid/instagrapi":
+            return True
+    return False
+
+
+class ClientStoryInteractiveMetadataLiveTestCase(unittest.TestCase):
+    def run_story_metadata_worker(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for story metadata live tests")
+        ctx = multiprocessing.get_context("spawn")
+        result_queue = ctx.Queue()
+        process = ctx.Process(target=_run_photo_story_interactive_metadata_live, args=(result_queue,))
+        process.start()
+        timeout = int(os.getenv("INSTAGRAPI_STORY_METADATA_LIVE_TIMEOUT", "180"))
+        process.join(timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join(10)
+            self.skipTest(f"Story metadata live workflow timed out after {timeout} seconds")
+        try:
+            return result_queue.get(timeout=5)
+        except queue.Empty:
+            if process.exitcode:
+                self.fail(f"Story metadata live workflow exited with code {process.exitcode}")
+            self.fail("Story metadata live workflow did not return a result")
+
+    def test_photo_story_interactive_metadata_round_trips_live(self):
+        result = self.run_story_metadata_worker()
+        if result["status"] == "skip":
+            self.skipTest(result["reason"])
+        if result["status"] == "error":
+            self.fail(result["traceback"])
+        self.assertEqual(result["story_id"], result["uploaded_story_id"])
+        self.assertTrue(result["mention_users"])
+        self.assertTrue(result["link_urls"])
+        self.assertTrue(result["hashtag_names"])
+        self.assertTrue(result["location_names"])
+        self.assertIn("instagram", result["hashtag_names"])
+        self.assertTrue(any(_is_instagrapi_github_link(url) for url in result["link_urls"]))
 
 
 class ClientStoryMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/regression/test_story_configure.py
+++ b/tests/regression/test_story_configure.py
@@ -98,6 +98,42 @@ class StoryConfigureRegressionTestCase(unittest.TestCase):
         self.assertEqual(configure_args[0], "media/configure_to_story/")
         self.assert_story_location_model(configure_args[1])
 
+    def test_photo_story_interactive_metadata_builds_tap_models(self):
+        client = self.build_client()
+        location = self.build_location()
+        user = UserShort(pk="2", username="artist", full_name="Artist", profile_pic_url=None)
+        hashtag = Hashtag(id="1", name="event")
+
+        with mock.patch.object(client, "location_complete", return_value=location):
+            with mock.patch.object(client, "private_request") as private_request:
+                private_request.side_effect = [
+                    {"status": "ok"},
+                    {"status": "ok"},
+                ]
+                client.photo_configure_to_story(
+                    upload_id="1",
+                    width=720,
+                    height=1280,
+                    caption="",
+                    mentions=[StoryMention(user=user, x=0.2, y=0.3, width=0.4, height=0.1)],
+                    links=[StoryLink(webUri="https://example.com")],
+                    hashtags=[StoryHashtag(hashtag=hashtag, x=0.3, y=0.4, width=0.4, height=0.1)],
+                    locations=[StoryLocation(location=location, x=0.4, y=0.5, width=0.4, height=0.1)],
+                )
+
+        configure_args, _ = private_request.call_args_list[1]
+        data = configure_args[1]
+        tap_models = json.loads(data["tap_models"])
+        self.assertEqual(
+            [model["type"] for model in tap_models],
+            ["mention", "hashtag", "location", "story_link"],
+        )
+        self.assertEqual(
+            data["story_sticker_ids"],
+            "hashtag_sticker,location_sticker,link_sticker_default",
+        )
+        self.assertIn("reel_mentions", data)
+
     def test_video_story_location_uses_external_location_id_tap_model(self):
         client = self.build_client()
         location = self.build_location()


### PR DESCRIPTION
Closes #1760.

## Summary
- add offline coverage that `photo_configure_to_story()` builds `tap_models` for mentions, links, hashtags, and locations in one configure payload
- add a guarded live test that uploads a photo story with a mention, link sticker, hashtag sticker, and location sticker, then reads the story back and verifies all interactive metadata round-trips
- keep production code unchanged because current `master` already round-trips this metadata in live diagnostics

## Tests
- `.venv/bin/python -m pytest tests/regression/test_story_configure.py -q` -> 4 passed
- `INSTAGRAPI_STORY_METADATA_LIVE_TIMEOUT=180 .venv/bin/python -m pytest tests/live/test_story.py::ClientStoryInteractiveMetadataLiveTestCase::test_photo_story_interactive_metadata_round_trips_live -q -s` -> 1 passed
- `.venv/bin/ruff check tests/regression/test_story_configure.py tests/live/test_story.py && .venv/bin/ruff format --check tests/regression/test_story_configure.py tests/live/test_story.py` -> passed
