### PR TITLE
Improve address book helper typing

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -38,7 +38,7 @@ View a list of a user's medias, following and followers
 | close_friend_add(user_id: str)                | bool                  | Add to Close Friends List                                    |
 | close_friend_remove(user_id: str)             | bool                  | Remove from Close Friends List                               |
 | user_suggested_profiles(user_id: str, expand_suggestion: bool = False) | dict | Suggested profiles ("Suggested for you") for a profile. Wraps `chaining` and, with `expand_suggestion=True`, returns the raw `fetch_suggestion_details` payload (`items` in current app responses) |
-| address_book_link(contacts: List[dict], include: str = "extra_display_name,thumbnails") | dict | Upload/link address book contacts and return Instagram's raw contact-based suggestions response |
+| address_book_link(contacts: List[AddressBookContact \| dict], include: Sequence[str] \| str = ("extra_display_name", "thumbnails")) | dict | Upload/link address book contacts and return Instagram's raw contact-based suggestions response |
 | address_book_unlink()                         | dict                  | Disconnect the uploaded address book from the current account |
 | chaining(user_id: str)                        | dict                  | Suggested users for a profile (`discover/chaining/`) — same surface as the app's "Suggested for you" carousel |
 | fetch_suggestion_details(user_id: str, chained_ids: str) | dict       | Expanded social-context fields for chained suggestion ids (`discover/fetch_suggestion_details/`) |

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -2,7 +2,7 @@ import json
 import logging
 from copy import deepcopy
 from json.decoder import JSONDecodeError
-from typing import Dict, List, Tuple
+from typing import Dict, List, Sequence, Tuple, Union
 
 from requests.exceptions import RequestException
 
@@ -24,7 +24,7 @@ from instagrapi.extractors import (
     extract_user_short,
     extract_user_v1,
 )
-from instagrapi.types import About, Guide, Relationship, RelationshipShort, User, UserShort
+from instagrapi.types import About, AddressBookContact, Guide, Relationship, RelationshipShort, User, UserShort
 from instagrapi.utils.serialization import dumps, json_value
 
 MAX_USER_COUNT = 200
@@ -33,6 +33,7 @@ FOLLOWERS_ORDERS = ("date_followed_latest", "date_followed_earliest")
 USER_WEB_PROFILE_DOC_ID = "26762473490008061"
 USER_INFO_V2_DOC_ID = "25980296051578533"
 USER_INFO_BY_USERNAME_V2_DOC_ID = "26347858941511777"
+ADDRESS_BOOK_DEFAULT_INCLUDE = ("extra_display_name", "thumbnails")
 
 logger = logging.getLogger(__name__)
 
@@ -1902,19 +1903,37 @@ class UserMixin:
             return chained
         return self.fetch_suggestion_details(user_id, chained_ids)
 
-    def address_book_link(self, contacts: List[dict], include: str = "extra_display_name,thumbnails") -> dict:
+    @staticmethod
+    def _serialize_address_book_contacts(contacts: List[Union[AddressBookContact, dict]]) -> List[dict]:
+        return [
+            contact.model_dump(exclude_none=True) if isinstance(contact, AddressBookContact) else contact
+            for contact in contacts
+        ]
+
+    @staticmethod
+    def _serialize_address_book_include(include: Union[str, Sequence[str]]) -> str:
+        if isinstance(include, str):
+            return include
+        return ",".join(str(field) for field in include)
+
+    def address_book_link(
+        self,
+        contacts: List[Union[AddressBookContact, dict]],
+        include: Union[str, Sequence[str]] = ADDRESS_BOOK_DEFAULT_INCLUDE,
+    ) -> dict:
         """
         Upload/link address book contacts and return Instagram's raw suggestions response.
 
         Parameters
         ----------
-        contacts: List[dict]
-            Address book contacts in Instagram's mobile payload shape, for example
+        contacts: List[AddressBookContact | dict]
+            Address book contacts as typed objects, or raw dictionaries in
+            Instagram's mobile payload shape, for example
             ``{"phone_numbers": [{"phone_number": "+15555550123"}],
             "email_addresses": [], "first_name": "Test", "last_name": "Contact"}``.
-        include: str, optional
+        include: Sequence[str] | str, optional
             Optional response fields requested from Instagram. Defaults to
-            ``"extra_display_name,thumbnails"``.
+            ``("extra_display_name", "thumbnails")``.
 
         Returns
         -------
@@ -1922,8 +1941,9 @@ class UserMixin:
             Raw ``address_book/link/`` response, usually containing suggested users
             when Instagram matches uploaded contacts.
         """
