### PR TITLE
v2.9.18 feat: add address book suggestions helpers

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -38,6 +38,8 @@ View a list of a user's medias, following and followers
 | close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
 | user_suggested_profiles(user_id: str, expand_suggestion: bool = False) | dict | Suggested profiles ("Suggested for you") for a profile. Wraps `chaining` and, with `expand_suggestion=True`, returns the raw `fetch_suggestion_details` payload (`items` in current app responses) |
+| address_book_link(contacts: List[dict], include: str = "extra_display_name,thumbnails") | dict | Upload/link address book contacts and return Instagram's raw contact-based suggestions response |
+| address_book_unlink()                         | dict                  | Disconnect the uploaded address book from the current account |
 | chaining(user_id: str)                        | dict                  | Suggested users for a profile (`discover/chaining/`) — same surface as the app's "Suggested for you" carousel |
 | fetch_suggestion_details(user_id: str, chained_ids: str) | dict       | Expanded social-context fields for chained suggestion ids (`discover/fetch_suggestion_details/`) |
 | discover_recommended_accounts_for_category_v1(user_id: str) | dict | Business-category-similar accounts: extracts `category_id` from the target's stream payload, then calls `discover/recommended_accounts_for_category/` |

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1902,6 +1902,52 @@ class UserMixin:
             return chained
         return self.fetch_suggestion_details(user_id, chained_ids)
 
+    def address_book_link(self, contacts: List[dict], include: str = "extra_display_name,thumbnails") -> dict:
+        """
+        Upload/link address book contacts and return Instagram's raw suggestions response.
+
+        Parameters
+        ----------
+        contacts: List[dict]
+            Address book contacts in Instagram's mobile payload shape, for example
+            ``{"phone_numbers": [{"phone_number": "+15555550123"}],
+            "email_addresses": [], "first_name": "Test", "last_name": "Contact"}``.
+        include: str, optional
+            Optional response fields requested from Instagram. Defaults to
+            ``"extra_display_name,thumbnails"``.
+
+        Returns
+        -------
+        dict
+            Raw ``address_book/link/`` response, usually containing suggested users
+            when Instagram matches uploaded contacts.
+        """
+        data = {
+            "contacts": json.dumps(contacts, separators=(",", ":")),
+            "_uuid": self.uuid,
+        }
+        if self.user_id:
+            data["_uid"] = str(self.user_id)
+        return self.private_request(
+            "address_book/link/",
+            data=data,
+            params={"include": include} if include else None,
+        )
+
+    def address_book_unlink(self) -> dict:
+        """
+        Disconnect the uploaded address book from the current account.
+
+        Returns
+        -------
+        dict
+            Raw ``address_book/unlink/`` response.
+        """
+        return self.private_request(
+            "address_book/unlink/",
+            data={"_uuid": self.uuid},
+        )
+
     def user_stream_by_username_v1(self, username: str) -> dict:
         """
         Get the streamed profile envelope by username.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.9.17"
+version = "2.9.18"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -220,6 +220,39 @@ class ClientFollowingLiveTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(first_ids.isdisjoint(next_ids), f"Duplicate following across pages: {first_ids & next_ids}")
 
 
+class ClientAddressBookLiveTestCase(unittest.TestCase):
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for address book live tests")
+        last_exc = None
+        for acc in _helpers.fetch_test_accounts(count=20, timeout=30):
+            try:
+                settings = dict(acc["client_settings"])
+                settings.pop("totp_seed", None)
+                self.cl = Client(settings=settings, proxy=os.getenv("IG_PROXY") or acc.get("proxy"))
+                self.cl._user_id = acc.get("user_id")
+                self.cl.account_info()
+                return
+            except Exception as exc:
+                last_exc = exc
+        self.skipTest(f"No usable saved-session account returned: {last_exc}")
+
+    def test_address_book_link_returns_suggestions_payload_live(self):
+        contacts = [
+            {
+                "phone_numbers": [{"phone_number": "+15555550123"}],
+                "email_addresses": [],
+                "first_name": "Test",
+                "last_name": "Contact",
+            }
+        ]
+        self.addCleanup(self.cl.address_book_unlink)
+        result = self.cl.address_book_link(contacts)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get("status"), "ok")
+
+
 class ClientGraphQLQueryLiveTestCase(_helpers.ClientPrivateTestCase):
     def test_user_short_gql(self):
         user = self.cl.user_short_gql("25025320", use_cache=False)

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -983,6 +983,60 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(result, chained)
         fetch_details.assert_not_called()
 
+    def test_address_book_link_posts_contacts_payload(self):
+        client = Client()
+        client.uuid = "uuid"
+        client.authorization_data = {"ds_user_id": "123"}
+        contacts = [
+            {
+                "phone_numbers": [{"phone_number": "+15555550123"}],
+                "email_addresses": [],
+                "first_name": "Test",
+                "last_name": "Contact",
+            }
+        ]
+        expected = {"users": []}
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.address_book_link(contacts)
+
+        self.assertEqual(result, expected)
+        private_request.assert_called_once_with(
+            "address_book/link/",
+            data={
+                "contacts": json.dumps(contacts, separators=(",", ":")),
+                "_uuid": "uuid",
+                "_uid": "123",
+            },
+            params={"include": "extra_display_name,thumbnails"},
+        )
+
+    def test_address_book_link_allows_empty_include(self):
+        client = Client()
+        client.uuid = "uuid"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            client.address_book_link([], include="")
+
+        private_request.assert_called_once_with(
+            "address_book/link/",
+            data={"contacts": "[]", "_uuid": "uuid"},
+            params=None,
+        )
+
+    def test_address_book_unlink_posts_uuid(self):
+        client = Client()
+        client.uuid = "uuid"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.address_book_unlink()
+
+        self.assertEqual(result, {"status": "ok"})
+        private_request.assert_called_once_with(
+            "address_book/unlink/",
+            data={"_uuid": "uuid"},
+        )
+
     def test_user_stream_by_id_v1_sends_expected_endpoint_and_data(self):
         client = Client()
         with mock.patch.object(client, "private_request", return_value={"stream_rows": []}) as private_request:


### PR DESCRIPTION
Summary
- Add `Client.address_book_link(contacts, include="extra_display_name,thumbnails")` for Instagram contact-based suggestions.
- Add `Client.address_book_unlink()` cleanup helper.
- Document the helpers, bump to 2.9.18, and add regression plus targeted live coverage.

Refs https://github.com/subzeroid/instagrapi/issues/1537

Verification
- `.venv/bin/python -m ruff check instagrapi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`
- `.venv/bin/python -m pytest -q tests/regression/test_user.py` -> 83 passed
- `.venv/bin/python -m py_compile tests/live/test_user.py`
- `.venv/bin/python -m build`
- Targeted remote verification: `tests/regression/test_user.py` + `ClientAddressBookLiveTestCase::test_address_book_link_returns_suggestions_payload_live` -> 84 passed