### PR TITLE
Add CAA email signup flow

### DIFF
--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -22,7 +22,13 @@ class BloksMixin:
             "bloks_versioning_id": versioning_id,
         }
 
-    def bloks_async_action(self, action: str, params: Dict, bloks_versioning_id: str = "") -> Dict:
+    def bloks_async_action(
+        self,
+        action: str,
+        params: Dict,
+        bloks_versioning_id: str = "",
+        domain: Optional[str] = None,
+    ) -> Dict:
         """
         Perform a raw Bloks async action.
 
@@ -34,6 +40,8 @@ class BloksMixin:
             Bloks ``params`` payload.
         bloks_versioning_id: str, optional
             Bloks versioning id. Uses ``Client.bloks_versioning_id`` when omitted.
+        domain: str, optional
+            API domain override. Uses the default private API domain when omitted.
 
         Returns
         -------
@@ -41,7 +49,14 @@ class BloksMixin:
             Raw Instagram response.
         """
         data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
-        return self.private_request(f"bloks/async_action/{action}/", data=data, with_signature=False)
+        kwargs = {
+            "data": data,
+            "with_signature": False,
+            "headers": {"X-FB-Friendly-Name": f"IgApi: bloks/async_action/{action}/"},
+        }
+        if domain:
+            kwargs["domain"] = domain
+        return self.private_request(f"bloks/async_action/{action}/", **kwargs)
 
     def bloks_app(self, app: str, params: Dict, bloks_versioning_id: str = "") -> Dict:
         """
@@ -63,6 +78,44 @@ class BloksMixin:
         """
         data = self._bloks_payload(params, bloks_versioning_id=bloks_versioning_id)
         return self.private_request(f"bloks/apps/{app}/", data=data, with_signature=False)
