### PR TITLE
Use media_info_gql in media count alias live test

### DIFF
--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -1,5 +1,4 @@
-from instagrapi.extractors import extract_media_gql
-from instagrapi.mixins.media import MEDIA_INFO_DOC_ID
+from instagrapi.exceptions import ClientForbiddenError
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -267,23 +266,35 @@ class ClientMediaCountAliasLiveTestCase(unittest.TestCase):
         except RuntimeError as exc:
             self.skipTest(str(exc))
 
-    def test_extract_media_gql_normalizes_live_video_count_aliases(self):
+    def test_media_info_gql_normalizes_live_video_count_aliases(self):
         code = "C_BM2yAN4Rm"
-        result = self.cl.public_doc_id_graphql_request(
-            MEDIA_INFO_DOC_ID,
-            {"shortcode": code},
-            referer=f"https://www.instagram.com/p/{code}/",
-        )
-        payload = result.get("xdt_shortcode_media") or result.get("shortcode_media")
-        self.assertTrue(payload, f"public doc_id media payload was empty: {result}")
-        self.assertIn(payload.get("__typename"), {"GraphVideo", "XDTGraphVideo"})
-        self.assertIn("video_view_count", payload)
-        self.assertIn("video_play_count", payload)
+        media_pk = self.cl.media_pk_from_code(code)
+        captured_payload = {}
+        original_doc_id_request = self.cl.public_doc_id_graphql_request
 
-        media = extract_media_gql(payload)
+        def capture_doc_id_payload(*args, **kwargs):
+            result = original_doc_id_request(*args, **kwargs)
+            payload = result.get("xdt_shortcode_media") or result.get("shortcode_media")
+            if payload:
+                captured_payload.update(payload)
+            return result
 
-        self.assertEqual(media.view_count, payload["video_view_count"])
-        self.assertEqual(media.play_count, payload["video_play_count"])
+        with (
+            mock.patch.object(
+                self.cl,
+                "public_graphql_request",
+                side_effect=ClientForbiddenError("force doc_id media fallback"),
+            ),
+            mock.patch.object(self.cl, "public_doc_id_graphql_request", side_effect=capture_doc_id_payload),
+        ):
+            media = self.cl.media_info_gql(media_pk)
+
+        self.assertTrue(captured_payload, "public doc_id media payload was empty")
+        self.assertIn(captured_payload.get("__typename"), {"GraphVideo", "XDTGraphVideo"})
+        self.assertIn("video_view_count", captured_payload)
+        self.assertIn("video_play_count", captured_payload)
+        self.assertEqual(media.view_count, captured_payload["video_view_count"])
+        self.assertEqual(media.play_count, captured_payload["video_play_count"])
 
 
 class ClientExtractTestCase(_helpers.ClientPrivateTestCase):


### PR DESCRIPTION
## Summary
- Update the live coverage for https://github.com/subzeroid/instagrapi/issues/1620 to exercise the public `media_info_gql(...)` helper.
- Keep the raw doc_id payload only as test instrumentation, so the test still proves Instagram returns `video_view_count` / `video_play_count` before extraction.
- Avoid presenting `MEDIA_INFO_DOC_ID` / referer wiring as the user-facing path.

## Verification
- `ruff check tests/live/test_media.py`
- `ruff format --check tests/live/test_media.py`
- `TEST_ACCOUNTS_URL= .venv/bin/python -m pytest -q -rs tests/live/test_media.py::ClientMediaCountAliasLiveTestCase::test_media_info_gql_normalizes_live_video_count_aliases` -> `1 skipped`
- Targeted live run with account pool -> `1 passed, 1 warning in 15.94s`

## Mirror
- Codeberg branch: https://codeberg.org/subzeroid/instagrapi/compare/master...test/media-info-gql-live-helper
