### PR TITLE
Preserve unknown clips Facebook share state

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -415,7 +415,7 @@ class ClipsMetadata(TypesBaseModel):
     disable_use_in_clips_client_cache: bool = False
     external_media_info: Optional[dict] = None
     is_fan_club_promo_video: bool = False
-    is_shared_to_fb: bool = False
+    is_shared_to_fb: Optional[bool] = None
     mashup_info: Optional[ClipsMashupInfo] = None
     merchandising_pill_info: Optional[dict] = None
     music_canonical_id: str

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -25,6 +25,23 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
             },
         }
 
+    def _clips_metadata_payload(self, **overrides):
+        payload = {
+            "clips_creation_entry_point": "clips",
+            "achievements_info": {"num_earned_achievements": None, "show_achievements": False},
+            "additional_audio_info": {
+                "additional_audio_username": None,
+                "audio_reattribution_info": {"should_allow_restore": False},
+            },
+            "audio_ranking_info": {"best_audio_cluster_id": ""},
+            "audio_type": "original_sounds",
+            "branded_content_tag_info": {"can_add_tag": True},
+            "content_appreciation_info": {"enabled": False},
+            "music_canonical_id": "",
+        }
+        payload.update(overrides)
+        return payload
+
     def test_media_info_v2_strips_userid_suffix(self):
         client = Client()
         with mock.patch.object(
@@ -113,6 +130,30 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         self.assertEqual(media.resources[0].usertags[0].x, 0.25)
         self.assertEqual(media.resources[1].usertags[0].user.pk, "200")
         self.assertEqual(media.resources[1].usertags[0].y, 0.5)
+
+    def test_extract_media_v1_does_not_default_missing_clips_shared_to_fb_to_false(self):
+        payload = self._media_or_ad_payload()
+        payload["media_type"] = 2
+        payload["product_type"] = "clips"
+        payload["clips_metadata"] = self._clips_metadata_payload()
+
+        media = extract_media_v1(payload)
+
+        self.assertIsNone(media.clips_metadata.is_shared_to_fb)
+        self.assertIsNone(media.model_dump()["clips_metadata"]["is_shared_to_fb"])
+
+    def test_extract_media_v1_preserves_clips_shared_to_fb_when_present(self):
+        for value in (False, True):
+            with self.subTest(value=value):
+                payload = self._media_or_ad_payload()
+                payload["media_type"] = 2
+                payload["product_type"] = "clips"
+                payload["clips_metadata"] = self._clips_metadata_payload(is_shared_to_fb=value)
+
+                media = extract_media_v1(payload)
+
+                self.assertIs(media.clips_metadata.is_shared_to_fb, value)
+                self.assertIs(media.model_dump()["clips_metadata"]["is_shared_to_fb"], value)
 
 
 class MediaInfoPrivateFirstRegressionTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary
- stop defaulting missing `clips_metadata.is_shared_to_fb` to `False`
- preserve `true`/`false` when Instagram sends an explicit value
- add regression coverage for missing and explicit Reel Facebook share state

Fixes part of https://github.com/subzeroid/instagrapi/issues/2619: `media_info()` should not claim a Reel is not shared to Facebook when the response did not include that state. Instagram may still omit the owner-only post-publication Facebook copy state from `media/{pk}/info/`; this change reports that as `None` instead of inventing `False`.

## Verification
- RED before fix: `.venv/bin/python -m pytest -q tests/regression/test_media.py::MediaInfoV2RegressionTestCase::test_extract_media_v1_does_not_default_missing_clips_shared_to_fb_to_false tests/regression/test_media.py::MediaInfoV2RegressionTestCase::test_extract_media_v1_preserves_clips_shared_to_fb_when_present`
- `.venv/bin/python -m pytest -q tests/regression/test_media.py::MediaInfoV2RegressionTestCase::test_extract_media_v1_does_not_default_missing_clips_shared_to_fb_to_false tests/regression/test_media.py::MediaInfoV2RegressionTestCase::test_extract_media_v1_preserves_clips_shared_to_fb_when_present`
- `.venv/bin/python -m pytest -q tests/regression/test_media.py`
- `.venv/bin/python -m pytest -q tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_share_to_fb_extra_data_builds_current_reel_crosspost_payload tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_upload_share_to_facebook_adds_crosspost_params_before_upload`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/bandit -c pyproject.toml -r instagrapi`
- `PATH="$PWD/.venv/bin:$PATH" mkdocs build --strict`
- `.venv/bin/python -m build`
- `.venv/bin/python -m pytest -q -rs tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_share_to_fb_destination_live` -> skipped: current live account pool has no confirmed Facebook Reel destination
