### PR TITLE
Name user doc_id constants

### DIFF
--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -31,6 +31,8 @@ MAX_USER_COUNT = 200
 INFO_FROM_MODULES = ("self_profile", "feed_timeline", "reel_feed_timeline")
 FOLLOWERS_ORDERS = ("date_followed_latest", "date_followed_earliest")
 USER_WEB_PROFILE_DOC_ID = "26762473490008061"
+USER_INFO_V2_DOC_ID = "25980296051578533"
+USER_INFO_BY_USERNAME_V2_DOC_ID = "26347858941511777"
 
 logger = logging.getLogger(__name__)
 
@@ -285,7 +287,7 @@ class UserMixin:
             "__relay_internal__pv__PolarisRepostsConsumptionEnabledrelayprovider": False,
         }
         self._inject_sessionid_for_v2_gql()
-        data = self.public_doc_id_graphql_request("25980296051578533", variables)
+        data = self.public_doc_id_graphql_request(USER_INFO_V2_DOC_ID, variables)
         user_data = (data or {}).get("user")
         if user_data is None:
             raise UserNotFound("User not found", user_id=user_id)
@@ -297,7 +299,9 @@ class UserMixin:
         """
         username = self._normalize_username(username)
         self._inject_sessionid_for_v2_gql()
-        data = self.public_doc_id_graphql_request("26347858941511777", {"hasQuery": True, "query": username})
+        data = self.public_doc_id_graphql_request(
+            USER_INFO_BY_USERNAME_V2_DOC_ID, {"hasQuery": True, "query": username}
+        )
         users = ((data or {}).get("xdt_api__v1__fbsearch__non_profiled_serp") or {}).get("users") or []
         for user in users:
             if (user.get("username") or "").lower() == username:

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1,5 +1,9 @@
 from instagrapi.extractors import extract_user_short, extract_user_v1
-from instagrapi.mixins.user import MAX_USER_COUNT
+from instagrapi.mixins.user import (
+    MAX_USER_COUNT,
+    USER_INFO_BY_USERNAME_V2_DOC_ID,
+    USER_INFO_V2_DOC_ID,
+)
 from tests.helpers import *
 
 
@@ -416,7 +420,7 @@ class UserMixinRegressionTestCase(unittest.TestCase):
                     result = client.user_info_by_username_v2_gql(" @Example ")
 
         self.assertEqual(result, "user")
-        search.assert_called_once_with("26347858941511777", {"hasQuery": True, "query": "example"})
+        search.assert_called_once_with(USER_INFO_BY_USERNAME_V2_DOC_ID, {"hasQuery": True, "query": "example"})
 
     def test_user_stream_by_username_v1_normalizes_endpoint(self):
         client = Client()
@@ -1106,7 +1110,7 @@ class UserMixinRegressionTestCase(unittest.TestCase):
 
         inject.assert_called_once_with()
         gql.assert_called_once()
-        self.assertEqual(gql.call_args.args[0], "25980296051578533")
+        self.assertEqual(gql.call_args.args[0], USER_INFO_V2_DOC_ID)
         self.assertEqual(gql.call_args.args[1]["id"], "25025320")
         self.assertEqual(user.pk, "25025320")
 
@@ -1124,7 +1128,7 @@ class UserMixinRegressionTestCase(unittest.TestCase):
                     result = client.user_info_by_username_v2_gql("Example")
 
         self.assertEqual(result, "user")
-        search.assert_called_once_with("26347858941511777", {"hasQuery": True, "query": "example"})
+        search.assert_called_once_with(USER_INFO_BY_USERNAME_V2_DOC_ID, {"hasQuery": True, "query": "example"})
         profile.assert_called_once_with("123")
 
     def test_user_about_v1_calls_bloks_action_and_extracts_last_json(self):


### PR DESCRIPTION
## Summary
- Add named constants for the user v2 profile and username-search doc_ids.
- Replace hardcoded `public_doc_id_graphql_request(...)` doc_id literals in user helpers.
- Update regression expectations to use the same constants.

## Verification
- `ruff check instagrapi/mixins/user.py tests/regression/test_user.py`
- `ruff format --check instagrapi/mixins/user.py tests/regression/test_user.py`
- `pytest -q tests/regression/test_user.py` -> `80 passed`
- Targeted regression run on remote test host -> `80 passed`

## Mirror
- Codeberg branch: https://codeberg.org/subzeroid/instagrapi/compare/master...chore/user-doc-id-constants
