### PR TITLE
Scope saved app profile hydration

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -636,7 +636,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
 
         self.set_timezone_offset(timezone_offset, timezone_name=timezone_name or None)
         self.set_push_disabled(push_disabled)
-        self.set_device(self.settings.get("device_settings"))
+        self.set_device(self.settings.get("device_settings"), hydrate_app_profile=True)
         self.set_user_agent(self.settings.get("user_agent"))
         self.set_uuids(self.settings.get("uuids") or {})
         self.set_locale(locale)
@@ -1072,7 +1072,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             )
         return True
 
-    def set_device(self, device: Dict = None, reset: bool = False) -> bool:
+    def set_device(self, device: Dict = None, reset: bool = False, hydrate_app_profile: bool = False) -> bool:
         """
         Helper to set a device for login
 
@@ -1080,6 +1080,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         ----------
         device: Dict, optional
             Dict of device settings, default is None
+        hydrate_app_profile: bool, optional
+            Hydrate incomplete app profile fields from the current default app when loading saved settings
 
         Returns
         -------
@@ -1093,13 +1095,13 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         if self.settings:
             uuids = self.settings.get("uuids") or {}
             seed = uuids.get("uuid")
-        self.set_app(seed=seed)
+        self.set_app(seed=seed, hydrate_incomplete_profile=hydrate_app_profile)
         self.set_user_agent()
         if reset:
             self.set_uuids({})
         return True
 
-    def set_app(self, app: Union[str, Dict] = None, seed: str = None) -> bool:
+    def set_app(self, app: Union[str, Dict] = None, seed: str = None, hydrate_incomplete_profile: bool = False) -> bool:
         """
         Helper to set app version settings
 
@@ -1109,6 +1111,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             App version string or settings dict
         seed: str, optional
             Seed used for stable app selection
+        hydrate_incomplete_profile: bool, optional
+            Hydrate incomplete app profile fields from the current default app
 
         Returns
         -------
@@ -1139,6 +1143,14 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         def default_settings() -> Dict:
             return config.APP_SETTINGS.get(config.DEFAULT_APP_VERSION) or pick_by_seed()
 
+        def is_current_or_newer_app_version(value: Any) -> bool:
+            try:
+                version = tuple(int(part) for part in str(value).split("."))
+                default_version = tuple(int(part) for part in config.DEFAULT_APP_VERSION.split("."))
+            except (TypeError, ValueError):
+                return False
+            return version >= default_version
+
         if app:
             if isinstance(app, str):
                 matched = config.APP_SETTINGS.get(app)
@@ -1154,7 +1166,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                 apply_settings(matched)
             else:
                 has_complete_app_profile = all(self.device_settings.get(key) for key in app_keys)
-                if override_app_version or not app_version or not has_complete_app_profile:
+                should_hydrate_incomplete_profile = (
+                    hydrate_incomplete_profile
+                    and not has_complete_app_profile
+                    and is_current_or_newer_app_version(app_version)
+                )
+                if override_app_version or not app_version or should_hydrate_incomplete_profile:
                     apply_settings(default_settings())
 
         if override_app_version:

--- a/tests/regression/test_current_app_profile.py
+++ b/tests/regression/test_current_app_profile.py
@@ -143,3 +143,29 @@ class CurrentAppProfileRegressionTestCase(unittest.TestCase):
             client.bloks_versioning_id,
             "7189b949425f9bf80ea8bd880cf5a3080b292d9b1c4b38a18d112f7c4b71e7a8",
         )
+
+    def test_legacy_saved_app_without_bloks_hash_is_not_overridden_by_default(self):
+        client = Client(
+            {
+                "device_settings": {
+                    "app_version": "269.0.0.19.301",
+                    "version_code": "301484483",
+                },
+            }
+        )
+
+        self.assertEqual(client.device_settings["app_version"], "269.0.0.19.301")
+        self.assertEqual(client.device_settings["version_code"], "301484483")
+        self.assertIsNone(client.bloks_versioning_id)
+
+    def test_explicit_set_device_preserves_unknown_incomplete_app_profile(self):
+        client = Client()
+        device = {
+            "app_version": "431.0.0.47.82",
+            "version_code": "979332773",
+        }
+
+        client.set_device(device)
+
+        self.assertEqual(client.device_settings["app_version"], "431.0.0.47.82")
+        self.assertEqual(client.device_settings["version_code"], "979332773")


### PR DESCRIPTION
## Summary
- scope incomplete saved app profile hydration to settings load only
- keep explicit set_device(...) behavior and older saved app profiles unchanged
- add regression coverage for legacy saved settings and explicit unknown app profiles

## Context
- Follow-up for https://github.com/subzeroid/instagrapi/issues/2617 after https://github.com/subzeroid/instagrapi/releases/tag/2.9.9
- Async mirror: https://github.com/subzeroid/aiograpi/pull/327

## Tests
- .venv/bin/python -m pytest -q tests/regression/test_current_app_profile.py tests/regression/test_bloks.py tests/regression/test_upload.py
- .venv/bin/python -m pytest -q tests/regression
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/bandit -c pyproject.toml -r instagrapi
- .venv/bin/python -m build
- .venv/bin/mkdocs build --strict
- .venv/bin/python -m pytest -q -rs tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_share_to_fb_unified_config_live tests/live/test_upload.py::ClientFacebookReelCrosspostLiveTestCase::test_clip_share_to_fb_destination_live (1 passed, 1 skipped: no confirmed Facebook Reel destination available)