+
+    def bloks_graphql_app(
+        self,
+        app: str,
+        params: Dict,
+        client_doc_id: str,
+        bloks_versioning_id: str = "",
+        domain: str = "b.i.instagram.com",
+        infra_device_id: str = "",
+    ) -> Dict:
+        """
+        Perform a Bloks app request through the mobile ``graphql_www`` endpoint.
+
+        Current CAA registration screens use this wrapper instead of
+        ``bloks/apps`` for most steps. Instagram expects ``params`` to be
+        nested as a JSON string inside another JSON string.
+        """
+        versioning_id = bloks_versioning_id or self.bloks_versioning_id
+        assert versioning_id, "Client.bloks_versioning_id is empty (hash is expected)"
+        variables = {
+            "params": {
+                "params": dumps({"params": dumps(params)}),
+                "bloks_versioning_id": versioning_id,
+                "infra_params": {"device_id": infra_device_id or self.uuid},
+                "app_id": app,
+            },
+            "bk_context": {
+                "is_flipper_enabled": False,
+                "theme_params": [],
+                "debug_tooling_metadata_token": None,
+            },
+        }
+        return self.private_graphql_www_request(
+            f"IGBloksAppRootQuery-{app}",
+            variables,
+            client_doc_id=client_doc_id,
+            domain=domain,
+        )
 
     def bloks_challenge_take_challenge(
         self,

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -107,7 +107,7 @@ class BloksMixin:
             "bk_context": {
                 "is_flipper_enabled": False,
                 "theme_params": [],
-                "debug_tooling_metadata_token": None,
+                "debug_tooling_metadata_token": None,  # nosec B105
             },
         }
         return self.private_graphql_www_request(

--- a/instagrapi/mixins/graphql.py
+++ b/instagrapi/mixins/graphql.py
@@ -31,6 +31,7 @@ from instagrapi.utils.timing import random_delay
 
 GRAPHQL_API_URL = "https://www.instagram.com/api/graphql"
 PRIVATE_GRAPHQL_QUERY_URL = "https://i.instagram.com/graphql/query"
+PRIVATE_GRAPHQL_WWW_DOMAIN = "b.i.instagram.com"
 
 GQL_STUFF = {
     "av": "17841464591314721",
@@ -291,6 +292,69 @@ class PrivateGraphQLRequestMixin:
         try:
             self.private_requests_count += 1
             response = self.private.post(url, data=data, proxies=self.private.proxies)
+            self.request_log(response)
+            self.last_response = response
+            response.raise_for_status()
+            self.last_json = self._json_from_graphql_response(response)
+        except JSONDecodeError as exc:
+            url = response.url if response else url
+            raise ClientJSONDecodeError(
+                "JSONDecodeError {0!s} while opening {1!s}".format(exc, url),
+                response=response,
+            )
+        except requests.HTTPError as exc:
+            raise ClientError(exc, response=exc.response)
+        except requests.ConnectionError as exc:
+            raise ClientConnectionError("{} {}".format(exc.__class__.__name__, str(exc)))
+        if self.last_json.get("errors"):
+            raise ClientGraphqlError(self.last_json.get("errors"))
+        if self.last_json.get("status") == "fail":
+            raise ClientError(response=response, **self.last_json)
+        return self.last_json
+
+    def private_graphql_www_request(
+        self,
+        friendly_name: str,
+        variables: Optional[Dict] = None,
+        client_doc_id: Optional[str] = None,
+        domain: str = PRIVATE_GRAPHQL_WWW_DOMAIN,
+        extra_headers: Optional[Dict] = None,
+    ) -> Dict:
+        data = {
+            "method": "post",
+            "pretty": "false",
+            "format": "json",
+            "server_timestamps": "true",
+            "locale": "user",
+            "purpose": "fetch",
+            "fb_api_req_friendly_name": friendly_name,
+            "enable_canonical_naming": "true",
+            "enable_canonical_variable_overrides": "true",
+            "enable_canonical_naming_ambiguous_type_prefixing": "true",
+            "variables": json.dumps(variables or {}, separators=(",", ":")),
+        }
+        if client_doc_id:
+            data["client_doc_id"] = str(client_doc_id)
+        headers = {
+            "X-FB-Friendly-Name": friendly_name,
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        }
+        if client_doc_id:
+            headers["X-Client-Doc-Id"] = str(client_doc_id)
+        if extra_headers:
+            headers.update(extra_headers)
+        merged = dict(self.base_headers)
+        merged.update(headers)
+        merged["Host"] = domain
+        if self.authorization:
+            merged.setdefault("Authorization", self.authorization)
+        if self.request_timeout:
+            time.sleep(self.request_timeout)
+        url = f"https://{domain}/graphql_www"
+        response = None
+        try:
+            self.private_requests_count += 1
+            response = self.private.post(url, data=data, headers=merged, proxies=self.private.proxies)
             self.request_log(response)
             self.last_response = response
             response.raise_for_status()

--- a/instagrapi/mixins/graphql.py
+++ b/instagrapi/mixins/graphql.py
@@ -273,6 +273,50 @@ class PrivateGraphQLRequestMixin:
         finally:
             self.last_response_ts = time.time()
 
+    def _raise_graphql_http_error(self, exc, response):
+        """Map a failed private GraphQL HTTP response to a typed exception.
+
+        Shared by ``private_graphql_query_request`` and ``private_graphql_www_request``
+        so both surface ``LoginRequired`` / ``ChallengeRequired`` / ``FeedbackRequired``
+        / ``RateLimitError`` and status-coded errors instead of a generic ``ClientError``.
+        Always raises.
+        """
+        last_json = {}
+        try:
+            body_json = response.json()
+            if isinstance(body_json, dict):
+                self.last_json = body_json
+                last_json = body_json
+        except Exception:
+            last_json = {}
+        message = (last_json.get("message") or "").lower()
+        error_type = last_json.get("error_type")
+        if message == "login_required":
+            raise LoginRequired(exc, response=response, **last_json)
+        if message == "challenge_required":
+            raise ChallengeRequired(**last_json)
+        if message == "feedback_required":
+            raise FeedbackRequired(exc, response=response, **last_json)
+        if error_type == "rate_limit_error":
+            raise RateLimitError(exc, response=response, **last_json)
+        if message == "user_blocked":
+            raise SentryBlock(exc, response=response, **last_json)
+        if "not authorized to view user" in message:
+            raise PrivateAccount(exc, response=response, **last_json)
+        if "unable to fetch followers" in message or "error generating user info response" in message:
+            raise UserNotFound(exc, response=response, **last_json)
+        if getattr(response, "status_code", None) == 404 and getattr(response, "content", None) == b"Not Found":
+            raise ChallengeRequired(**last_json)
+        status_code = getattr(response, "status_code", None)
+        exc_cls = {
+            400: ClientBadRequestError,
+            401: ClientUnauthorizedError,
+            403: ClientForbiddenError,
+            404: ClientNotFoundError,
+            429: ClientThrottledError,
+        }.get(status_code, ClientError)
+        raise exc_cls(exc, response=response, **last_json)
+
     def private_graphql_request(self, data: Dict, headers: Optional[Dict] = None, domain: Optional[str] = None) -> Dict:
         self.last_response = None
         self.last_json = {}
@@ -366,7 +410,7 @@ class PrivateGraphQLRequestMixin:
                 response=response,
             )
         except requests.HTTPError as exc:
-            raise ClientError(exc, response=exc.response)
+            self._raise_graphql_http_error(exc, response)
         except requests.ConnectionError as exc:
             raise ClientConnectionError("{} {}".format(exc.__class__.__name__, str(exc)))
         if self.last_json.get("errors"):
@@ -424,50 +468,7 @@ class PrivateGraphQLRequestMixin:
         try:
             response.raise_for_status()
         except requests.HTTPError as e:
-            try:
-                body_json = response.json()
-                if isinstance(body_json, dict):
-                    self.last_json = body_json
-                    last_json = body_json
-                else:
-                    last_json = {}
-            except Exception:
-                last_json = {}
-            message = ""
-            error_type = None
-            if isinstance(last_json, dict):
-                message = (last_json.get("message") or "").lower()
-                error_type = last_json.get("error_type")
-            if message == "login_required":
-                raise LoginRequired(e, response=response, **last_json)
-            if message == "challenge_required":
-                raise ChallengeRequired(**last_json)
-            if message == "feedback_required":
-                raise FeedbackRequired(e, response=response, **last_json)
-            if error_type == "rate_limit_error":
-                raise RateLimitError(e, response=response, **last_json)
-            if message == "user_blocked":
-                raise SentryBlock(e, response=response, **last_json)
-            if "not authorized to view user" in message:
-                raise PrivateAccount(e, response=response, **last_json)
-            if "unable to fetch followers" in message or "error generating user info response" in message:
-                raise UserNotFound(e, response=response, **last_json)
-            if getattr(response, "status_code", None) == 404 and getattr(response, "content", None) == b"Not Found":
-                raise ChallengeRequired(**last_json)
-            status_code = getattr(response, "status_code", None)
-            if status_code == 400:
-                exc = ClientBadRequestError
-            elif status_code == 401:
-                exc = ClientUnauthorizedError
-            elif status_code == 403:
-                exc = ClientForbiddenError
-            elif status_code == 404:
-                exc = ClientNotFoundError
-            elif status_code == 429:
-                exc = ClientThrottledError
-            else:
-                exc = ClientError
-            raise exc(e, response=response, **last_json)
+            self._raise_graphql_http_error(e, response)
         try:
             body = response.json()
         except JSONDecodeError:

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -386,6 +386,8 @@ class PrivateRequestMixin:
         self.private.headers.update(self.base_headers)
         if headers:
             self.private.headers.update(headers)
+        if domain:
+            self.private.headers["Host"] = domain
         if not login:
             time.sleep(self.request_timeout)
         # if self.user_id and login:

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -384,10 +384,13 @@ class PrivateRequestMixin:
         self.last_response = None
         self.last_json = last_json = {}  # for Sentry context in traceback
         self.private.headers.update(self.base_headers)
-        if headers:
-            self.private.headers.update(headers)
+        # Per-request overrides (caller headers such as X-FB-Friendly-Name, and the
+        # Host override used for domain routing) must not be merged into the
+        # persistent session headers: doing so leaks e.g. a Bloks async-action
+        # friendly name onto every later unrelated request. Send them per-request.
+        request_headers = dict(headers) if headers else {}
         if domain:
-            self.private.headers["Host"] = domain
+            request_headers["Host"] = domain
         if not login:
             time.sleep(self.request_timeout)
         # if self.user_id and login:
@@ -410,10 +413,21 @@ class PrivateRequestMixin:
                     data = generate_signature(dumps(data))
                     if extra_sig:
                         data += "&".join(extra_sig)
-                response = self.private.post(api_url, data=data, params=params, proxies=self.private.proxies)
+                response = self.private.post(
+                    api_url,
+                    data=data,
+                    params=params,
+                    headers=request_headers or None,
+                    proxies=self.private.proxies,
+                )
             else:  # GET
                 self.private.headers.pop("Content-Type", None)
-                response = self.private.get(api_url, params=params, proxies=self.private.proxies)
+                response = self.private.get(
+                    api_url,
+                    params=params,
+                    headers=request_headers or None,
+                    proxies=self.private.proxies,
+                )
             self.logger.debug(
                 "private_request %s: %s (%s)",
                 response.status_code,

--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -169,9 +169,13 @@ class SignUpMixin:
                 response = value["registration_response"]
                 if isinstance(response, str):
                     try:
-                        return json.loads(response)
+                        parsed = json.loads(response)
                     except json.JSONDecodeError:
                         return None
+                    # Only a dict is usable downstream (state["registration_response"]
+                    # is read with .get("created_user")); a JSON array/scalar from an
+                    # error payload must not flow through as a truthy non-dict.
+                    return parsed if isinstance(parsed, dict) else None
                 if isinstance(response, dict):
                     return response
             if value.get("account_created") is not None and "created_user" in value:
@@ -307,6 +311,10 @@ class SignUpMixin:
         }
 
     def _caa_password(self, password: str) -> str:
+        # Version 0 (plaintext envelope) is intentional here: the current Android
+        # CAA registration flow sends ``encrypted_password`` as ``#PWD_INSTAGRAM:0:``,
+        # not the ``:4:`` sealed-box used by login/legacy signup. Verified against a
+        # current Android app capture. Do not "fix" this to ``password_encrypt``.
         return f"#PWD_INSTAGRAM:0:{int(time.time())}:{password}"
 
     def _caa_reg_info_value(self, state: Dict, key: str, default: Any = None) -> Any:
@@ -499,7 +507,8 @@ class SignUpMixin:
             code = self.challenge_code_handler(username, CHOICE_EMAIL)
             if code:
                 break
-            if wait_seconds:
+            # Skip the backoff after the final attempt: no further poll follows it.
+            if wait_seconds and attempt < attempts - 1:
                 time.sleep(wait_seconds * (attempt + 1))
         if not code:
             raise ClientError("email confirmation code is required for CAA signup")

--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -83,11 +83,11 @@ class SignUpMixin:
                 return json.loads(token)
             except json.JSONDecodeError:
                 return token[1:-1]
-        if token == "true":
+        if token == "true":  # nosec B105
             return True
-        if token == "false":
+        if token == "false":  # nosec B105
             return False
-        if token == "null":
+        if token == "null":  # nosec B105
             return None
         try:
             return int(token)
@@ -98,12 +98,12 @@ class SignUpMixin:
         root = []
         stack = [root]
         for token in CAA_REG_VM_TOKEN_RE.findall(value):
-            if token == "(":
+            if token == "(":  # nosec B105
                 child = []
                 stack[-1].append(child)
                 stack.append(child)
                 continue
-            if token == ")":
+            if token == ")":  # nosec B105
                 if len(stack) > 1:
                     stack.pop()
                 continue
@@ -242,7 +242,7 @@ class SignUpMixin:
             "contactpoint_type": "email" if email else None,
             "confirmation_code": None,
             "birthday": None,
-            "encrypted_password": None,
+            "encrypted_password": None,  # nosec B105
             "username": None,
             "username_prefill": None,
             "device_id": device_id,
@@ -277,8 +277,8 @@ class SignUpMixin:
             "device_id": state["device_id"],
             "family_device_id": state["family_device_id"],
             "machine_id": state.get("machine_id", ""),
-            "lois_settings": {"lois_token": ""},
-            "cloud_trust_token": None,
+            "lois_settings": {"lois_token": ""},  # nosec B105
+            "cloud_trust_token": None,  # nosec B105
             "zero_balance_state": "",
             "network_bssid": None,
             "qe_device_id": state["qe_device_id"],
@@ -603,7 +603,7 @@ class SignUpMixin:
                 "force_sessionless_nux_experience": 0,
                 "ig_partially_created_account_user_id": 0,
                 "ck_id": "",
-                "no_contact_perm_email_oauth_token": "",
+                "no_contact_perm_email_oauth_token": "",  # nosec B105
                 "encrypted_msisdn": "",
             },
             server_params={

--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -1,8 +1,10 @@
+import json
 import random
+import re
 import secrets
 import time
 import warnings
-from typing import Optional
+from typing import Any, Dict, Iterable, Optional
 from urllib.parse import urlsplit
 from uuid import uuid4
 
@@ -20,12 +22,24 @@ from instagrapi.exceptions import (
 from instagrapi.extractors import extract_user_short
 from instagrapi.mixins.challenge import ChallengeChoice
 from instagrapi.types import UserShort
+from instagrapi.utils.serialization import dumps
 
 CHOICE_EMAIL = 1
 LEGACY_SIGNUP_WARNING = (
     "signup() uses Instagram's legacy account-create flow and should be treated as experimental. "
     "Modern Instagram signup often requires additional official-app device trust checks that instagrapi does not currently generate."
 )
+CAA_REG_GRAPHQL_DOC_ID = "356548512614739681018024088968"
+CAA_REG_CONTACTPOINT_DOC_ID = "253360298312778871684788706414"
+CAA_REG_CONTACTPOINT_APPS = {
+    "com.bloks.www.bloks.caa.reg.contactpoint_phone",
+    "com.bloks.www.bloks.caa.reg.contactpoint_email",
+    "com.bloks.www.bloks.caa.reg.transition",
+}
+CAA_REG_FLOW_INFO = {"flow_name": "new_to_family_ig_default", "flow_type": "ntf"}
+CAA_REG_OFFLINE_EXPERIMENT_GROUP = "caa_iteration_v3_perf_ig_4"
+CAA_REG_LAYERED_HOMEPAGE_EXPERIMENT_GROUP = "Deploy: Not in Experiment"
+CAA_REG_VM_TOKEN_RE = re.compile(r'\(|\)|"(?:\\.|[^"\\])*"|[^\s()]+')
 
 
 class SignUpMixin:
@@ -52,6 +66,551 @@ class SignUpMixin:
 
     def _challenge_url(self, api_path: str, prefix: str = "", field_name: str = "api_path") -> str:
         return f"https://i.instagram.com{prefix}{self._safe_challenge_api_path(api_path, field_name)}"
+
+    def _caa_string_values(self, value: Any) -> Iterable[str]:
+        if isinstance(value, dict):
+            for item in value.values():
+                yield from self._caa_string_values(item)
+        elif isinstance(value, list):
+            for item in value:
+                yield from self._caa_string_values(item)
+        elif isinstance(value, str):
+            yield value
+
+    def _caa_parse_vm_atom(self, token: str) -> Any:
+        if token.startswith('"') and token.endswith('"'):
+            try:
+                return json.loads(token)
+            except json.JSONDecodeError:
+                return token[1:-1]
+        if token == "true":
+            return True
+        if token == "false":
+            return False
+        if token == "null":
+            return None
+        try:
+            return int(token)
+        except ValueError:
+            return token
+
+    def _caa_parse_vm(self, value: str) -> list:
+        root = []
+        stack = [root]
+        for token in CAA_REG_VM_TOKEN_RE.findall(value):
+            if token == "(":
+                child = []
+                stack[-1].append(child)
+                stack.append(child)
+                continue
+            if token == ")":
+                if len(stack) > 1:
+                    stack.pop()
+                continue
+            stack[-1].append(self._caa_parse_vm_atom(token))
+        return root
+
+    def _caa_iter_vm_lists(self, value: Any) -> Iterable[list]:
+        if isinstance(value, list):
+            yield value
+            for item in value:
+                yield from self._caa_iter_vm_lists(item)
+
+    def _caa_extract_dkc_maps(self, value: str) -> Iterable[Dict[str, Any]]:
+        if "(dkc" not in value:
+            return
+        try:
+            parsed = self._caa_parse_vm(value)
+        except Exception:
+            return
+        for item in self._caa_iter_vm_lists(parsed):
+            if (
+                len(item) >= 3
+                and item[0] == "f4i"
+                and isinstance(item[1], list)
+                and isinstance(item[2], list)
+                and item[1][:1] == ["dkc"]
+                and item[2][:1] == ["dkc"]
+            ):
+                keys = item[1][1:]
+                values = item[2][1:]
+                yield {
+                    key: values[index] for index, key in enumerate(keys) if isinstance(key, str) and index < len(values)
+                }
+
+    def _caa_json_objects_from_string(self, value: str) -> Iterable[Any]:
+        stripped = value.strip()
+        if stripped.startswith(("{", "[")):
+            try:
+                yield json.loads(stripped)
+            except json.JSONDecodeError:
+                pass
+        decoder = json.JSONDecoder()
+        index = 0
+        while True:
+            index = value.find('"{', index)
+            if index < 0:
+                break
+            try:
+                decoded, consumed = decoder.raw_decode(value[index:])
+            except json.JSONDecodeError:
+                index += 2
+                continue
+            if isinstance(decoded, str) and decoded.startswith(("{", "[")):
+                try:
+                    yield json.loads(decoded)
+                except json.JSONDecodeError:
+                    pass
+            index += max(consumed, 1)
+
+    def _caa_extract_registration_response(self, value: Any) -> Optional[Dict]:
+        if isinstance(value, dict):
+            if "registration_response" in value:
+                response = value["registration_response"]
+                if isinstance(response, str):
+                    try:
+                        return json.loads(response)
+                    except json.JSONDecodeError:
+                        return None
+                if isinstance(response, dict):
+                    return response
+            if value.get("account_created") is not None and "created_user" in value:
+                return value
+            for item in value.values():
+                response = self._caa_extract_registration_response(item)
+                if response:
+                    return response
+        elif isinstance(value, list):
+            for item in value:
+                response = self._caa_extract_registration_response(item)
+                if response:
+                    return response
+        return None
+
+    def _caa_extract_state(self, response: Dict) -> Dict:
+        state = {}
+        payloads = [response]
+        for payload in list(payloads):
+            for value in self._caa_string_values(payload):
+                if "bloks_bundle_action" in value or "bloks_payload" in value or "registration_response" in value:
+                    for decoded in self._caa_json_objects_from_string(value):
+                        if isinstance(decoded, (dict, list)):
+                            payloads.append(decoded)
+        for payload in payloads:
+            registration_response = self._caa_extract_registration_response(payload)
+            if registration_response:
+                state["registration_response"] = registration_response
+            for value in self._caa_string_values(payload):
+                if not any(key in value for key in ("reg_info", "reg_context", "email_token", "created_user")):
+                    continue
+                for dkc_map in self._caa_extract_dkc_maps(value) or []:
+                    for key in ("reg_info", "reg_context", "email_token", "created_user_id", "created_userid"):
+                        if key not in dkc_map or dkc_map[key] in (None, ""):
+                            continue
+                        if key in ("reg_info", "reg_context", "email_token") and not isinstance(dkc_map[key], str):
+                            continue
+                        state[key] = dkc_map[key]
+                for decoded in self._caa_json_objects_from_string(value):
+                    registration_response = self._caa_extract_registration_response(decoded)
+                    if registration_response:
+                        state["registration_response"] = registration_response
+        return state
+
+    def _caa_update_state(self, state: Dict, response: Dict) -> Dict:
+        for key, value in self._caa_extract_state(response).items():
+            if value not in (None, ""):
+                state[key] = value
+        return state
+
+    def _caa_initial_state(self, email: str = "") -> Dict:
+        device_id = getattr(self, "android_device_id", "") or f"android-{secrets.token_hex(8)}"
+        family_device_id = getattr(self, "phone_id", "") or str(uuid4())
+        qe_device_id = getattr(self, "uuid", "") or str(uuid4())
+        waterfall_id = getattr(self, "waterfall_id", "") or str(uuid4())
+        machine_id = getattr(self, "mid", None) or ""
+        registration_flow_id = str(uuid4())
+        reg_info = {
+            "first_name": None,
+            "last_name": None,
+            "full_name": None,
+            "contactpoint": email or None,
+            "ar_contactpoint": None,
+            "contactpoint_type": "email" if email else None,
+            "confirmation_code": None,
+            "birthday": None,
+            "encrypted_password": None,
+            "username": None,
+            "username_prefill": None,
+            "device_id": device_id,
+            "ig4a_qe_device_id": qe_device_id,
+            "family_device_id": family_device_id,
+            "machine_id": machine_id or None,
+            "registration_flow_id": registration_flow_id,
+            "caa_reg_flow_source": "login_home_native_integration_point",
+            "is_caa_perf_enabled": True,
+            "is_preform": True,
+            "screen_visited": [],
+        }
+        return {
+            "device_id": device_id,
+            "family_device_id": family_device_id,
+            "qe_device_id": qe_device_id,
+            "waterfall_id": waterfall_id,
+            "machine_id": machine_id,
+            "flow_info": dumps(CAA_REG_FLOW_INFO),
+            "reg_info": dumps(reg_info),
+        }
+
+    def _caa_common_client_input(self, state: Dict) -> Dict:
+        return {
+            "aac": dumps(
+                {
+                    "aac_init_timestamp": int(time.time()),
+                    "aacjid": str(uuid4()),
+                    "aaccs": "",
+                }
+            ),
+            "device_id": state["device_id"],
+            "family_device_id": state["family_device_id"],
+            "machine_id": state.get("machine_id", ""),
+            "lois_settings": {"lois_token": ""},
+            "cloud_trust_token": None,
+            "zero_balance_state": "",
+            "network_bssid": None,
+            "qe_device_id": state["qe_device_id"],
+        }
+
+    def _caa_network_info(self) -> Dict:
+        return {
+            "active_subscriptions_info": None,
+            "default_subscription_info": {
+                "network_type": 13,
+                "is_data_roaming": 1,
+                "is_esim": None,
+                "is_gsm_roaming": 0,
+                "is_sim_sms_capable": None,
+                "is_mobile_data_enabled": 1,
+                "sim_carrier_id": 1,
+                "sim_carrier_id_name": "T-Mobile - US",
+                "sim_state": 5,
+                "sim_operator": "310270",
+                "sim_operator_name": "T-Mobile",
+                "signal_strength": 4,
+                "group_id_level_1": None,
+                "network_operator": "310260",
+            },
+            "is_airplane_mode": 0,
+            "is_active_network_cellular": 0,
+            "is_device_sms_capable": 1,
+            "sim_count": 1,
+            "is_wifi": 1,
+        }
+
+    def _caa_password(self, password: str) -> str:
+        return f"#PWD_INSTAGRAM:0:{int(time.time())}:{password}"
+
+    def _caa_reg_info_value(self, state: Dict, key: str, default: Any = None) -> Any:
+        try:
+            reg_info = json.loads(state.get("reg_info") or "{}")
+        except json.JSONDecodeError:
+            return default
+        return reg_info.get(key, default)
+
+    def _caa_common_server_params(self, state: Dict, current_step: int = 0) -> Dict:
+        server_params = {
+            "event_request_id": str(uuid4()),
+            "is_from_logged_out": 0,
+            "layered_homepage_experiment_group": CAA_REG_LAYERED_HOMEPAGE_EXPERIMENT_GROUP,
+            "device_id": state["device_id"],
+            "login_surface": "login_home",
+            "waterfall_id": state["waterfall_id"],
+            "INTERNAL__latency_qpl_instance_id": random.randint(100000000000000, 999999999999999),
+            "flow_info": state["flow_info"],
+            "is_platform_login": 0,
+            "login_entry_point": "logged_out",
+            "INTERNAL__latency_qpl_marker_id": 36707139,
+            "reg_info": state["reg_info"],
+            "family_device_id": state["family_device_id"],
+            "offline_experiment_group": CAA_REG_OFFLINE_EXPERIMENT_GROUP,
+            "access_flow_version": "pre_mt_behavior",
+            "is_from_logged_in_switcher": 0,
+            "current_step": current_step,
+            "qe_device_id": state["qe_device_id"],
+        }
+        if state.get("reg_context"):
+            server_params["reg_context"] = state["reg_context"]
+        return server_params
+
+    def _caa_params(
+        self,
+        state: Dict,
+        current_step: int = 0,
+        client_input_params: Optional[Dict] = None,
+        server_params: Optional[Dict] = None,
+    ) -> Dict:
+        client_inputs = self._caa_common_client_input(state)
+        client_inputs.update(client_input_params or {})
+        servers = self._caa_common_server_params(state, current_step=current_step)
+        servers.update(server_params or {})
+        servers = {key: value for key, value in servers.items() if value is not None}
+        return {
+            "client_input_params": client_inputs,
+            "server_params": servers,
+        }
+
+    def caa_reg_graphql(
+        self,
+        app: str,
+        state: Optional[Dict] = None,
+        current_step: int = 0,
+        client_input_params: Optional[Dict] = None,
+        server_params: Optional[Dict] = None,
+        client_doc_id: Optional[str] = None,
+    ) -> Dict:
+        state = state or self._caa_initial_state()
+        params = self._caa_params(
+            state,
+            current_step=current_step,
+            client_input_params=client_input_params,
+            server_params=server_params,
+        )
+        doc_id = client_doc_id or (
+            CAA_REG_CONTACTPOINT_DOC_ID if app in CAA_REG_CONTACTPOINT_APPS else CAA_REG_GRAPHQL_DOC_ID
+        )
+        return self.bloks_graphql_app(
+            app,
+            params,
+            client_doc_id=doc_id,
+            infra_device_id=state["qe_device_id"],
+        )
+
+    def caa_reg_async_action(
+        self,
+        action: str,
+        state: Optional[Dict] = None,
+        current_step: int = 0,
+        client_input_params: Optional[Dict] = None,
+        server_params: Optional[Dict] = None,
+    ) -> Dict:
+        state = state or self._caa_initial_state()
+        params = self._caa_params(
+            state,
+            current_step=current_step,
+            client_input_params=client_input_params,
+            server_params=server_params,
+        )
+        return self.bloks_async_action(action, params, domain="b.i.instagram.com")
+
+    def signup_caa_email(
+        self,
+        username: str,
+        password: str,
+        email: str,
+        full_name: str = "",
+        year: int = None,
+        month: int = None,
+        day: int = None,
+        attempts: int = 10,
+        wait_seconds: Optional[int] = None,
+    ) -> UserShort:
+        if not email:
+            raise ClientError("email is required for CAA signup")
+        year = year or random.randint(1980, 1995)
+        month = month or random.randint(1, 12)
+        day = day or random.randint(1, 28)
+        wait_seconds = self.wait_seconds if wait_seconds is None else wait_seconds
+        state = self._caa_initial_state(email=email)
+
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.aymh_create_account_button.async",
+            state=state,
+            current_step=0,
+            client_input_params={"accounts_list": [], "device_emails": [], "device_phone_numbers": []},
+            server_params={"reg_flow_source": "login_home_native_integration_point", "entrypoint": "login_home"},
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_async_action(
+            "com.bloks.www.bloks.caa.reg.async.expose_ntm_experiment.async",
+            state=state,
+            current_step=0,
+            client_input_params={"si_device_param_network_info": ""},
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.async.contactpoint_prefill.async",
+            state=state,
+            current_step=0,
+            client_input_params={"accounts_list": [], "si_device_param_network_info": ""},
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.contactpoint_phone",
+            state=state,
+            current_step=0,
+            server_params={"INTERNAL_INFRA_screen_id": str(uuid4())},
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.contactpoint_email",
+            state=state,
+            current_step=0,
+            server_params={
+                "root_screen_id": "CAA_REG_CONTACT_POINT_PHONE",
+                "INTERNAL_INFRA_screen_id": str(uuid4()),
+                "reg_context": None,
+            },
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_async_action(
+            "com.bloks.www.bloks.caa.reg.async.contactpoint_email_new.async",
+            state=state,
+            current_step=0,
+            client_input_params={
+                "accounts_list": [],
+                "email": email,
+                "email_prefilled": 0,
+                "confirmed_cp_and_code": {},
+                "is_from_device_emails": 0,
+                "prefetch_version": 11,
+                "si_device_param_network_info": self._caa_network_info(),
+                "block_store_machine_id": "",
+                "fb_ig_device_id": [],
+            },
+            server_params={
+                "cp_funnel": 0,
+                "cp_source": 0,
+                "prefetch_on_field": 1,
+                "text_input_id": random.randint(100000000000000, 999999999999999),
+                "reg_context": None,
+            },
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_async_action(
+            "com.bloks.www.bloks.caa.reg.send_confirmation_email.async",
+            state=state,
+            current_step=0,
+            client_input_params={"email_token": state.get("email_token", "")},
+            server_params={"is_from_unified_cp_screen": False, "is_direct_from_conf": False, "accounts_list": []},
+        )
+        self._caa_update_state(state, response)
+
+        code = ""
+        for attempt in range(attempts):
+            code = self.challenge_code_handler(username, CHOICE_EMAIL)
+            if code:
+                break
+            if wait_seconds:
+                time.sleep(wait_seconds * (attempt + 1))
+        if not code:
+            raise ClientError("email confirmation code is required for CAA signup")
+
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.confirmation.async",
+            state=state,
+            current_step=3,
+            client_input_params={"code": code, "confirmed_cp_and_code": {"contactpoint": email, "code": code}},
+            server_params={"text_input_id": str(uuid4()), "wa_timer_id": str(uuid4())},
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.password.async",
+            state=state,
+            current_step=4,
+            client_input_params={
+                "encrypted_password": self._caa_password(password),
+                "spi_action": 1,
+                "whatsapp_installed_on_client": False,
+                "safetynet_token": self._caa_reg_info_value(state, "safetynet_token", ""),
+                "safetynet_response": self._caa_reg_info_value(
+                    state,
+                    "safetynet_response",
+                    "GOOGLE_PLAY_UNAVAILABLE: SERVICE_INVALID",
+                ),
+                "system_permissions_status": {
+                    "READ_CONTACTS": "DENIED",
+                    "GET_ACCOUNTS": "DENIED",
+                    "READ_PHONE_STATE": "DENIED",
+                    "READ_PHONE_NUMBERS": "DENIED",
+                },
+            },
+            server_params={"flow_modifier": state["flow_info"], "si_device_param_network_info": ""},
+        )
+        self._caa_update_state(state, response)
+        birthday = f"{day:02d}-{month:02d}-{year:04d}"
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.birthday.async",
+            state=state,
+            current_step=6,
+            client_input_params={
+                "accounts_list": [],
+                "client_timezone": getattr(self, "timezone_offset", 0),
+                "birthday_or_current_date_string": birthday,
+                "birthday_timestamp": int(time.time()),
+                "os_age_range": "o18",
+                "should_skip_youth_tos": False,
+                "is_youth_regulation_flow_complete": False,
+            },
+            server_params={"si_device_param_network_info": ""},
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_async_action(
+            "com.bloks.www.bloks.caa.reg.name_vtwo.async",
+            state=state,
+            current_step=7,
+            client_input_params={"accounts_list": [], "name": full_name or username},
+            server_params={"si_device_param_network_info": ""},
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.username.async",
+            state=state,
+            current_step=8,
+            client_input_params={"validation_text": username},
+            server_params={
+                "action": 1,
+                "post_tos": 0,
+                "text_input_id": random.randint(100000000000000, 999999999999999),
+                "suggestions_container_id": random.randint(100000000000000, 999999999999999),
+                "screen_id": random.randint(100000000000000, 999999999999999),
+                "input_id": random.randint(100000000000000, 999999999999999),
+            },
+        )
+        self._caa_update_state(state, response)
+        response = self.caa_reg_graphql(
+            "com.bloks.www.bloks.caa.reg.create.account.async",
+            state=state,
+            current_step=9,
+            client_input_params={
+                "passkey_eligible_device": 0,
+                "ck_error": "",
+                "failed_birthday_year_count": "",
+                "headers_last_infra_flow_id": "",
+                "ig_partially_created_account_nonce_expiry": 0,
+                "should_ignore_existing_login": 0,
+                "reached_from_tos_screen": 1,
+                "ig_partially_created_account_nonce": "",
+                "has_dismissed_suma_pre_conf": 0,
+                "ck_nonce": "",
+                "force_sessionless_nux_experience": 0,
+                "ig_partially_created_account_user_id": 0,
+                "ck_id": "",
+                "no_contact_perm_email_oauth_token": "",
+                "encrypted_msisdn": "",
+            },
+            server_params={
+                "sa_prefetch_callback_id": "",
+                "should_ignore_suma_check": 0,
+                "bloks_controller_source": "bk_caa_reg_tos_screen",
+                "app_id": 0,
+            },
+        )
+        self._caa_update_state(state, response)
+        registration_response = state.get("registration_response")
+        if not registration_response or not registration_response.get("created_user"):
+            raise ClientError("CAA signup did not return created_user")
+        if registration_response.get("account_created") is False:
+            raise ClientError(f"CAA signup did not create an account: {registration_response}")
+        return extract_user_short(registration_response["created_user"])
 
     def signup(
         self,

--- a/tests/live/test_signup.py
+++ b/tests/live/test_signup.py
@@ -72,6 +72,34 @@ class SignUpTestCase(unittest.TestCase):
             self.assertEqual(getattr(user, key), val)
         self.assertTrue(user.profile_pic_url.startswith("https://"))
 
+    def test_email_signup_caa_live(self):
+        cl = Client()
+        username = gen_password()
+        email = self.signup_email(username)
+        password = gen_password(12)
+        full_name = f"John {username}"
+        cl.challenge_code_handler = lambda username, choice: self.signup_code_handler(
+            "IG_SIGNUP_EMAIL_CODE",
+            "IG_SIGNUP_EMAIL_CODE_COMMAND",
+            {
+                "IG_SIGNUP_USERNAME": username,
+                "IG_SIGNUP_EMAIL": email,
+            },
+        )
+        user = cl.signup_caa_email(
+            username,
+            password,
+            email,
+            full_name,
+            year=random.randint(1980, 1990),
+            month=random.randint(1, 12),
+            day=random.randint(1, 28),
+        )
+        self.assertIsInstance(user, UserShort)
+        for key, val in {"username": username, "full_name": full_name}.items():
+            self.assertEqual(getattr(user, key), val)
+        self.assertTrue(user.profile_pic_url.startswith("https://"))
+
     def test_phone_signup_live(self):
         phone_number = self.signup_phone_number()
         if not phone_number:

--- a/tests/live/test_signup.py
+++ b/tests/live/test_signup.py
@@ -15,7 +15,7 @@ class SignUpTestCase(unittest.TestCase):
         )
         return result.stdout.strip()
 
-    def signup_email(self, username):
+    def _get_signup_email_address(self, username):
         email = os.environ.get("IG_SIGNUP_EMAIL")
         if email:
             return email
@@ -45,7 +45,7 @@ class SignUpTestCase(unittest.TestCase):
     def test_email_signup_live(self):
         cl = Client()
         username = gen_password()
-        email = self.signup_email(username)
+        email = self._get_signup_email_address(username)
         password = gen_password(12)
         phone_number = self.signup_phone_number()
         full_name = f"John {username}"
@@ -75,7 +75,7 @@ class SignUpTestCase(unittest.TestCase):
     def test_email_signup_caa_live(self):
         cl = Client()
         username = gen_password()
-        email = self.signup_email(username)
+        email = self._get_signup_email_address(username)
         password = gen_password(12)
         full_name = f"John {username}"
         cl.challenge_code_handler = lambda username, choice: self.signup_code_handler(

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -53,6 +53,27 @@ class BloksRegressionTestCase(unittest.TestCase):
             domain="b.i.instagram.com",
         )
 
+    def test_bloks_async_action_does_not_leak_friendly_name_onto_session(self):
+        client = self.build_client()
+        client.request_timeout = 0
+        response = mock.Mock(status_code=200)
+        response.headers = {}
+        response.json.return_value = {"status": "ok"}
+        response.raise_for_status.return_value = None
+        client.private.post = mock.Mock(return_value=response)
+
+        client.bloks_async_action("com.example.action", {"server_params": {"flow": "example_flow"}})
+
+        # The friendly name is sent per-request...
+        sent_headers = client.private.post.call_args.kwargs["headers"]
+        self.assertEqual(
+            sent_headers["X-FB-Friendly-Name"],
+            "IgApi: bloks/async_action/com.example.action/",
+        )
+        # ...but must not stick to the persistent session headers, where it would
+        # leak onto every later unrelated private request.
+        self.assertNotIn("X-FB-Friendly-Name", client.private.headers)
+
     def test_bloks_app_posts_unsigned_bloks_payload(self):
         client = self.build_client()
         params = {"server_params": {"flow": "example_flow"}}

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -28,6 +28,29 @@ class BloksRegressionTestCase(unittest.TestCase):
                 "bloks_versioning_id": "bloks-version",
             },
             with_signature=False,
+            headers={"X-FB-Friendly-Name": "IgApi: bloks/async_action/com.example.action/"},
+        )
+
+    def test_bloks_async_action_accepts_domain_override(self):
+        client = self.build_client()
+        params = {"server_params": {"flow": "example_flow"}}
+        expected = {"status": "ok"}
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.bloks_async_action("com.example.action", params, domain="b.i.instagram.com")
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "bloks/async_action/com.example.action/",
+            data={
+                "params": dumps(params),
+                "_uuid": "uuid-1",
+                "bk_client_context": dumps({"bloks_version": "bloks-version", "styles_id": "instagram"}),
+                "bloks_versioning_id": "bloks-version",
+            },
+            with_signature=False,
+            headers={"X-FB-Friendly-Name": "IgApi: bloks/async_action/com.example.action/"},
+            domain="b.i.instagram.com",
         )
 
     def test_bloks_app_posts_unsigned_bloks_payload(self):
