### PR TITLE
Handle non-JSON private HTTP errors

### DIFF
--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -458,7 +458,7 @@ class PrivateRequestMixin:
         except requests.HTTPError as e:
             try:
                 self.last_json = last_json = response.json()
-            except JSONDecodeError:
+            except ValueError:
                 pass
             message = last_json.get("message", "")
             if "Please wait a few minutes" in message:

--- a/tests/regression/test_hardening.py
+++ b/tests/regression/test_hardening.py
@@ -127,6 +127,17 @@ class HardeningRegressionTestCase(unittest.TestCase):
             with self.assertRaises(ClientNotFoundError):
                 client._send_private_request("nonexistent/")
 
+    def test_send_private_request_ignores_non_json_body_on_http_error(self):
+        from instagrapi.exceptions import ClientNotFoundError
+
+        client = self._build_private_client()
+        response = self._make_http_error_response(404, content=b"<html>not json</html>")
+        response.json.side_effect = ValueError("bad json")
+
+        with mock.patch.object(client.private, "get", return_value=response):
+            with self.assertRaises(ClientNotFoundError):
+                client._send_private_request("nonexistent/")
+
     def test_send_private_request_promotes_direct_message_requests_disabled_http_error(self):
         client = self._build_private_client()
         payload = {

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -211,6 +211,24 @@ class PublicRegressionTestCase(unittest.TestCase):
 
 
 class PrivateGraphQLRequestRegressionTestCase(unittest.TestCase):
+    def test_send_private_request_ignores_non_json_body_on_http_error(self):
+        client = Client()
+        client.request_timeout = 0
+        client.authorization_data = {"ds_user_id": "1"}
+        response = Mock()
+        response.status_code = 404
+        response.content = b"<html>not json</html>"
+        response.headers = {}
+        response.url = "https://i.instagram.com/api/v1/nonexistent/"
+        response.text = response.content.decode("utf-8")
+        response.request = Mock(method="GET")
+        response.json.side_effect = ValueError("bad json")
+        response.raise_for_status.side_effect = requests.HTTPError(response=response)
+
+        with mock.patch.object(client.private, "get", return_value=response):
+            with self.assertRaises(ClientNotFoundError):
+                client._send_private_request("nonexistent/")
+
     def test_private_graphql_request_posts_to_app_graphql_endpoint(self):
         client = Client()
         client.request_timeout = 0


### PR DESCRIPTION
Refs https://github.com/subzeroid/instagrapi/issues/708

Private HTTP error handling now ignores JSON parse failures while trying to enrich `last_json` from a failed response body. This preserves status-specific mapping such as 404 -> `ClientNotFoundError` instead of leaking a JSON decode exception for HTML/non-JSON error pages.

The regression is covered both in the hardening suite and in `PrivateGraphQLRequestRegressionTestCase`, which is included in the GitHub Actions compatibility test subset.

Verification:
- `.venv/bin/python -m pytest -q tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase::test_send_private_request_ignores_non_json_body_on_http_error tests/regression/test_hardening.py::HardeningRegressionTestCase::test_send_private_request_ignores_non_json_body_on_http_error`
- `.venv/bin/python -m pytest -q tests/regression/test_public.py::PublicRegressionTestCase tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase tests/regression/test_hardening.py tests/regression/test_request_logging.py`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m bandit -c pyproject.toml -r instagrapi`
- `.venv/bin/python -m build`