### PR TITLE
Preserve follower metadata in UserShort

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -144,7 +144,9 @@ class UserShort(TypesBaseModel):
     profile_pic_url: Optional[HttpUrl] = None
     profile_pic_url_hd: Optional[HttpUrl] = None
     is_private: Optional[bool] = None
-    # is_verified: bool  # not found in hashtag_medias_v1
+    is_verified: Optional[bool] = None
+    latest_reel_media: Optional[int] = None
+    has_anonymous_profile_picture: Optional[bool] = None
     # stories: List = [] # not found in fbsearch_suggested_profiles
 
 

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -142,6 +142,18 @@ class ClientFollowersLiveTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(list(followers.values())[0], UserShort)
         public_lookup.assert_not_called()
 
+    def test_user_followers_v1_preserves_extended_user_short_fields_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        followers = self.cl.user_followers_v1(user_id, amount=5)
+
+        self.assertEqual(len(followers), 5)
+        follower = followers[0]
+        self.assertIsInstance(follower, UserShort)
+        self.assertIsInstance(follower.is_verified, bool)
+        self.assertIsInstance(follower.latest_reel_media, int)
+        self.assertIsInstance(follower.has_anonymous_profile_picture, bool)
+
     def test_user_followers_gql_chunk_paginates_two_pages(self):
         user_id = self.user_id_from_username("instagram")
 

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1,4 +1,4 @@
-from instagrapi.extractors import extract_user_v1
+from instagrapi.extractors import extract_user_short, extract_user_v1
 from tests.helpers import *
 
 
@@ -96,6 +96,26 @@ class UserMixinRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(user.public_email, "public@example.com")
         self.assertEqual(user.contact_phone_number, "+15551234567")
+
+    def test_extract_user_short_preserves_follower_payload_fields(self):
+        payload = {
+            "pk": 123,
+            "id": "123",
+            "username": "follower",
+            "full_name": "Follower",
+            "is_private": False,
+            "is_verified": True,
+            "latest_reel_media": 1710000123,
+            "has_anonymous_profile_picture": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+        }
+
+        user = extract_user_short(payload)
+
+        self.assertEqual(user.pk, "123")
+        self.assertTrue(user.is_verified)
+        self.assertEqual(user.latest_reel_media, 1710000123)
+        self.assertFalse(user.has_anonymous_profile_picture)
 
     def test_user_short_gql_uses_web_profile_doc_id_without_legacy_query_hash(self):
         client = Client()


### PR DESCRIPTION
## Summary
- expose follower payload fields on `UserShort`: `is_verified`, `latest_reel_media`, `has_anonymous_profile_picture`
- add regression coverage for `extract_user_short(...)`
- add a focused live followers test proving the private mobile follower endpoint preserves those fields

Refs https://github.com/subzeroid/instagrapi/issues/1564

## Verification
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m pytest -q tests/regression/test_user.py`
- `.venv/bin/python -m pytest -q tests/live/test_user.py::ClientFollowersLiveTestCase::test_user_followers_v1_preserves_extended_user_short_fields_live`
- `.venv/bin/python -m build`