@@ -49,6 +72,45 @@ class BloksRegressionTestCase(unittest.TestCase):
             },
             with_signature=False,
         )
+
+    def test_bloks_graphql_app_posts_wrapped_bloks_payload(self):
+        client = self.build_client()
+        params = {
+            "client_input_params": {"device_id": "android-id"},
+            "server_params": {"flow": "example_flow"},
+        }
+        expected = {"data": {"ok": True}}
+
+        with mock.patch.object(client, "private_graphql_www_request", return_value=expected) as graphql_request:
+            result = client.bloks_graphql_app(
+                "com.example.app",
+                params,
+                client_doc_id="doc-id",
+                infra_device_id="qe-device-id",
+            )
+
+        self.assertEqual(result, expected)
+        graphql_request.assert_called_once()
+        friendly_name, variables = graphql_request.call_args.args[:2]
+        self.assertEqual(friendly_name, "IGBloksAppRootQuery-com.example.app")
+        self.assertEqual(
+            graphql_request.call_args.kwargs,
+            {"client_doc_id": "doc-id", "domain": "b.i.instagram.com"},
+        )
+        self.assertEqual(
+            variables["bk_context"],
+            {
+                "is_flipper_enabled": False,
+                "theme_params": [],
+                "debug_tooling_metadata_token": None,
+            },
+        )
+        wrapped_params = variables["params"]
+        self.assertEqual(wrapped_params["app_id"], "com.example.app")
+        self.assertEqual(wrapped_params["bloks_versioning_id"], "bloks-version")
+        self.assertEqual(wrapped_params["infra_params"], {"device_id": "qe-device-id"})
+        outer_params = json.loads(wrapped_params["params"])
+        self.assertEqual(json.loads(outer_params["params"]), params)
 
     def test_bloks_challenge_take_challenge_posts_unsigned_direct_payload(self):
         client = self.build_client()

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -262,3 +262,33 @@ class PrivateGraphQLRequestRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(result["data"]["timeline"]["items"][0]["media"]["id"], "1")
         self.assertEqual(result["data"]["timeline"]["items"][0]["media"]["code"], "abc")