+        include_value = self._serialize_address_book_include(include)
         data = {
-            "contacts": json.dumps(contacts, separators=(",", ":")),
+            "contacts": json.dumps(self._serialize_address_book_contacts(contacts), separators=(",", ":")),
             "_uuid": self.uuid,
         }
         if self.user_id:
@@ -1931,7 +1951,7 @@ class UserMixin:
         return self.private_request(
             "address_book/link/",
             data=data,
-            params={"include": include} if include else None,
+            params={"include": include_value} if include_value else None,
         )
 
     def address_book_unlink(self) -> dict:

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Union
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     FilePath,
     HttpUrl,
     ValidationError,
@@ -104,6 +105,21 @@ class About(TypesBaseModel):
     country: Optional[str] = ""
     date: Optional[str] = ""
     former_usernames: Optional[str] = ""
+
+
+class AddressBookPhone(TypesBaseModel):
+    phone_number: str
+
+
+class AddressBookEmail(TypesBaseModel):
+    email_address: str
+
+
+class AddressBookContact(TypesBaseModel):
+    phone_numbers: List[AddressBookPhone] = Field(default_factory=list)
+    email_addresses: List[AddressBookEmail] = Field(default_factory=list)
+    first_name: str = ""
+    last_name: str = ""
 
 
 class Account(TypesBaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.9.18"
+version = "2.9.19"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1,3 +1,4 @@
+from instagrapi import types as ig_types
 from instagrapi.extractors import extract_user_short, extract_user_v1
 from instagrapi.mixins.user import (
     MAX_USER_COUNT,
@@ -1022,6 +1023,36 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             "address_book/link/",
             data={"contacts": "[]", "_uuid": "uuid"},
             params=None,
+        )
+
+    def test_address_book_link_accepts_typed_contacts_and_include_list(self):
+        client = Client()
+        client.uuid = "uuid"
+        contact = ig_types.AddressBookContact(
+            phone_numbers=[ig_types.AddressBookPhone(phone_number="+15555550123")],
+            email_addresses=[ig_types.AddressBookEmail(email_address="test@example.com")],
+            first_name="Test",
+            last_name="Contact",
+        )
+        expected_contacts = [
+            {
+                "phone_numbers": [{"phone_number": "+15555550123"}],
+                "email_addresses": [{"email_address": "test@example.com"}],
+                "first_name": "Test",
+                "last_name": "Contact",
+            }
+        ]
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            client.address_book_link([contact], include=["extra_display_name", "thumbnails"])
+
+        private_request.assert_called_once_with(
+            "address_book/link/",
+            data={
+                "contacts": json.dumps(expected_contacts, separators=(",", ":")),
+                "_uuid": "uuid",
+            },
+            params={"include": "extra_display_name,thumbnails"},
         )
 
     def test_address_book_unlink_posts_uuid(self):


### PR DESCRIPTION
## Summary
- add typed `AddressBookContact`, `AddressBookPhone`, and `AddressBookEmail` models
- allow `address_book_link(...)` to accept typed contacts or raw dicts
- allow `include` to be a sequence while preserving comma-separated string compatibility
- bump package version to 2.9.19

Follow-up to https://github.com/subzeroid/instagrapi/issues/1537.

## Verification
- `.venv/bin/python -m pytest -q tests/regression/test_user.py`
- `.venv/bin/python -m ruff check instagrapi/types.py instagrapi/mixins/user.py tests/regression/test_user.py docs/usage-guide/user.md`
- `.venv/bin/python -m py_compile tests/live/test_user.py`
- `.venv/bin/python -m build`
- clean-clone live verification: `85 passed` including `ClientAddressBookLiveTestCase::test_address_book_link_returns_suggestions_payload_live`