### PR TITLE
Add user_suggested_profiles convenience method

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -37,6 +37,7 @@ View a list of a user's medias, following and followers
 | disable_stories_notifications(user_id: str)   | bool                  | Disable stories notifications of user                        |
 | close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
+| user_suggested_profiles(user_id: str, expand_suggestion: bool = False) | dict | Suggested profiles ("Suggested for you") for a profile. Wraps `chaining` and, with `expand_suggestion=True`, returns the raw `fetch_suggestion_details` payload (`items` in current app responses) |
 | chaining(user_id: str)                        | dict                  | Suggested users for a profile (`discover/chaining/`) — same surface as the app's "Suggested for you" carousel |
 | fetch_suggestion_details(user_id: str, chained_ids: str) | dict       | Expanded social-context fields for chained suggestion ids (`discover/fetch_suggestion_details/`) |
 | discover_recommended_accounts_for_category_v1(user_id: str) | dict | Business-category-similar accounts: extracts `category_id` from the target's stream payload, then calls `discover/recommended_accounts_for_category/` |
@@ -163,6 +164,25 @@ cl.login(USERNAME, PASSWORD)
 followers = cl.user_followers(cl.user_id)
 for user_id in followers.keys():
     cl.user_unfollow(user_id)
+```
+
+Example: Suggested profiles ("Suggested for you") for a target user:
+
+``` python
+from instagrapi import Client
+from instagrapi.exceptions import InvalidTargetUser
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+user_id = cl.user_id_from_username("example")
+try:
+    suggested = cl.user_suggested_profiles(user_id)
+    # Expanded social-context fields (current app responses expose them under "items"):
+    detailed = cl.user_suggested_profiles(user_id, expand_suggestion=True)
+except InvalidTargetUser:
+    # Instagram refuses chaining for locked-down / private targets
+    suggested = {"users": []}
 ```
 
 Tip:

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1848,6 +1848,47 @@ class UserMixin:
             params=params,
         )
 
+    def user_suggested_profiles(self, user_id: str, expand_suggestion: bool = False) -> dict:
+        """
+        Get suggested profiles ("Suggested for you") for a target user_id.
+
+        Convenience wrapper over :meth:`chaining` and
+        :meth:`fetch_suggestion_details`. By default it returns the raw
+        ``chaining`` payload; with ``expand_suggestion=True`` it feeds the
+        chained pks back into ``fetch_suggestion_details`` and returns the
+        social-context-rich payload instead.
+
+        Parameters
+        ----------
+        user_id: str
+            Target user pk whose suggested profiles to fetch.
+        expand_suggestion: bool, optional
+            When ``True``, return the expanded ``fetch_suggestion_details``
+            payload. Falls back to the ``chaining`` payload when the target
+            has no chained users. Defaults to ``False``.
+
+        Returns
+        -------
+        dict
+            Raw ``discover/chaining/`` response, or the
+            ``discover/fetch_suggestion_details/`` response when
+            ``expand_suggestion`` is ``True`` and chained users exist
+            (currently keyed by ``items`` in app responses).
+
+        Raises
+        ------
+        InvalidTargetUser
+            Instagram refused chaining for this target ("Not eligible
+            for chaining."). Common on locked-down / private accounts.
+        """
+        chained = self.chaining(user_id)
+        if not expand_suggestion:
+            return chained
+        chained_ids = ",".join(str(user["pk"]) for user in chained.get("users", []) if user.get("pk"))
+        if not chained_ids:
+            return chained
+        return self.fetch_suggestion_details(user_id, chained_ids)
+
     def user_stream_by_username_v1(self, username: str) -> dict:
         """
         Get the streamed profile envelope by username.

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -852,6 +852,42 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             },
         )
 
+    def test_user_suggested_profiles_returns_chaining_payload_by_default(self):
+        client = Client()
+        chained = {"users": [{"pk": "9", "username": "a"}, {"pk": "10", "username": "b"}]}
+
+        with mock.patch.object(client, "chaining", return_value=chained) as chaining:
+            with mock.patch.object(client, "fetch_suggestion_details") as fetch_details:
+                result = client.user_suggested_profiles("123")
+
+        self.assertEqual(result, chained)
+        chaining.assert_called_once_with("123")
+        fetch_details.assert_not_called()
+
+    def test_user_suggested_profiles_expands_suggestion_details(self):
+        client = Client()
+        chained = {"users": [{"pk": "9"}, {"pk": "10"}]}
+        expanded = {"items": [{"user": {"pk": "9"}, "social_context": "Followed by you"}]}
+
+        with mock.patch.object(client, "chaining", return_value=chained) as chaining:
+            with mock.patch.object(client, "fetch_suggestion_details", return_value=expanded) as fetch_details:
+                result = client.user_suggested_profiles("123", expand_suggestion=True)
+
+        self.assertEqual(result, expanded)
+        chaining.assert_called_once_with("123")
+        fetch_details.assert_called_once_with("123", "9,10")
+
+    def test_user_suggested_profiles_expand_without_users_returns_chaining(self):
+        client = Client()
+        chained = {"users": []}
+
+        with mock.patch.object(client, "chaining", return_value=chained):
+            with mock.patch.object(client, "fetch_suggestion_details") as fetch_details:
+                result = client.user_suggested_profiles("123", expand_suggestion=True)
+
+        self.assertEqual(result, chained)
+        fetch_details.assert_not_called()
+
     def test_user_stream_by_id_v1_sends_expected_endpoint_and_data(self):
         client = Client()
         with mock.patch.object(client, "private_request", return_value={"stream_rows": []}) as private_request:


### PR DESCRIPTION
## Summary
- add `Client.user_suggested_profiles(user_id, expand_suggestion=False)` — a single "Suggested for you" helper that composes the existing `chaining()` and `fetch_suggestion_details()` methods
- by default returns the raw `discover/chaining/` payload; with `expand_suggestion=True` it feeds the chained pks into `discover/fetch_suggestion_details/` and returns the raw expanded payload (`items` in current app responses), falling back to the chaining payload when the target has no chained users
- mirrors the common two-call pattern people otherwise write by hand (and the same composition HikerAPI exposes as `/v2/user/suggested/profiles`)

## Tests
- `ruff check instagrapi/mixins/user.py tests/regression/test_user.py`
- `pytest -q tests/regression` (516 passed, 3 skipped, 5 subtests passed)
- live smoke with pooled account against `instagram`: default chaining returned 77 users; expanded details returned 30 items
- new regression tests cover: default chaining return, expanded path with joined pks, and the no-chained-users fallback

## Docs
- `docs/usage-guide/user.md`: method-table row + a usage example (including the `InvalidTargetUser` path for locked-down / private targets)