+
+    def test_private_graphql_www_request_posts_to_app_graphql_www_endpoint(self):
+        client = Client()
+        client.request_timeout = 0
+        variables = {"params": {"app_id": "com.example.app"}}
+        response = Mock()
+        response.url = "https://b.i.instagram.com/graphql_www"
+        response.json.return_value = {"data": {"ok": True}}
+        response.raise_for_status.return_value = None
+
+        with mock.patch.object(client, "request_log") as request_log:
+            with mock.patch.object(client.private, "post", return_value=response) as post:
+                result = client.private_graphql_www_request(
+                    "IGBloksAppRootQuery-com.example.app",
+                    variables,
+                    client_doc_id="doc-id",
+                )
+
+        self.assertEqual(result, {"data": {"ok": True}})
+        data = post.call_args.kwargs["data"]
+        self.assertEqual(post.call_args.args, ("https://b.i.instagram.com/graphql_www",))
+        self.assertEqual(data["purpose"], "fetch")
+        self.assertEqual(data["fb_api_req_friendly_name"], "IGBloksAppRootQuery-com.example.app")
+        self.assertEqual(data["client_doc_id"], "doc-id")
+        self.assertEqual(json.loads(data["variables"]), variables)
+        self.assertEqual(post.call_args.kwargs["headers"]["X-FB-Friendly-Name"], "IGBloksAppRootQuery-com.example.app")
+        self.assertEqual(post.call_args.kwargs["headers"]["X-Client-Doc-Id"], "doc-id")
+        self.assertEqual(post.call_args.kwargs["headers"]["Host"], "b.i.instagram.com")
+        self.assertEqual(post.call_args.kwargs["proxies"], client.private.proxies)
+        request_log.assert_called_once_with(response)

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -579,13 +579,13 @@ class SignupHelperRegressionTestCase(unittest.TestCase):
 
 
 class SignupLiveHelperRegressionTestCase(unittest.TestCase):
