### PR TITLE
Send hashtag tab key in private sections requests

### DIFF
--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -130,6 +130,7 @@ class HashtagMixin:
             "recent": "top_recent_posts",
         }
         data = {
+            "tab": tab_key,
             "media_recency_filter": media_recency_filter.get(tab_key, tab_key),
             # "page": 1,
             "_uuid": self.uuid,

--- a/tests/live/test_hashtag.py
+++ b/tests/live/test_hashtag.py
@@ -68,6 +68,24 @@ class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(data["code"])
             self.assertTrue(data["media_type"])
 
+    def test_hashtag_medias_recent_v1_chunk_paginates_live(self):
+        medias, max_id = self.cl.hashtag_medias_v1_chunk("instagram", max_amount=12, tab_key="recent")
+        self.assertGreater(len(medias), 0)
+        self.assertIsInstance(medias[0], Media)
+        if not max_id:
+            self.skipTest("instagram hashtag did not return next_max_id")
+
+        next_medias, next_max_id = self.cl.hashtag_medias_v1_chunk(
+            "instagram",
+            max_amount=12,
+            tab_key="recent",
+            max_id=max_id,
+        )
+
+        self.assertGreater(len(next_medias), 0)
+        self.assertNotEqual(max_id, next_max_id)
+        self.assertTrue({media.pk for media in medias}.isdisjoint({media.pk for media in next_medias}))
+
     def test_hashtag_following(self):
         hashtags = self.cl.hashtag_following(amount=1)
         self.assertIsInstance(hashtags, list)

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -41,6 +41,22 @@ class HashtagRegressionTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Hashtag name cannot be empty"):
             client.hashtag_medias_recent("#")
 
+    def test_hashtag_medias_v1_chunk_sends_tab_key(self):
+        client = Client()
+        client.private_request = Mock(
+            return_value={
+                "sections": [],
+                "more_available": False,
+                "next_max_id": None,
+            }
+        )
+
+        client.hashtag_medias_v1_chunk("pizza", tab_key="recent")
+
+        request_data = client.private_request.call_args.kwargs["data"]
+        self.assertEqual(request_data["tab"], "recent")
+        self.assertEqual(request_data["media_recency_filter"], "top_recent_posts")
+
     def test_hashtag_following_fetches_current_account_hashtags(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123"}


### PR DESCRIPTION
## Summary
- send the selected hashtag `tab_key` as `tab` in private `tags/{name}/sections/` requests
- keep the existing `media_recency_filter` mapping for `top`/`recent`
- add offline regression coverage for the request payload
- add a live pagination test that reads two recent hashtag pages and checks cursor/media progression

Fixes #1575

## Tests
- `.venv/bin/python -m pytest tests/regression/test_hashtag.py::HashtagRegressionTestCase::test_hashtag_medias_v1_chunk_sends_tab_key -q`
- `.venv/bin/python -m pytest tests/regression/test_hashtag.py -q`
- `.venv/bin/python -m pytest tests/live/test_hashtag.py::ClientHashtagTestCase::test_hashtag_medias_recent_v1_chunk_paginates_live -q`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/hashtag.py tests/regression/test_hashtag.py tests/live/test_hashtag.py`
- `.venv/bin/python -m ruff check instagrapi/mixins/hashtag.py tests/regression/test_hashtag.py tests/live/test_hashtag.py`