### PR TITLE
Handle limited private follower lists

### DIFF
--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -954,8 +954,11 @@ class UserMixin:
         unique_set = set()
         users = []
         while True:
+            count = MAX_USER_COUNT
+            if max_amount:
+                count = min(max_amount - len(users), MAX_USER_COUNT)
             params = {
-                "count": max_amount or MAX_USER_COUNT,
+                "count": count,
                 "rank_token": self.rank_token,
                 "search_surface": "follow_list_page",
                 "query": "",
@@ -1157,6 +1160,8 @@ class UserMixin:
             if self._has_private_auth():
                 try:
                     users = self.user_followers_v1(user_id, amount)
+                    if self.last_json.get("should_limit_list_of_followers") and (not amount or len(users) < amount):
+                        users = self.user_followers_gql(user_id, amount)
                 except Exception as e:
                     if not isinstance(e, ClientError):
                         self.logger.exception(e)

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1,4 +1,5 @@
 from instagrapi.extractors import extract_user_short, extract_user_v1
+from instagrapi.mixins.user import MAX_USER_COUNT
 from tests.helpers import *
 
 
@@ -541,6 +542,53 @@ class UserMixinRegressionTestCase(unittest.TestCase):
 
         params = private_request.call_args.kwargs["params"]
         self.assertEqual(params["order"], "date_followed_latest")
+
+    def test_user_followers_v1_chunk_caps_count_to_max_user_count(self):
+        client = self.build_private_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"users": [], "next_max_id": None},
+        ) as private_request:
+            client.user_followers_v1_chunk("123", max_amount=MAX_USER_COUNT + 1)
+
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(params["count"], MAX_USER_COUNT)
+
+    def test_authorized_user_followers_falls_back_when_private_list_is_limited(self):
+        client = self.build_private_client()
+        private_user = UserShort(pk="private", username="private")
+        public_user = UserShort(pk="public", username="public")
+
+        def private_lookup(user_id, amount):
+            client.last_json = {"should_limit_list_of_followers": True}
+            return [private_user]
+
+        with mock.patch.object(client, "user_followers_v1", side_effect=private_lookup) as private_lookup_mock:
+            with mock.patch.object(client, "user_followers_gql", return_value=[public_user]) as public_lookup:
+                followers = client.user_followers("123", use_cache=False, amount=2)
+
+        private_lookup_mock.assert_called_once_with("123", 2)
+        public_lookup.assert_called_once_with("123", 2)
+        self.assertEqual(list(followers), ["public"])
+
+    def test_authorized_user_followers_default_amount_falls_back_when_private_list_is_limited(self):
+        client = self.build_private_client()
+        private_user = UserShort(pk="private", username="private")
+        public_user = UserShort(pk="public", username="public")
+
+        def private_lookup(user_id, amount):
+            client.last_json = {"should_limit_list_of_followers": True}
+            return [private_user]
+
+        with mock.patch.object(client, "user_followers_v1", side_effect=private_lookup) as private_lookup_mock:
+            with mock.patch.object(client, "user_followers_gql", return_value=[public_user]) as public_lookup:
+                followers = client.user_followers("123", use_cache=False)
+
+        private_lookup_mock.assert_called_once_with("123", 0)
+        public_lookup.assert_called_once_with("123", 0)
+        self.assertEqual(list(followers), ["public"])
 
     def test_user_followers_with_order_uses_private_api_without_cache(self):
         client = self.build_private_client()


### PR DESCRIPTION
## Summary
- cap private followers v1 page `count` at `MAX_USER_COUNT` instead of sending the total requested amount
- when the private followers endpoint returns `should_limit_list_of_followers` and does not satisfy the requested amount, fall back to public GraphQL intentionally
- add regression coverage for the bounded count and limited-private-list fallback paths

Fixes https://github.com/subzeroid/instagrapi/issues/1318

## Verification
- RED: new regression tests failed before the implementation
- `.venv/bin/python -m pytest -q tests/regression/test_user.py`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m bandit -c pyproject.toml -r instagrapi`
- `.venv/bin/python -m build`
- live: `user_followers(45600199849, use_cache=False, amount=350)` returned 350 after one limited private page (`count=200`, 49 users, `should_limit_list_of_followers=True`) and public GraphQL fallback
- live: `user_followers_v1(45600199849, amount=350)` no longer sends `count=350`/400s; it returns the limited private slice from Instagram
- live: `tests/live/test_user.py::ClientFollowersLiveTestCase::test_user_followers_uses_private_api_live` and `test_user_followers_v1_preserves_extended_user_short_fields_live` passed