### PR TITLE
Fix private video count aliases

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -79,7 +79,8 @@ def extract_media_v1(data):
     media["like_count"] = media.get("like_count", 0)
     media["has_liked"] = media.get("has_liked", False)
     media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags") or []]
-    media["play_count"] = media.get("play_count", 0)
+    media["view_count"] = media.get("view_count", media.get("video_view_count", 0))
+    media["play_count"] = media.get("play_count", media.get("video_play_count", 0))
     media["coauthor_producers"] = media.get("coauthor_producers", [])
     return Media(
         caption_text=(media.get("caption") or {}).get("text", ""),

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -42,6 +42,22 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         payload.update(overrides)
         return payload
 
+    def test_extract_media_v1_normalizes_video_view_count(self):
+        payload = self._media_or_ad_payload()
+        payload.update(
+            {
+                "media_type": 2,
+                "product_type": "clips",
+                "video_view_count": 1234,
+                "video_play_count": 5678,
+            }
+        )
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(media.view_count, 1234)
+        self.assertEqual(media.play_count, 5678)
+
     def test_media_info_v2_strips_userid_suffix(self):
         client = Client()
         with mock.patch.object(


### PR DESCRIPTION
## Summary
- Normalize Private API `video_view_count` into `Media.view_count`.
- Normalize Private API `video_play_count` into `Media.play_count`.
- Add regression coverage for private video count aliases.

Fixes https://github.com/subzeroid/instagrapi/issues/1620

## Tests
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/bandit -c pyproject.toml -r instagrapi`
- `.venv/bin/mkdocs build --strict`
- Remote clean-clone targeted regression: passed
- Targeted live media video check was attempted in an isolated clone, but the live account pool did not return a usable fresh account before the media request.