### PR TITLE
Add live coverage for comment preflight

### DIFF
--- a/docs/usage-guide/comment.md
+++ b/docs/usage-guide/comment.md
@@ -106,8 +106,12 @@ QVFEbHpIWmpFc3BNUkgzUFVuOGZOQlhDQ1hHeWlVWHlJSnBhb2FHbFB3YlJtNThnOUlrd01JUWdKRmRw
  'has_liked': False,
  'like_count': 0}
 
->>> cl.media_check_offensive_comment(media_id, "Some draft text")
+>>> preflight = cl.media_check_offensive_comment_v2(media_id, "Some draft text")
+>>> preflight["is_offensive"]
 False
+
+>>> if not preflight["is_offensive"]:
+...     cl.media_comment(media_id, "Some draft text")
 
 >>> cl.comment_like(17926777897585108)
 True
@@ -124,6 +128,7 @@ Notes:
 * `media_comments()` fetches both regular and headload comment pages until `amount` is reached.
 * `media_comments_chunk()` is the better choice when you want to store and resume the server cursor manually.
 * `media_comment_replies()` fetches `inline_child_comments` for a parent comment and paginates with the returned child cursor.
+* `media_check_offensive_comment_v2()` can be used as an explicit lightweight preflight before `media_comment()`. `media_comment()` does not run extra preflight requests automatically, so callers can choose the request volume and handle the raw response.
 * `comment_pin()` / `comment_unpin()` only work on media owned by the authenticated account.
 * Reply creation is supported through `replied_to_comment_id`; reply retrieval is supported through `media_comment_replies()`.
 * Comment creation is a write action and can still trigger Instagram spam or trust checks. Reuse saved sessions, keep volume low on new accounts, and stop when Instagram returns feedback/challenge responses.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,11 +4,14 @@ import os
 import os.path
 import random
 import shutil
+import signal
 import subprocess
 import tempfile
+import threading
 import time
 import types
 import unittest
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from json.decoder import JSONDecodeError
 from pathlib import Path
@@ -96,6 +99,34 @@ COMMENT_REPLIES_LIVE_FIXTURES = [
     ("3735285994514812478_640806256", "18052801016557024"),
     ("3735285994514812478_640806256", "17944918626046204"),
 ]