-    def test_signup_email_command_receives_username_context(self):
+    def test_get_signup_email_address_command_receives_username_context(self):
         case = SignUpTestCase("test_email_signup_live")
         completed = subprocess.CompletedProcess(args="email-command", returncode=0, stdout="fresh@example.test\n")
 
         with mock.patch.dict(os.environ, {"IG_SIGNUP_EMAIL_COMMAND": "email-command"}, clear=True):
             with mock.patch("tests.live.test_signup.subprocess.run", return_value=completed) as run:
-                email = case.signup_email("freshuser")
+                email = case._get_signup_email_address("freshuser")
 
         self.assertEqual(email, "fresh@example.test")
         self.assertEqual(run.call_args.kwargs["env"]["IG_SIGNUP_USERNAME"], "freshuser")
@@ -609,12 +609,12 @@ class SignupLiveHelperRegressionTestCase(unittest.TestCase):
         self.assertEqual(run.call_args.kwargs["env"]["IG_SIGNUP_USERNAME"], "freshuser")
         self.assertEqual(run.call_args.kwargs["env"]["IG_SIGNUP_EMAIL"], "fresh@example.test")
 
-    def test_signup_email_skips_without_static_email_or_command(self):
+    def test_get_signup_email_address_skips_without_static_email_or_command(self):
         case = SignUpTestCase("test_email_signup_live")
 
         with mock.patch.dict(os.environ, {}, clear=True):
             with self.assertRaises(unittest.SkipTest):
