### PR TITLE
Cap private following page count

### DIFF
--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -770,10 +770,13 @@ class UserMixin:
             Tuple of List of users and max_id
         """
         unique_set = set()
-        users = []
+        users: List[UserShort] = []
         while True:
+            count = MAX_USER_COUNT
+            if max_amount:
+                count = min(max_amount - len(users), MAX_USER_COUNT)
             params = {
-                "count": max_amount or MAX_USER_COUNT,
+                "count": count,
                 "rank_token": self.rank_token,
                 "search_surface": "follow_list_page",
                 "query": "",

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -721,6 +721,19 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         params = private_request.call_args.kwargs["params"]
         self.assertNotIn("max_id", params)
 
+    def test_user_following_v1_chunk_caps_count_to_max_user_count(self):
+        client = self.build_private_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"users": [], "next_max_id": None},
+        ) as private_request:
+            client.user_following_v1_chunk("123", max_amount=MAX_USER_COUNT + 1)
+
+        params = private_request.call_args.kwargs["params"]
+        self.assertEqual(params["count"], MAX_USER_COUNT)
+
     def test_user_follow_requests_chunk_fetches_pending_users(self):
         client = self.build_private_client()
 


### PR DESCRIPTION
Fixes the private mobile `user_following_v1` pagination path sending oversized `count` values to Instagram.

Context:
- Issue: https://github.com/subzeroid/instagrapi/issues/1253
- Related older report: https://github.com/subzeroid/instagrapi/issues/1292

Root cause:
- `user_following_v1_chunk(..., max_amount=N)` passed `N` directly as the private endpoint `count`.
- Instagram rejects oversized private following requests, e.g. live reproduction on `instagram` with `amount=350` returned HTTP 400 for `count=350`.
- This is the following-side equivalent of the follower count cap fixed in 2.9.5.

Changes:
- Cap each private following page `count` at `MAX_USER_COUNT`.
- Keep subsequent pages bounded to the remaining requested amount.
- Add regression coverage for the count cap.

Verification:
- RED: new regression test failed before the fix with `201 != 200`.
- GREEN: new regression test passes after the fix.
- Live before fix: `user_following_v1(instagram, amount=350)` sent `count=350` and raised `ClientBadRequestError` / HTTP 400.
- Live after fix: `user_following_v1(instagram, amount=350)` completed with capped private page counts (`200` or lower) and returned HTTP 200.
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m pytest -q tests/live/test_user.py::ClientFollowingLiveTestCase::test_user_following_uses_private_api_live tests/live/test_user.py::ClientFollowingLiveTestCase::test_user_following_v1_chunk_paginates_two_pages`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m bandit -c pyproject.toml -r instagrapi`
- `.venv/bin/python -m build`
