### PR TITLE
Normalize challenge API paths

### DIFF
--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -42,6 +42,14 @@ class ChallengeResolveMixin:
     Helpers for resolving login challenge
     """
 
+    @staticmethod
+    def _normalize_challenge_api_path(api_path: str) -> str:
+        if api_path.startswith("/api/v1/"):
+            return api_path[len("/api/v1") :]
+        if api_path.startswith("/api/"):
+            return api_path[len("/api") :]
+        return api_path
+
     def challenge_code_or_raised(self, choice: ChallengeChoice, wait_seconds: int = 5, attempts: int = 24) -> str:
         error_context = dict(self.last_json)
         error_context.pop("message", None)
@@ -72,7 +80,7 @@ class ChallengeResolveMixin:
             A boolean value
         """
         # START GET REQUEST to challenge_url
-        challenge_url = last_json["challenge"]["api_path"]
+        challenge_url = self._normalize_challenge_api_path(last_json["challenge"]["api_path"])
         if challenge_url.startswith("/auth_platform/"):
             last_json["message"] = (
                 "Manual verification required via Instagram auth platform flow. "
@@ -100,7 +108,7 @@ class ChallengeResolveMixin:
             # not enough values to unpack (expected 2, got 1)
             params = {}
         try:
-            self._send_private_request(challenge_url[1:], params=params)
+            self._send_private_request(challenge_url.lstrip("/"), params=params)
         except ChallengeRequired:
             assert self.last_json["message"] == "challenge_required", self.last_json
             return self.challenge_resolve_contact_form(challenge_url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.9.19"
+version = "2.10.0"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_challenge.py
+++ b/tests/regression/test_challenge.py
@@ -123,6 +123,42 @@ class ChallengeRegressionTestCase(unittest.TestCase):
         )
         resolve_simple.assert_called_once_with("/challenge/12345/nonce-code/")
 
+    def test_challenge_resolve_normalizes_prefixed_api_challenge_path(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-1"
+        last_json = {
+            "message": "challenge_required",
+            "challenge": {"api_path": "/api/challenge/12345/nonce-code/"},
+            "status": "fail",
+        }
+
+        with mock.patch.object(client, "_send_private_request") as send_request:
+            with mock.patch.object(client, "challenge_resolve_simple", return_value=True) as resolve_simple:
+                result = client.challenge_resolve(last_json)
+
+        self.assertTrue(result)
+        self.assertEqual(send_request.call_args.args[0], "challenge/12345/nonce-code/")
+        resolve_simple.assert_called_once_with("/challenge/12345/nonce-code/")
+
+    def test_challenge_resolve_normalizes_prefixed_api_v1_challenge_path(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-1"
+        last_json = {
+            "message": "challenge_required",
+            "challenge": {"api_path": "/api/v1/challenge/12345/nonce-code/"},
+            "status": "fail",
+        }
+
+        with mock.patch.object(client, "_send_private_request") as send_request:
+            with mock.patch.object(client, "challenge_resolve_simple", return_value=True) as resolve_simple:
+                result = client.challenge_resolve(last_json)
+
+        self.assertTrue(result)
+        self.assertEqual(send_request.call_args.args[0], "challenge/12345/nonce-code/")
+        resolve_simple.assert_called_once_with("/challenge/12345/nonce-code/")
+
     def test_challenge_resolve_falls_back_to_contact_form(self):
         client = Client()
         client.last_json = {"message": "challenge_required", "status": "fail"}


### PR DESCRIPTION
## Summary
- normalize challenge `api_path` values that already include `/api/` or `/api/v1/`
- prevent challenge resolution from requesting `/api/v1/api/challenge/...`
- keep the Bloks redirect checkpoint surfaced as a clear `ChallengeRequired` instead of falling through to `ChallengeUnknownStep`
- bump package version to 2.10.0

Fixes https://github.com/subzeroid/instagrapi/issues/2638.

## Verification
- `.venv/bin/python -m pytest -q tests/regression/test_challenge.py`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m ruff check instagrapi/mixins/challenge.py tests/regression/test_challenge.py pyproject.toml`
- `.venv/bin/python -m build`
- clean-clone regression verification on remote test host: `27 passed` for `tests/regression/test_challenge.py`