### PR TITLE
Fix Notes inbox tray reads

### DIFF
--- a/instagrapi/mixins/note.py
+++ b/instagrapi/mixins/note.py
@@ -1,10 +1,13 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Union
 
 from instagrapi.exceptions import ClientGraphqlError
 from instagrapi.types import Note, Track, UserShort
 from instagrapi.utils.serialization import dumps
 
+INBOX_TRAY_CLIENT_DOC_ID = "26838444193647008103482058049"
+INBOX_TRAY_FRIENDLY_NAME = "InboxTrayRequest"
+INBOX_TRAY_ROOT_FIELD = "xdt_get_inbox_tray_items"
 CREATE_INBOX_TRAY_ITEM_CLIENT_DOC_ID = "3510400299951610199199089856"
 CREATE_INBOX_TRAY_ITEM_FRIENDLY_NAME = "CreateInboxTrayItemRequest"
 
@@ -23,8 +26,14 @@ class NoteMixin:
 
     @staticmethod
     def _note_from_note_dict(data: Dict) -> Note:
+        note_id = data.get("note_id") or data.get("id")
         author = data.get("author") or {}
-        user_id = str(data.get("author_id") or author.get("pk") or author.get("id"))
+        user_id = str(data.get("author_id") or author.get("pk") or author.get("id") or "")
+        created_at = int(data.get("1lcreated_at") or data.get("created_at") or 0)
+        expires_at = data.get("1lexpires_at") or data.get("expires_at")
+        if expires_at is None:
+            # Inbox tray GraphQL omits expires_at in current web responses; Notes expire after 24 hours.
+            expires_at = int((datetime.fromtimestamp(created_at, tz=timezone.utc) + timedelta(days=1)).timestamp())
         user = UserShort(
             pk=str(author.get("pk") or author.get("id") or user_id),
             username=author.get("username"),
@@ -33,17 +42,45 @@ class NoteMixin:
             is_private=author.get("is_private"),
         )
         return Note(
-            id=str(data["note_id"]),
+            id=str(note_id),
             text=data.get("text") or "",
             user_id=user_id,
             user=user,
             audience=int(data.get("audience", 0)),
-            created_at=datetime.fromtimestamp(int(data.get("1lcreated_at", 0)), tz=timezone.utc),
-            expires_at=datetime.fromtimestamp(int(data.get("1lexpires_at", 0)), tz=timezone.utc),
+            created_at=datetime.fromtimestamp(created_at, tz=timezone.utc),
+            expires_at=datetime.fromtimestamp(int(expires_at), tz=timezone.utc),
             is_emoji_only=bool(data.get("is_emoji_only", False)),
             has_translation=bool(data.get("has_translation", False)),
             note_style=int(data.get("note_style", 0)),
         )
+
+    @staticmethod
+    def _user_from_inbox_tray_item(item: Dict, user_id: str) -> Dict:
+        users = (item.get("pog_info") or {}).get("pog_users") or []
+        for user in users:
+            if str(user.get("id") or user.get("pk")) == str(user_id):
+                return user
+        return users[0] if users else {}
+
+    @classmethod
+    def _note_dict_from_inbox_tray_item(cls, item: Dict) -> Dict:
+        note_dict = dict(item.get("note_dict") or {})
+        if not note_dict:
+            return {}
+        note_dict.setdefault("note_id", item.get("inbox_tray_item_id") or item.get("id"))
+        author = note_dict.get("author") or {}
+        user_id = str(note_dict.get("author_id") or author.get("pk") or author.get("id") or "")
+        if not author:
+            user = cls._user_from_inbox_tray_item(item, user_id)
+            if user:
+                note_dict["author"] = {
+                    "pk": user.get("pk") or user.get("id"),
+                    "username": user.get("username"),
+                    "full_name": user.get("full_name") or "",
+                    "profile_pic_url": user.get("profile_pic_url"),
+                    "is_private": user.get("is_private"),
+                }
+        return note_dict
 
     @staticmethod
     def _note_dict_from_create_inbox_tray_item(result: Dict) -> Dict:
@@ -54,6 +91,13 @@ class NoteMixin:
                     return note_dict
         raise ClientGraphqlError("Failed to create music Note")
 
+    @staticmethod
+    def _inbox_tray_from_graphql_result(result: Dict) -> Dict:
+        for payload in (result.get("data") or {}).values():
+            if isinstance(payload, dict) and "inbox_tray_items" in payload:
+                return payload
+        raise ClientGraphqlError("Failed to retrieve Notes in Direct")
+
     def get_notes(self) -> List[Note]:
         """
         Retrieves Notes in Direct
@@ -63,12 +107,31 @@ class NoteMixin:
         List[Notes]
             List of all the Notes in Direct
         """
