### PR TITLE
Normalize private business contact fields

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -249,6 +249,8 @@ def extract_user_v1(data):
     """For Private API"""
     data["broadcast_channel"] = extract_broadcast_channel(data)
     data["external_url"] = data.get("external_url") or None
+    data["public_email"] = data.get("public_email") or data.get("business_email")
+    data["contact_phone_number"] = data.get("contact_phone_number") or data.get("business_phone_number")
     versions = data.get("hd_profile_pic_versions")
     pic_hd = versions[-1] if versions else data.get("hd_profile_pic_url_info", {})
     data["profile_pic_url_hd"] = pic_hd.get("url")

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -1,3 +1,8 @@
+import multiprocessing
+import os
+import queue
+import traceback
+
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -48,6 +53,63 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         followers = self.cl.user_followers_private_gql(user_id, amount=5, order="date_followed_latest")
         self.assertEqual(len(followers), 5)
         self.assertIsInstance(followers[0], UserShort)
+
+
+def _run_business_email_live(result_queue):
+    if not TEST_ACCOUNTS_URL:
+        result_queue.put({"status": "skip", "reason": "TEST_ACCOUNTS_URL is required for business email live tests"})
+        return
+    try:
+        cl = fresh_test_account(count=3, attempts=3, timeout=30)
+        user = cl.user_info_by_username_v1("toyota")
+        raw_user = cl.last_json.get("user") or {}
+        raw_email = raw_user.get("public_email") or raw_user.get("business_email")
+        if not raw_email:
+            result_queue.put({"status": "skip", "reason": "toyota profile did not return a public email"})
+            return
+        result_queue.put(
+            {
+                "status": "ok",
+                "username": user.username,
+                "is_business": user.is_business,
+                "raw_email": raw_email,
+                "public_email": user.public_email,
+            }
+        )
+    except Exception:
+        result_queue.put({"status": "error", "traceback": traceback.format_exc()})
+
+
+class ClientBusinessEmailLiveTestCase(unittest.TestCase):
+    def run_business_email_worker(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for business email live tests")
+        ctx = multiprocessing.get_context("spawn")
+        result_queue = ctx.Queue()
+        process = ctx.Process(target=_run_business_email_live, args=(result_queue,))
+        process.start()
+        timeout = int(os.getenv("INSTAGRAPI_BUSINESS_EMAIL_LIVE_TIMEOUT", "120"))
+        process.join(timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join(10)
+            self.skipTest(f"Business email live workflow timed out after {timeout} seconds")
+        try:
+            return result_queue.get(timeout=5)
+        except queue.Empty:
+            if process.exitcode:
+                self.fail(f"Business email live workflow exited with code {process.exitcode}")
+            self.fail("Business email live workflow did not return a result")
+
+    def test_user_info_by_username_v1_maps_public_business_email_live(self):
+        result = self.run_business_email_worker()
+        if result["status"] == "skip":
+            self.skipTest(result["reason"])
+        if result["status"] == "error":
+            self.fail(result["traceback"])
+        self.assertEqual(result["username"], "toyota")
+        self.assertTrue(result["is_business"])
+        self.assertEqual(result["public_email"], result["raw_email"])
 
 
 class ClientFollowersLiveTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1,3 +1,4 @@
+from instagrapi.extractors import extract_user_v1
 from tests.helpers import *
 
 
@@ -73,6 +74,28 @@ class UserMixinRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(user.username, "instagram")
         fallback.assert_called_once_with("25025320")
+
+    def test_extract_user_v1_maps_business_contact_fields(self):
+        payload = {
+            "pk": "123",
+            "username": "business",
+            "full_name": "Business",
+            "is_private": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+            "is_verified": False,
+            "media_count": 0,
+            "follower_count": 0,
+            "following_count": 0,
+            "is_business": True,
+            "business_email": "public@example.com",
+            "business_phone_number": "+15551234567",
+            "external_url": "",
+        }
+
+        user = extract_user_v1(payload)
+
+        self.assertEqual(user.public_email, "public@example.com")
+        self.assertEqual(user.contact_phone_number, "+15551234567")
 
     def test_user_short_gql_uses_web_profile_doc_id_without_legacy_query_hash(self):
         client = Client()


### PR DESCRIPTION
Fixes #1761.

## Summary
- normalize private API `business_email` into the existing `User.public_email` field when `public_email` is absent
- normalize private API `business_phone_number` into the existing `User.contact_phone_number` field when `contact_phone_number` is absent
- add regression coverage for private `extract_user_v1()` business contact fields
- add a guarded live test that fetches the `toyota` business profile through `user_info_by_username_v1()` and verifies the model email matches the raw private payload email

## Tests
- `.venv/bin/python -m pytest tests/regression/test_user.py -q` -> 71 passed
- `INSTAGRAPI_BUSINESS_EMAIL_LIVE_TIMEOUT=120 .venv/bin/python -m pytest tests/live/test_user.py::ClientBusinessEmailLiveTestCase::test_user_info_by_username_v1_maps_public_business_email_live -q -s` -> 1 passed
- `.venv/bin/ruff check instagrapi/extractors.py tests/regression/test_user.py tests/live/test_user.py && .venv/bin/ruff format --check instagrapi/extractors.py tests/regression/test_user.py tests/live/test_user.py` -> passed