-                case.signup_email("freshuser")
+                case._get_signup_email_address("freshuser")
 
     def test_signup_phone_number_prefers_signup_specific_env(self):
         case = SignUpTestCase("test_phone_signup_live")

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -1,5 +1,6 @@
 from instagrapi.exceptions import FeedbackRequired, SignupSpamError
 from instagrapi.mixins.challenge import ChallengeChoice
+from instagrapi.mixins.signup import CHOICE_EMAIL
 from tests.helpers import *
 from tests.live.test_signup import SignUpTestCase
 
@@ -16,6 +17,166 @@ class PasswordEncryptionRegressionTestCase(unittest.TestCase):
 
 
 class SignupHelperRegressionTestCase(unittest.TestCase):
+    def caa_response(
+        self,
+        reg_info='{"contactpoint":"addr@example.com"}',
+        reg_context="ctx-1",
+        email_token="email-token-1",
+        registration_response=None,
+    ):
+        escaped_reg_info = reg_info.replace('"', '\\"')
+        chunks = [
+            (
+                '(f4i (dkc "reg_info" "reg_context" "email_token") '
+                f'(dkc "{escaped_reg_info}" "{reg_context}" "{email_token}"))'
+            )
+        ]
+        if registration_response:
+            response_json = json.dumps(
+                {"registration_response": json.dumps(registration_response, separators=(",", ":"))}
+            )
+            chunks.append(f"(dsh (fom 1 1 {json.dumps(response_json)}))")
+        return {
+            "layout": {
+                "bloks_payload": {
+                    "ft": {"state": " ".join(chunks)},
+                }
+            },
+            "status": "ok",
+        }
+
+    def test_caa_extract_state_reads_bloks_dkc_maps_and_registration_response(self):
+        client = Client()
+        registration_response = {
+            "account_created": True,
+            "created_user": {
+                "pk": "123",
+                "username": "example",
+                "full_name": "Example User",
+                "profile_pic_url": "https://example.com/avatar.jpg",
+            },
+        }
+
+        state = client._caa_extract_state(self.caa_response(registration_response=registration_response))
+
+        self.assertEqual(state["reg_context"], "ctx-1")
+        self.assertEqual(state["email_token"], "email-token-1")
+        self.assertEqual(state["reg_info"], '{"contactpoint":"addr@example.com"}')
+        self.assertEqual(state["registration_response"], registration_response)
+
+    def test_caa_extract_state_reads_graphql_bloks_bundle_action(self):
+        client = Client()
+        response = {
+            "data": {
+                "1$bloks_action(bk_context:$bk_context,params:$params)": {
+                    "action": {
+                        "action_bundle": {
+                            "bloks_bundle_action": json.dumps(
+                                self.caa_response(reg_context="ctx-from-graphql", email_token="token-from-graphql"),
+                                separators=(",", ":"),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        state = client._caa_extract_state(response)
+
+        self.assertEqual(state["reg_context"], "ctx-from-graphql")
+        self.assertEqual(state["email_token"], "token-from-graphql")
+
+    def test_signup_caa_email_runs_modern_email_flow(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.phone_id = "family-device-id"
+        client.android_device_id = "android-id"
+        client.mid = "machine-id"
+        client.bloks_versioning_id = "bloks-version"
+        client.waterfall_id = "waterfall-id"
+        client.wait_seconds = 0
+        client.password_encrypt = mock.Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+        client.challenge_code_handler = mock.Mock(return_value="123456")
+        registration_response = {
+            "account_created": True,
+            "created_user": {
+                "pk": "123",
+                "username": "example",
+                "full_name": "Example User",
+                "profile_pic_url": "https://example.com/avatar.jpg",
+            },
+        }
+        graphql_responses = [
+            self.caa_response(reg_context=f"ctx-gql-{index}", email_token=f"email-token-{index}") for index in range(8)
+        ]
+        graphql_responses.append(self.caa_response(registration_response=registration_response))
+        async_responses = [
+            self.caa_response(reg_context=f"ctx-async-{index}", email_token=f"email-token-async-{index}")
+            for index in range(4)
+        ]
+
+        with mock.patch.object(client, "caa_reg_graphql", side_effect=graphql_responses) as caa_reg_graphql:
+            with mock.patch.object(client, "caa_reg_async_action", side_effect=async_responses) as caa_reg_async_action:
+                user = client.signup_caa_email(
+                    username="example",
+                    password="password",
+                    email="addr@example.com",
+                    full_name="Example User",
+                    year=1995,
+                    month=6,
+                    day=9,
+                )
+
+        self.assertIsInstance(user, UserShort)
+        self.assertEqual(user.pk, "123")
+        self.assertEqual(user.username, "example")
+        self.assertEqual(user.full_name, "Example User")
+        self.assertEqual(
+            [call.args[0] for call in caa_reg_graphql.call_args_list],
+            [
+                "com.bloks.www.bloks.caa.reg.aymh_create_account_button.async",
+                "com.bloks.www.bloks.caa.reg.async.contactpoint_prefill.async",
+                "com.bloks.www.bloks.caa.reg.contactpoint_phone",
+                "com.bloks.www.bloks.caa.reg.contactpoint_email",
+                "com.bloks.www.bloks.caa.reg.confirmation.async",
+                "com.bloks.www.bloks.caa.reg.password.async",
+                "com.bloks.www.bloks.caa.reg.birthday.async",
+                "com.bloks.www.bloks.caa.reg.username.async",
+                "com.bloks.www.bloks.caa.reg.create.account.async",
+            ],
+        )
+        self.assertEqual(
+            [call.args[0] for call in caa_reg_async_action.call_args_list],
+            [
+                "com.bloks.www.bloks.caa.reg.async.expose_ntm_experiment.async",
+                "com.bloks.www.bloks.caa.reg.async.contactpoint_email_new.async",
+                "com.bloks.www.bloks.caa.reg.send_confirmation_email.async",
+                "com.bloks.www.bloks.caa.reg.name_vtwo.async",
+            ],
+        )
+        client.challenge_code_handler.assert_called_once_with("example", CHOICE_EMAIL)
+        password_call = caa_reg_graphql.call_args_list[5]
+        self.assertRegex(
+            password_call.kwargs["client_input_params"]["encrypted_password"],
+            r"^#PWD_INSTAGRAM:0:\d+:password$",
+        )
+        self.assertEqual(password_call.kwargs["client_input_params"]["spi_action"], 1)
+        self.assertEqual(
+            password_call.kwargs["server_params"]["flow_modifier"],
+            dumps({"flow_name": "new_to_family_ig_default", "flow_type": "ntf"}),
+        )
+        birthday_call = caa_reg_graphql.call_args_list[6]
+        self.assertEqual(birthday_call.kwargs["client_input_params"]["birthday_or_current_date_string"], "09-06-1995")
+        username_call = caa_reg_graphql.call_args_list[7]
+        self.assertEqual(username_call.kwargs["server_params"]["action"], 1)
+        self.assertEqual(username_call.kwargs["server_params"]["post_tos"], 0)
+        email_new_call = caa_reg_async_action.call_args_list[1]
+        self.assertIsNone(email_new_call.kwargs["server_params"]["reg_context"])
+        self.assertEqual(email_new_call.kwargs["client_input_params"]["email_prefilled"], 0)
+        self.assertEqual(email_new_call.kwargs["client_input_params"]["prefetch_version"], 11)
+        self.assertEqual(email_new_call.kwargs["server_params"]["cp_funnel"], 0)
+        self.assertEqual(email_new_call.kwargs["server_params"]["prefetch_on_field"], 1)
+
     def test_check_username_posts_uuid_payload(self):
         client = Client()
         client.uuid = "uuid"

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -95,7 +95,6 @@ class SignupHelperRegressionTestCase(unittest.TestCase):
         client.bloks_versioning_id = "bloks-version"
         client.waterfall_id = "waterfall-id"
         client.wait_seconds = 0
-        client.password_encrypt = mock.Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
         client.challenge_code_handler = mock.Mock(return_value="123456")
         registration_response = {
             "account_created": True,


### PR DESCRIPTION
## Summary
- add a mobile CAA email signup path as `Client.signup_caa_email(...)`
- add low-level `graphql_www` and Bloks GraphQL app helpers used by current CAA registration screens
- parse Bloks VM state for `reg_info`, `reg_context`, `email_token`, and `registration_response.created_user`
- add a skip-friendly live test for the CAA email signup flow

## Verification
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m pytest -q tests/regression/test_signup.py tests/regression/test_bloks.py tests/regression/test_public.py tests/live/test_signup.py`
- `.venv/bin/python -m ruff check instagrapi/mixins/signup.py instagrapi/mixins/bloks.py instagrapi/mixins/graphql.py instagrapi/mixins/private.py tests/regression/test_signup.py tests/regression/test_bloks.py tests/regression/test_public.py tests/live/test_signup.py`

## Live status
A full successful CAA signup live run still needs a working email-code hook. The local mailbox transport was not available from this session, so the new live test currently skips without `IG_SIGNUP_EMAIL(_COMMAND)` and `IG_SIGNUP_EMAIL_CODE(_COMMAND)`.

Manual smoke with a deliberately invalid email code reached `com.bloks.www.bloks.caa.reg.create.account.async`, which confirms the request sequence gets past email submit, confirmation send, password, birthday, name, and username steps. It does not prove account creation succeeds with a real code.