-        result = self.private_request("notes/get_notes/")
-        assert result.get("status", "") == "ok", "Failed to retrieve Notes in Direct"
+        result = self.private_graphql_query_request(
+            friendly_name=INBOX_TRAY_FRIENDLY_NAME,
+            root_field_name=INBOX_TRAY_ROOT_FIELD,
+            variables={
+                "should_fetch_friend_map_user": True,
+                "should_fetch_friend_map_entrypoint": False,
+                "should_fetch_comment_info": False,
+                "request": {
+                    "include_quicksnap_pog": False,
+                    "include_friend_map_pog": False,
+                    "inbox_tray_item_ids_on_client": [],
+                },
+                "is_saved_media_on_map_enabled": False,
+                "is_location_likes_v2_enabled": True,
+            },
+            client_doc_id=INBOX_TRAY_CLIENT_DOC_ID,
+            priority="u=3, i",
+        )
+        inbox_tray = self._inbox_tray_from_graphql_result(result)
 
         notes = []
-        for item in result.get("items", []):
-            notes.append(Note(**item))
+        for item in inbox_tray.get("inbox_tray_items") or []:
+            note_dict = self._note_dict_from_inbox_tray_item(item)
+            if note_dict:
+                notes.append(self._note_from_note_dict(note_dict))
         return notes
 
     def get_note_by_user(self, notes: List[Note], username: str) -> Optional[Note]:

--- a/tests/live/test_notes.py
+++ b/tests/live/test_notes.py
@@ -61,6 +61,8 @@ class ClientNoteLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(note.id)
             self.assertEqual(note.audience, 0)
             self.assertEqual(note.note_style, 1)
+            notes = self.cl.get_notes()
+            self.assertIn(str(note.id), {str(item.id) for item in notes})
         finally:
             if note:
                 try:

--- a/tests/regression/test_notes.py
+++ b/tests/regression/test_notes.py
@@ -45,6 +45,76 @@ class NoteMixinRegressionTestCase(unittest.TestCase):
         )
         self.assertEqual(result, expected)
 
+    def test_get_notes_uses_inbox_tray_graphql_items(self):
+        client = Client()
+        graphql_response = {
+            "data": {
+                "__typename": "XDTGetInboxTrayItemsResponse",
+                "1$xdt_get_inbox_tray_items(request:$request)": {
+                    "inbox_tray_items": [
+                        {
+                            "inbox_tray_item_id": "18072502430410984",
+                            "note_dict": {
+                                "text": "hello from notes",
+                                "author_id": "123",
+                                "audience": 0,
+                                "created_at": 1710000000,
+                                "is_emoji_only": False,
+                                "note_style": 0,
+                            },
+                            "pog_info": {
+                                "pog_users": [
+                                    {
+                                        "id": "123",
+                                        "username": "example",
+                                        "full_name": "Example User",
+                                        "profile_pic_url": "https://example.com/p.jpg",
+                                        "is_private": False,
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
+            }
+        }
+
+        with (
+            mock.patch.object(client, "private_request") as private_request,
+            mock.patch.object(client, "private_graphql_query_request", return_value=graphql_response) as graphql_query,
+        ):
+            notes = client.get_notes()
+
+        private_request.assert_not_called()
+        graphql_query.assert_called_once_with(
+            friendly_name="InboxTrayRequest",
+            root_field_name="xdt_get_inbox_tray_items",
+            variables={
+                "should_fetch_friend_map_user": True,
+                "should_fetch_friend_map_entrypoint": False,
+                "should_fetch_comment_info": False,
+                "request": {
+                    "include_quicksnap_pog": False,
+                    "include_friend_map_pog": False,
+                    "inbox_tray_item_ids_on_client": [],
+                },
+                "is_saved_media_on_map_enabled": False,
+                "is_location_likes_v2_enabled": True,
+            },
+            client_doc_id="26838444193647008103482058049",
+            priority="u=3, i",
+        )
+        self.assertEqual(len(notes), 1)
+        note = notes[0]
+        self.assertEqual(note.id, "18072502430410984")
+        self.assertEqual(note.text, "hello from notes")
+        self.assertEqual(note.user_id, "123")
+        self.assertEqual(note.user.pk, "123")
+        self.assertEqual(note.user.username, "example")
+        self.assertEqual(note.user.full_name, "Example User")
+        self.assertEqual(note.created_at, datetime(2024, 3, 9, 16, 0, tzinfo=UTC()))
+        self.assertEqual(note.expires_at, datetime(2024, 3, 10, 16, 0, tzinfo=UTC()))
+
     def test_create_music_note_uses_create_inbox_tray_item_graphql_payload(self):
         client = Client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
Summary
- switch Client.get_notes() from retired notes/get_notes/ REST endpoint to current InboxTrayRequest GraphQL tray
- parse current inbox_tray_items/note_dict response shape, including author data from pog_info and missing expires_at fallback
- cover get_notes() with regression tests and read back created Notes in live coverage

Verification
- pytest -q tests/regression -> 531 passed, 3 skipped, 7 subtests passed
- live Notes target with a live test account -> 1 passed
- ruff check .
- ruff format --check .
- bandit -c pyproject.toml -r instagrapi -> no issues
- python -m build -> success

Fixes https://github.com/subzeroid/instagrapi/issues/2627