### PR TITLE
Retry private incomplete read errors

### DIFF
--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -16,6 +16,7 @@ from instagrapi.exceptions import (
     ClientConnectionError,
     ClientError,
     ClientForbiddenError,
+    ClientIncompleteReadError,
     ClientJSONDecodeError,
     ClientNotFoundError,
     ClientRequestTimeout,
@@ -547,6 +548,8 @@ class PrivateRequestMixin:
                 self.logger.warning("Status 408: Request Timeout")
                 raise ClientRequestTimeout(e, response=e.response, **last_json)
             raise ClientError(e, response=e.response, **last_json)
+        except requests.exceptions.ChunkedEncodingError as e:
+            raise ClientIncompleteReadError("{} {}".format(e.__class__.__name__, str(e))) from e
         except requests.ConnectionError as e:
             raise ClientConnectionError("{e.__class__.__name__} {e}".format(e=e))
         if last_json.get("status") == "fail":
@@ -614,6 +617,10 @@ class PrivateRequestMixin:
         except ClientRequestTimeout:
             self.logger.info("Wait 60 seconds and try one more time (ClientRequestTimeout)")
             time.sleep(60)
+            return self._send_private_request(endpoint, **kwargs)
+        except ClientIncompleteReadError:
+            self.logger.info("Wait 2 seconds and try one more time (ClientIncompleteReadError)")
+            time.sleep(2)
             return self._send_private_request(endpoint, **kwargs)
         # except BadPassword as e:
         #     raise e

--- a/tests/regression/test_hardening.py
+++ b/tests/regression/test_hardening.py
@@ -161,6 +161,28 @@ class HardeningRegressionTestCase(unittest.TestCase):
         self.assertEqual(cm.exception.message, payload["message"])
         self.assertEqual(cm.exception.status, "fail")
 
+    def test_private_request_retries_chunked_encoding_error_once(self):
+        client = self._build_private_client()
+        client.request_timeout = 0
+        response = self._make_json_response({"status": "ok"})
+
+        with mock.patch.object(
+            client.private,
+            "post",
+            side_effect=[
+                requests.exceptions.ChunkedEncodingError(
+                    "Connection broken: IncompleteRead(207264 bytes read, 168584 more expected)"
+                ),
+                response,
+            ],
+        ) as private_post:
+            with mock.patch("instagrapi.mixins.private.time.sleep") as sleep:
+                result = client.private_request("test/", data={"_uuid": client.uuid}, with_signature=False)
+
+        self.assertEqual(result, {"status": "ok"})
+        self.assertEqual(private_post.call_count, 2)
+        self.assertEqual(sleep.call_args_list.count(mock.call(2)), 1)
+
     # --- hashtag chunk: skip malformed nodes ---
 
     def test_hashtag_medias_top_v1_chunk_skips_malformed_nodes(self):


### PR DESCRIPTION
## Summary
- normalize private API `ChunkedEncodingError` responses into `ClientIncompleteReadError`
- retry private incomplete reads once, matching the existing request-timeout retry behavior
- cover the POST path that failed during hashtag sections requests

## Tests
- `.venv/bin/python -m pytest tests/regression/test_hardening.py::HardeningRegressionTestCase::test_private_request_retries_chunked_encoding_error_once -q`
- `.venv/bin/python -m pytest tests/regression/test_hardening.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/private.py tests/regression/test_hardening.py`
- `.venv/bin/python -m ruff check instagrapi/mixins/private.py tests/regression/test_hardening.py`
- live smoke: `hashtag_medias_top("downhill", amount=2)` returned 2 Media objects