### PR TITLE
Read hashtag section layout items

### DIFF
--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -18,6 +18,18 @@ class HashtagMixin:
     Helpers for managing Hashtag
     """
 
+    def _hashtag_section_media_nodes(self, section):
+        layout_content = section.get("layout_content") or {}
+        one_by_two_item = layout_content.get("one_by_two_item") or {}
+        if isinstance(one_by_two_item, dict):
+            clips = one_by_two_item.get("clips") or {}
+            if isinstance(clips, dict):
+                for node in clips.get("items") or []:
+                    yield node
+        for key in ("fill_items", "medias"):
+            for node in layout_content.get(key) or []:
+                yield node
+
     def _normalize_hashtag_name(self, name: str) -> str:
         normalized = name.strip()
         if normalized.startswith("#"):
@@ -157,9 +169,7 @@ class HashtagMixin:
             ids = result.get("next_media_ids")
             next_max_id = base64.b64encode(json.dumps([np, ids]).encode()).decode()
         for section in result["sections"]:
-            layout_content = section.get("layout_content") or {}
-            nodes = layout_content.get("medias") or []
-            for node in nodes:
+            for node in self._hashtag_section_media_nodes(section):
                 if max_amount and len(medias) >= max_amount:
                     break
                 try:

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -57,6 +57,73 @@ class HashtagRegressionTestCase(unittest.TestCase):
         self.assertEqual(request_data["tab"], "recent")
         self.assertEqual(request_data["media_recency_filter"], "top_recent_posts")
 
+    def test_hashtag_medias_v1_chunk_reads_top_level_section_layout_items(self):
+        client = Client()
+
+        def media(pk):
+            return {
+                "pk": pk,
+                "id": f"{pk}_2",
+                "code": f"code-{pk}",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": f"https://example.com/{pk}.jpg",
+                            "width": 100,
+                            "height": 100,
+                        }
+                    ]
+                },
+            }
+
+        client.private_request = Mock(
+            return_value={
+                "sections": [
+                    {
+                        "layout_type": "one_by_two_left",
+                        "feed_type": "clips",
+                        "layout_content": {
+                            "one_by_two_item": {
+                                "clips": {
+                                    "items": [
+                                        {"media": media("1")},
+                                        {"media": media("2")},
+                                    ]
+                                }
+                            },
+                            "fill_items": [
+                                {"media": media("3")},
+                                {"media": media("4")},
+                            ],
+                        },
+                    },
+                    {
+                        "layout_type": "media_grid",
+                        "feed_type": "media",
+                        "layout_content": {
+                            "medias": [
+                                {"media": media("5")},
+                            ]
+                        },
+                    },
+                ],
+                "more_available": False,
+                "next_max_id": None,
+            }
+        )
+
+        medias, next_max_id = client.hashtag_medias_v1_chunk("example", 0, "top")
+
+        self.assertEqual([media.pk for media in medias], ["1", "2", "3", "4", "5"])
+        self.assertIsNone(next_max_id)
+
     def test_hashtag_following_fetches_current_account_hashtags(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123"}


### PR DESCRIPTION
Fixes hashtag section parsing for private mobile `tags/{name}/sections/` responses that include top-level media outside `layout_content.medias`.

Context:
- Issue: https://github.com/subzeroid/instagrapi/issues/2621

Root cause:
- `hashtag_medias_v1_chunk(...)` only read `layout_content.medias`.
- Instagram hashtag `top` sections can also include top-level media in `layout_content.fill_items[*].media` and `layout_content.one_by_two_item.clips.items[*].media`.
- Those layout items were skipped, so `hashtag_medias_v1(..., tab_key="top")` under-counted searchable hashtag media.

Changes:
- Add a small hashtag section node iterator for the known top-level section containers.
- Keep existing malformed node handling through the existing extraction path.
- Add regression coverage for `one_by_two_item.clips.items`, `fill_items`, and ordinary `medias` in one response.

Live notes:
- On `메쉬번`, `hashtag_info().media_count` was `153`.
- Before the fix, `recent` exhausted at `77` unique and `top` missed non-grid section items.
- With the fixed parser, the targeted live diagnostic found the additional `one_by_two_left` layout items and the combined `recent`/`top`/`clips` union reached up to `146` unique in one run. Instagram still controls cursor exhaustion and duplicate/filtered media, so `media_count` is not guaranteed to be fully retrievable.
- The standard live pytest collector was blocked by fresh account pool login failures/challenges, not by this change.

Verification:
- RED: `test_hashtag_medias_v1_chunk_reads_top_level_section_layout_items` failed before the fix with `['5'] != ['1', '2', '3', '4', '5']`.
- GREEN: targeted regression and hardening tests pass after the fix.
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/bandit -c pyproject.toml -r instagrapi`
- `PATH="$PWD/.venv/bin:$PATH" mkdocs build --strict`
- `.venv/bin/python -m build`