### PR TITLE
Hydrate incomplete saved app profiles

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -1153,7 +1153,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             if matched and not override_app_version:
                 apply_settings(matched)
             else:
-                if override_app_version or not app_version:
+                has_complete_app_profile = all(self.device_settings.get(key) for key in app_keys)
+                if override_app_version or not app_version or not has_complete_app_profile:
                     apply_settings(default_settings())
 
         if override_app_version:

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -126,3 +126,20 @@ class CurrentAppProfileRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(client.device_settings["app_version"], config.DEFAULT_APP_VERSION)
         self.assertEqual(client.device_settings["version_code"], "961145276")
+
+    def test_unknown_saved_app_without_bloks_hash_uses_current_default_profile(self):
+        client = Client(
+            {
+                "device_settings": {
+                    "app_version": "431.0.0.47.82",
+                    "version_code": "979332773",
+                },
+            }
+        )
+
+        self.assertEqual(client.device_settings["app_version"], config.DEFAULT_APP_VERSION)
+        self.assertEqual(client.device_settings["version_code"], "961145276")
+        self.assertEqual(
+            client.bloks_versioning_id,
+            "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
+        )


### PR DESCRIPTION
## Summary
- fall back to the current known Android app profile when saved `device_settings` contain an unknown/incomplete app tuple without `bloks_versioning_id`
- keep complete saved app profiles intact
- add regression coverage for the saved `431.0.0.47.82`/missing-Bloks-hash shape seen while investigating Facebook Reel destination discovery

This fixes the local diagnostic failure where `bloks_fxcal_link_reels_share()` raised `Client.bloks_versioning_id is empty` before it could fetch the Account Center linking response.

It does not treat Account Center `fbid`/linking identifiers as `share_to_fb_destination_id`; live diagnostics still show no confirmed Reel publish destination fields in the current response shape.

Refs https://github.com/subzeroid/instagrapi/issues/2617

## Tests
- `.venv/bin/python -m pytest -q tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase::test_unknown_saved_app_without_bloks_hash_uses_current_default_profile` -> 1 passed
- `.venv/bin/python -m pytest -q tests/regression/test_current_app_profile.py tests/regression/test_bloks.py tests/regression/test_upload.py` -> 83 passed
- `.venv/bin/python -m pytest -q tests/regression` -> 528 passed, 3 skipped, 7 subtests passed
- `.venv/bin/python -m ruff check .` -> passed
- `.venv/bin/python -m ruff format --check .` -> passed
- `.venv/bin/bandit -c pyproject.toml -r instagrapi` -> no issues
- `PATH="$PWD/.venv/bin:$PATH" mkdocs build --strict` -> success
- `.venv/bin/python -m build` -> success
- live: `tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_share_to_fb_unified_config_live` -> passed
- live: `tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_share_to_fb_destination_live` -> skipped: no confirmed Facebook Reel destination available
