### PR TITLE
Clamp Reel music audio window

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -886,11 +886,19 @@ class UploadClipMixin:
             video = VideoFileClip(str(path))
             audio_clip = AudioFileClip(str(tmpaudio))
             # set the start time of the audio and create the actual media
+            video_duration = float(video.duration)
             start = highlight_start_time / 1000
-            end = highlight_start_time / 1000 + video.duration
+            end = start + video_duration
+            audio_duration = getattr(audio_clip, "duration", None)
+            if audio_duration:
+                audio_duration = float(audio_duration)
+                if end > audio_duration:
+                    start = max(0.0, audio_duration - video_duration)
+                    end = audio_duration
             audio_clip = audio_clip.subclipped(start, end)
             video = video.with_audio(audio_clip)
-            video_duration = video.duration
+            audio_asset_start_time = int(start * 1000)
+            overlap_duration = int((end - start) * 1000)
             # save the media in tmp folder
             tmpvideo = Path(_make_tmp_path(".mp4"))
             video.write_videofile(str(tmpvideo))
@@ -898,8 +906,8 @@ class UploadClipMixin:
             data = self.clip_music_extra_data(
                 track,
                 extra_data=extra_data,
-                audio_asset_start_time=highlight_start_time,
-                overlap_duration=int(video_duration * 1000),
+                audio_asset_start_time=audio_asset_start_time,
+                overlap_duration=overlap_duration,
                 original_volume=0.0,
             )
             return self.clip_upload(tmpvideo, caption, extra_data=data)

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1570,6 +1570,76 @@ class UploadRegressionTestCase(unittest.TestCase):
             "canonical-id",
         )
 
+    def test_clip_upload_as_reel_with_music_keeps_audio_window_inside_track(self):
+        client = self.build_client()
+        track = Mock(
+            uri="https://example.com/track.m4a",
+            highlight_start_times_in_ms=[173000],
+            display_artist="Artist",
+            id="track-id",
+            audio_cluster_id="cluster-id",
+            title="Track title",
+        )
+        audio_segments = []
+
+        class FakeAudioClip:
+            def __init__(self, path):
+                self.path = path
+                self.duration = 174.0
+
+            def subclipped(self, start, end):
+                if end > self.duration:
+                    raise OSError(f"end {end} exceeds audio duration {self.duration}")
+                audio_segments.append((start, end))
+                return self
+
+            def close(self):
+                return None
+
+        class FakeVideoClip:
+            def __init__(self, path):
+                self.path = path
+                self.duration = 2.5
+
+            def with_audio(self, audio_clip):
+                self.audio_clip = audio_clip
+                return self
+
+            def write_videofile(self, path):
+                Path(path).write_bytes(b"video")
+
+            def close(self):
+                return None
+
+        fake_mp = types.ModuleType("moviepy")
+        fake_mp.VideoFileClip = FakeVideoClip
+        fake_mp.AudioFileClip = FakeAudioClip
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = Path(tmpdir) / "track.m4a"
+            audio_path.write_bytes(b"audio")
+            video_path = Path(tmpdir) / "output.mp4"
+            with mock.patch.dict(
+                "sys.modules",
+                {
+                    "moviepy": fake_mp,
+                },
+            ):
+                with mock.patch("tempfile.mktemp", side_effect=[str(audio_path), str(video_path)]):
+                    with mock.patch.object(client, "track_download_by_url", return_value=audio_path):
+                        with mock.patch.object(client, "clip_upload", return_value="uploaded") as clip_upload:
+                            result = client.clip_upload_as_reel_with_music(
+                                Path("input.mp4"),
+                                "caption",
+                                track,
+                            )
+
+        self.assertEqual(result, "uploaded")
+        self.assertEqual(audio_segments, [(171.5, 174.0)])
+        upload_extra = clip_upload.call_args.kwargs["extra_data"]
+        self.assertEqual(upload_extra["music_params"]["audio_asset_start_time_in_ms"], 171500)
+        self.assertEqual(upload_extra["music_params"]["overlap_duration_in_ms"], 2500)
+
     def test_clip_upload_as_reel_with_music_cleans_temp_files_on_failure(self):
         client = self.build_client()
         track = Mock(


### PR DESCRIPTION
## Summary
- keep the MoviePy audio slice for `clip_upload_as_reel_with_music()` inside the downloaded track duration
- when the preferred highlight starts too close to the end of the track, shift the slice earlier so it still covers the video duration
- keep `music_params.audio_asset_start_time_in_ms` and `overlap_duration_in_ms` aligned with the actual burned-in audio slice

Fixes https://github.com/subzeroid/instagrapi/issues/1613

## Testing
- RED: `pytest -q tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_upload_as_reel_with_music_keeps_audio_window_inside_track` failed with `OSError: end 175.5 exceeds audio duration 174.0`
- GREEN: `pytest -q tests/regression/test_upload.py::UploadRegressionTestCase::test_clip_upload_as_reel_with_music_keeps_audio_window_inside_track`
- `pytest -q tests/regression/test_upload.py`
- `pytest -q tests/regression`
- `ruff check .`
- `ruff format --check .`
- isolated remote regression target passed
- targeted live upload check was attempted in an isolated clone, but no usable live account session was available before upload