### PR TITLE
v2.9.17 feat: add bookmarked music helper

### DIFF
--- a/docs/usage-guide/track.md
+++ b/docs/usage-guide/track.md
@@ -17,6 +17,7 @@ Viewing and downloading tracks
 | music_clips_audio_browser(product: str = "story_camera_clips_v2", browse_session_id: str = None) | dict | Browse music candidates for the Reels/Clips camera |
 | music_verify_original_audio_title(original_audio_name: str) | bool | Validate an original audio title for Reels publishing |
 | music_bookmark(original_audio_id: str, surface_requested_from: str = "audio_aggregation_page") | bool | Bookmark an original audio track |
+| music_bookmarked(max_id: str = "") | dict | Retrieve bookmarked music tracks |
 
 ### Example:
 

--- a/instagrapi/mixins/track.py
+++ b/instagrapi/mixins/track.py
@@ -252,6 +252,29 @@ class TrackMixin:
         )
         return bool(result.get("success")) or result.get("status") == "ok"
 
+    def music_bookmarked(self, max_id: str = "") -> Dict:
+        """
+        Retrieve bookmarked music tracks.
+
+        Parameters
+        ----------
+        max_id: str, optional
+            Pagination cursor.
+
+        Returns
+        -------
+        Dict
+            Raw response from ``music/playlist/bookmarked/``.
+        """
+        data = {"_uuid": self.uuid}
+        if max_id:
+            data["max_id"] = max_id
+        return self.private_request(
+            "music/playlist/bookmarked/",
+            data=data,
+            with_signature=False,
+        )
+
     def music_clips_audio_browser(
         self,
         product: str = "story_camera_clips_v2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.9.16"
+version = "2.9.17"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_track.py
+++ b/tests/live/test_track.py
@@ -10,10 +10,14 @@ class ClientTrackLiveTestCase(_helpers.ClientPrivateTestCase):
     def setUp(self):
         if not TEST_ACCOUNTS_URL:
             self.skipTest("TEST_ACCOUNTS_URL is required for Track live tests")
-        try:
-            self.cl = self.fresh_account()
-        except RuntimeError as exc:
-            self.skipTest(str(exc))
+        last_error = None
+        for account in _helpers.fetch_test_accounts(count=20):
+            try:
+                self.cl = _helpers.client_from_test_account(account)
+                return
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
+        self.skipTest(f"Could not login with any test account: {last_error}")
 
     def test_music_app_surfaces_live(self):
         self.assertTrue(self.cl.music_verify_original_audio_title("Original Audio"))
@@ -21,6 +25,10 @@ class ClientTrackLiveTestCase(_helpers.ClientPrivateTestCase):
         trending = self.cl.music_trending()
         self.assertEqual(trending.get("status"), "ok")
         self.assertIsInstance(trending.get("items"), list)
+
+        bookmarked = self.cl.music_bookmarked()
+        self.assertEqual(bookmarked.get("status"), "ok")
+        self.assertIsInstance(bookmarked.get("items"), list)
 
         search = self.cl.music_search_v2("love")
         self.assertEqual(search.get("status"), "ok")

--- a/tests/regression/test_track.py
+++ b/tests/regression/test_track.py
@@ -93,6 +93,33 @@ class TrackMixinRegressionTestCase(unittest.TestCase):
             with_signature=False,
         )
 
+    def test_music_bookmarked_posts_empty_payload_by_default(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"items": [], "status": "ok"}) as private:
+            result = client.music_bookmarked()
+
+        self.assertEqual(result, {"items": [], "status": "ok"})
+        private.assert_called_once_with(
+            "music/playlist/bookmarked/",
+            data={"_uuid": "uuid-1"},
+            with_signature=False,
+        )
+
+    def test_music_bookmarked_forwards_max_id(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(client, "private_request", return_value={"items": [], "status": "ok"}) as private:
+            client.music_bookmarked(max_id="cursor-1")
+
+        private.assert_called_once_with(
+            "music/playlist/bookmarked/",
+            data={"_uuid": "uuid-1", "max_id": "cursor-1"},
+            with_signature=False,
+        )
+
     def test_music_clips_audio_browser_posts_browse_session(self):
         client = Client()
         client.uuid = "uuid-1"


### PR DESCRIPTION
## Summary
- add `Client.music_bookmarked(max_id="")` for `music/playlist/bookmarked/`
- document the helper in the Track usage guide
- add regression coverage for endpoint/payload and live coverage for the music app surfaces
- bump package version to 2.9.17

Fixes https://github.com/subzeroid/instagrapi/issues/1561

## Verification
- ruff check targeted files
- pytest tests/regression/test_track.py -> 11 passed
- py_compile tests/live/test_track.py
- python -m build
- remote targeted regression + live track suite -> 12 passed