### PR TITLE
Add Reel mashup info helper

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -53,6 +53,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_pin(media_pk: str) | bool | Pin media to profile |
 | media_unpin(media_pk: str) | bool | Unpin media from profile |
 | media_template_v1(media_id: str) | dict | Fetch a clip template payload for a Reel/clip media |
+| clip_mashup_info(media_pk: str) | dict | Fetch Reel remix/reuse availability metadata |
 | clip_pin(media_pk: str) | bool | Pin Reel to the Reels tab/profile Reels grid |
 | clip_unpin(media_pk: str) | bool | Unpin Reel from the Reels tab/profile Reels grid |
 | clip_change_cover(media_pk: str, cover_path: Path) | bool | Change the cover image for a published Reel |

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -94,6 +94,30 @@ class ClipMixin:
             response_text=response_text,
         )
 
+    def clip_mashup_info(self, media_pk: str) -> Dict:
+        """
+        Fetch Reel remix/reuse availability metadata.
+
+        Parameters
+        ----------
+        media_pk: str
+            PK for the Reel
+
+        Returns
+        -------
+        Dict
+            A dictionary of response from the call
+        """
+        assert self.user_id, "Login required"
+        return self.private_request(
+            "clips/get_mashup_info_for_media/",
+            data={
+                "media_id": str(media_pk),
+                "_uid": str(self.user_id),
+                "_uuid": self.uuid,
+            },
+        )
+
     def clip_pin(self, media_pk: str, revert: bool = False) -> bool:
         """
         Pin Reel to the Reels tab/profile Reels grid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.9.15"
+version = "2.9.16"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_public.py
+++ b/tests/live/test_public.py
@@ -43,3 +43,27 @@ class ClientPublicTestCase(_helpers.ClientPrivateTestCase):
         self.assertGreaterEqual(m.like_count, -1)
         self.assertTrue(m.thumbnail_url)
         self.assertTrue(m.video_url)
+
+
+class ClientClipMashupInfoLiveTestCase(unittest.TestCase):
+    def live_client(self):
+        if not _helpers.TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for clip mashup info live tests")
+        last_error = None
+        for account in _helpers.fetch_test_accounts(count=20):
+            try:
+                return _helpers.client_from_test_account(account)
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
+        self.skipTest(f"Could not login with any test account: {last_error}")
+
+    def test_clip_mashup_info_live(self):
+        cl = self.live_client()
+        media_pk = cl.media_pk_from_url("https://www.instagram.com/p/C_BM2yAN4Rm/")
+        result = cl.clip_mashup_info(media_pk)
+
+        self.assertEqual(result.get("status"), "ok")
+        mashup_info = result.get("mashup_info")
+        self.assertIsInstance(mashup_info, dict)
+        self.assertIn("is_reuse_allowed", mashup_info)
+        self.assertIn("mashups_allowed", mashup_info)

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -20,6 +20,31 @@ class ClipPinRegressionTestCase(unittest.TestCase):
         self.assertEqual(device_status["chip_vendor"], "others")
         self.assertFalse(device_status["hw_av1_dec"])
 
+    def test_clip_mashup_info_posts_media_id_and_identity(self):
+        client = Client()
+        client.private.cookies.set("ds_user_id", "29060001803")
+        client.uuid = "uuid"
+        expected = {
+            "mashup_info": {
+                "is_reuse_allowed": True,
+                "mashups_allowed": True,
+            },
+            "status": "ok",
+        }
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.clip_mashup_info("3894040329476845448")
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "clips/get_mashup_info_for_media/",
+            data={
+                "media_id": "3894040329476845448",
+                "_uid": "29060001803",
+                "_uuid": "uuid",
+            },
+        )
+
     def test_clip_pin_uses_reels_grid_payload(self):
         client = Client()
         with mock.patch.object(


### PR DESCRIPTION
## Summary
- Added `Client.clip_mashup_info(media_pk)` for Instagram's `clips/get_mashup_info_for_media/` Reel remix/reuse metadata endpoint.
- Documented the helper and added regression coverage for the captured Android payload shape.
- Added a read-only live test against a public Reel and bumped the package to `2.9.16`.

Refs https://github.com/subzeroid/instagrapi/issues/1759

## Tests
- `.venv/bin/python -m ruff check instagrapi/mixins/clip.py tests/regression/test_clip.py tests/live/test_public.py`
- `.venv/bin/python -m pytest -q tests/regression/test_clip.py::ClipPinRegressionTestCase`
- `.venv/bin/python -m pytest -q tests/live/test_public.py::ClientClipMashupInfoLiveTestCase::test_clip_mashup_info_live`
- `.venv/bin/python -m build`