### PR TITLE
Align media comment payload with app fields

### DIFF
--- a/instagrapi/mixins/comment.py
+++ b/instagrapi/mixins/comment.py
@@ -442,6 +442,7 @@ class CommentMixin:
         """
         assert self.user_id, "Login required"
         media_id = self.media_id(media_id)
+        idempotence_token = self.generate_uuid()
         data = {
             "delivery_class": "organic",
             "feed_position": str(random.randint(0, 6)),
@@ -455,7 +456,10 @@ class CommentMixin:
             "floating_context_items": "[]",
             "media_pct_watched": "0",
             "user_breadcrumb": self.gen_user_breadcrumb(len(text)),
-            "idempotence_token": self.generate_uuid(),
+            "idempotence_token": idempotence_token,
+            "comment_creation_key": idempotence_token,
+            "include_e2ee_mentioned_user_list": "true",
+            "include_media_code": "true",
             "comment_text": text,
         }
         if replied_to_comment_id:

--- a/tests/regression/test_comments.py
+++ b/tests/regression/test_comments.py
@@ -52,6 +52,9 @@ class CommentRepliesRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["replied_to_comment_id"], 100)
         self.assertIn("user_breadcrumb", data)
         self.assertIn("idempotence_token", data)
+        self.assertEqual(data["comment_creation_key"], data["idempotence_token"])
+        self.assertEqual(data["include_e2ee_mentioned_user_list"], "true")
+        self.assertEqual(data["include_media_code"], "true")
 
     def test_media_comment_replies_fetches_inline_child_comments(self):
         client = Client()


### PR DESCRIPTION
Summary:
- Reuse the generated media comment idempotence token as `comment_creation_key`.
- Send `include_e2ee_mentioned_user_list` and `include_media_code` with `media_comment()`.
- Extend regression coverage for the app-like comment payload fields.

Scope:
- This is a focused payload alignment for the main `media/%s/comment/` request.
- It does not add automatic preflight or speculative side-effect requests.

Validation:
- `.venv/bin/pytest -q tests/regression/test_comments.py`
- `.venv/bin/ruff check instagrapi/mixins/comment.py tests/regression/test_comments.py`
- `PYTHONUNBUFFERED=1 gtimeout 300 .venv/bin/pytest -q -s tests/live/test_comments.py::ClientCommentExtendTestCase::test_media_comment` -> passed, 2 warnings

Refs #2606
