### PR TITLE
Treat pending follow requests as follow success

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -14,7 +14,7 @@ View a list of a user's medias, following and followers
 | user_info_by_username(username: str)          | User                  | Get user info by username                                    |
 | user_about_v1(user_id: str)                   | About                 | Get "About this account" info                                |
 | user_guides_v1(user_id: int)                  | List[Guide]           | Get user's guides                                            |
-| user_follow(user_id: str)                     | bool                  | Follow user                                                  |
+| user_follow(user_id: str)                     | bool                  | Follow user, or request to follow a private user             |
 | user_unfollow(user_id: str)                   | bool                  | Unfollow user                                                |
 | user_follow_requests(amount: int = 0)         | List[UserShort]       | Get pending incoming follow requests                         |
 | user_follow_request_approve(user_id: str)     | bool                  | Approve a pending incoming follow request                    |
@@ -85,6 +85,8 @@ Low level methods:
 
 The batch follow request helpers call the single-user approve/decline endpoints for
 each `user_id`; they do not implement an auto-approval policy.
+
+`user_follow()` returns `True` when Instagram reports either an immediate follow or an outgoing follow request for a private account. Use `user_friendship_v1()` when you need to distinguish `following` from `outgoing_request`.
 
 Example:
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1339,7 +1339,8 @@ class UserMixin:
         result = self.private_request(f"friendships/create/{user_id}/", data)
         if self.user_id in self._users_following:
             self._users_following.pop(self.user_id)  # reset
-        return result["friendship_status"]["following"] is True
+        friendship_status = result["friendship_status"]
+        return friendship_status.get("following") is True or friendship_status.get("outgoing_request") is True
 
     def user_unfollow(self, user_id: str) -> bool:
         """

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -398,6 +398,21 @@ class ClientUserExtendTestCase(_helpers.ClientPrivateTestCase):
 
 
 class ClientFollowRequestLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for follow request live tests")
+        try:
+            self.cl = self.fresh_account()
+        except Exception as exc:
+            self.skipTest(str(exc))
+
     def wait_for_pending_user_ids(self, client, expected_user_ids, timeout=30):
         expected_user_ids = {str(user_id) for user_id in expected_user_ids}
         deadline = time.time() + timeout
@@ -447,9 +462,31 @@ class ClientFollowRequestLiveTestCase(_helpers.ClientPrivateTestCase):
         except Exception as exc:
             print(f"Follow request live cleanup account_set_public failed: {exc.__class__.__name__} {exc}")
 
+    def test_user_follow_private_account_returns_true_for_pending_request_live(self):
+        target = self.cl
+        try:
+            requester = self.fresh_accounts(1, exclude_user_ids={target.user_id})[0]
+        except Exception as exc:
+            self.skipTest(str(exc))
+
+        try:
+            self.assertTrue(target.account_set_private())
+
+            self.assertTrue(requester.user_follow(target.user_id))
+            self.wait_for_friendship(
+                requester,
+                target.user_id,
+                lambda relationship: relationship.following is False and relationship.outgoing_request is True,
+            )
+        finally:
+            self.cleanup_follow_request_live_clients(target, [requester])
+
     def test_follow_request_helpers_live(self):
         target = self.cl
-        requesters = self.fresh_accounts(4, exclude_user_ids={target.user_id})
+        try:
+            requesters = self.fresh_accounts(4, exclude_user_ids={target.user_id})
+        except Exception as exc:
+            self.skipTest(str(exc))
         single_approve, single_decline, batch_approve, batch_decline = requesters
         requester_ids = [str(requester.user_id) for requester in requesters]
 
@@ -457,7 +494,7 @@ class ClientFollowRequestLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(target.account_set_private())
 
             for requester in requesters:
-                requester.user_follow(target.user_id)
+                self.assertTrue(requester.user_follow(target.user_id))
 
             pending = self.wait_for_pending_user_ids(target, requester_ids)
             pending_ids = {user.pk for user in pending}

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -853,6 +853,16 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["include_follow_friction_check"], "1")
         self.assertEqual(data["container_module"], "profile")
 
+    def test_user_follow_returns_true_for_pending_private_follow_request(self):
+        client = self.build_private_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"friendship_status": {"following": False, "outgoing_request": True}},
+        ):
+            self.assertTrue(client.user_follow("42"))
+
     def test_user_unfollow_posts_current_action_context(self):
         client = self.build_private_client()
         client.android_device_id = "android-device"


### PR DESCRIPTION
## Summary
- return `True` from `user_follow()` when Instagram accepts an outgoing follow request for a private account
- document that callers can use `user_friendship_v1()` to distinguish `following` from `outgoing_request`
- add regression coverage and a focused live check for the private-account pending-request path

Fixes https://github.com/subzeroid/instagrapi/issues/1156

## Verification
- `pytest -q tests/regression/test_user.py::UserMixinRegressionTestCase::test_user_follow_returns_true_for_pending_private_follow_request` failed before the implementation and passes after it
- `pytest -q tests/regression/test_user.py`
- `ruff check .`
- `ruff format --check .`
- `mkdocs build --strict`
- `bandit -c pyproject.toml -r instagrapi`
- `python -m build`

A targeted live check was attempted in an isolated test clone, but no usable live session was available, so the live assertion was skipped before exercising this path.