+
+
+class FreshAccountLoginTimeout(RuntimeError):
+    pass
+
+
+@contextmanager
+def fresh_account_login_timeout():
+    seconds = float(os.getenv("INSTAGRAPI_TEST_LOGIN_TIMEOUT", "30"))
+    if seconds <= 0 or not hasattr(signal, "SIGALRM") or threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    def raise_timeout(signum, frame):
+        raise FreshAccountLoginTimeout(f"Fresh account login timed out after {seconds:g}s")
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+    signal.signal(signal.SIGALRM, raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, *previous_timer)
+
 
 REQUIRED_MEDIA_FIELDS = [
     "pk",
@@ -191,7 +222,8 @@ def client_from_test_account(acc):
         cl.totp_seed = totp_seed
         cl.totp_code = totp_code
         login_kwargs["verification_code"] = totp_code
-    cl.login(**login_kwargs)
+    with fresh_account_login_timeout():
+        cl.login(**login_kwargs)
     cl._user_id = acc.get("user_id")
     return cl
 

--- a/tests/live/test_comments.py
+++ b/tests/live/test_comments.py
@@ -78,6 +78,15 @@ class ClientCommentExtendTestCase(_helpers.ClientPrivateTestCase):
                     return item
         self.fail(f"Comment {comment_pk} was not readable after {attempts} attempts: {last_error}")
 
+    def assertCommentPreflightAllows(self, media_id, text):
+        result = self.cl.media_check_offensive_comment_v2(media_id, text)
+        self.assertIsInstance(result, dict)
+        self.assertIn("is_offensive", result)
+        self.assertFalse(result["is_offensive"])
+        if "status" in result:
+            self.assertEqual(result["status"], "ok")
+        return result
+
     def test_media_comment(self):
         text = "Test text [%s]" % datetime.now().strftime("%s")
         now = datetime.now(tz=UTC())
@@ -87,6 +96,7 @@ class ClientCommentExtendTestCase(_helpers.ClientPrivateTestCase):
         self.addCleanup(self.cleanup_media, media.id)
         self.assertUploadedMediaAccessible(media, media_type=1, caption_text=caption_text)
         media_id = media.id
+        self.assertCommentPreflightAllows(media_id, text)
         comment = self.cl.media_comment(media_id, text)
         self.addCleanup(self.cleanup_comment, media_id, comment.pk)
         self.assertIsInstance(comment, Comment)

--- a/tests/regression/test_helpers.py
+++ b/tests/regression/test_helpers.py
@@ -3,6 +3,15 @@ from tests.helpers import *
 
 
 class LiveAccountHelperRegressionTestCase(unittest.TestCase):
+    def _account_payload(self, username="fresh.account"):
+        return {
+            "client_settings": {},
+            "username": username,
+            "password": "password",
+            "proxy": "",
+            "user_id": "123",
+        }
+
     def test_build_test_accounts_url_overrides_existing_default_count(self):
         case = object.__new__(helper_module.ClientPrivateTestCase)
         with mock.patch.object(
@@ -45,3 +54,28 @@ class LiveAccountHelperRegressionTestCase(unittest.TestCase):
 
         self.assertIs(result, clients)
         fresh_test_accounts.assert_called_once_with(1, exclude_user_ids=exclude_user_ids)
+
+    @unittest.skipUnless(hasattr(signal, "SIGALRM"), "SIGALRM is required for login timeout guard")
+    def test_client_from_test_account_times_out_hung_login(self):
+        client = Mock()
+        client.login.side_effect = lambda **kwargs: time.sleep(1)
+
+        with mock.patch.dict(helper_module.os.environ, {"INSTAGRAPI_TEST_LOGIN_TIMEOUT": "0.01", "IG_PROXY": ""}):
+            with mock.patch.object(helper_module, "Client", return_value=client):
+                with self.assertRaises(helper_module.FreshAccountLoginTimeout):
+                    helper_module.client_from_test_account(self._account_payload())
+
+    def test_fresh_test_account_tries_next_account_after_login_timeout(self):
+        accounts = [self._account_payload("first.account"), self._account_payload("second.account")]
+        client = object()
+
+        with mock.patch.object(helper_module, "fetch_test_accounts", return_value=accounts):
+            with mock.patch.object(
+                helper_module,
+                "client_from_test_account",
+                side_effect=[helper_module.FreshAccountLoginTimeout("timeout"), client],
+            ) as client_from_test_account:
+                result = helper_module.fresh_test_account(count=2, attempts=2)
+
+        self.assertIs(result, client)
+        self.assertEqual(client_from_test_account.call_count, 2)


### PR DESCRIPTION
## Summary
- Add live coverage for the explicit `media_check_offensive_comment_v2()` preflight before `media_comment()`.
- Document the v2 offensive-comment preflight as an optional explicit step before posting a comment.
- Add a bounded fresh-account login guard in live test helpers so a bad account/proxy cannot hang live test collection indefinitely.

## Investigation
- Existing repository HAR fixtures do not include a captured comment-action request sequence.
- This PR does not add automatic side-effect requests to `media_comment()` without captured app evidence.
- The live path now verifies upload -> offensive preflight -> comment creation -> comment readback.

## Tests
- `.venv/bin/pytest -q tests/regression/test_helpers.py tests/regression/test_comments.py tests/regression/test_media.py::CheckOffensiveCommentV2RegressionTestCase` -> 20 passed
- `.venv/bin/ruff check tests/helpers.py tests/regression/test_helpers.py tests/live/test_comments.py` -> passed
- `.venv/bin/pytest -q -s tests/live/test_comments.py::ClientCommentExtendTestCase::test_media_comment` -> 1 passed, 2 warnings

Refs #2606
