### PR TITLE
Handle missing canonical track info

### DIFF
--- a/instagrapi/mixins/track.py
+++ b/instagrapi/mixins/track.py
@@ -388,6 +388,8 @@ class TrackMixin:
         }
         result = self.private_request("clips/music/", data)
         track = json_value(result, "metadata", "music_info", "music_asset_info")
+        if not track:
+            raise TrackNotFound(music_canonical_id=str(music_canonical_id))
         return extract_track(track)
 
     def track_info_by_id(self, track_id: str, max_id: str = "") -> Dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.0"
+version = "2.10.1"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_track.py
+++ b/tests/live/test_track.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import TrackNotFound
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -32,3 +33,9 @@ class ClientTrackLiveTestCase(_helpers.ClientPrivateTestCase):
 
         search = self.cl.music_search_v2("love")
         self.assertEqual(search.get("status"), "ok")
+
+    def test_track_info_by_canonical_id_missing_live(self):
+        with self.assertRaises(TrackNotFound) as cm:
+            self.cl.track_info_by_canonical_id("0")
+
+        self.assertEqual(cm.exception.music_canonical_id, "0")

--- a/tests/regression/test_track.py
+++ b/tests/regression/test_track.py
@@ -1,3 +1,4 @@
+from instagrapi.exceptions import TrackNotFound
 from tests.helpers import *
 
 
@@ -153,6 +154,29 @@ class TrackMixinRegressionTestCase(unittest.TestCase):
             "music/verify_original_audio_title/",
             data={"original_audio_name": "Original Audio", "_uuid": "uuid-1"},
             with_signature=False,
+        )
+
+    def test_track_info_by_canonical_id_raises_track_not_found_when_music_asset_missing(self):
+        client = Client()
+        client.uuid = "uuid-1"
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"metadata": {"music_info": {"music_asset_info": None}}, "status": "ok"},
+        ) as private_request:
+            with self.assertRaises(TrackNotFound) as cm:
+                client.track_info_by_canonical_id("18159860503036324")
+
+        self.assertEqual(cm.exception.music_canonical_id, "18159860503036324")
+        private_request.assert_called_once_with(
+            "clips/music/",
+            {
+                "tab_type": "clips",
+                "referrer_media_id": "",
+                "_uuid": "uuid-1",
+                "music_canonical_id": "18159860503036324",
+            },
         )
 
     def test_track_stream_info_by_id_sends_expected_endpoint_and_payload(self):


### PR DESCRIPTION
## Summary
- Raise `TrackNotFound(music_canonical_id=...)` when `track_info_by_canonical_id(...)` receives a successful `clips/music/` response without `metadata.music_info.music_asset_info`.
- Add regression coverage for the missing `music_asset_info` payload.
- Add live coverage for the current canonical-id missing-track response and bump the package version to 2.10.1.

Fixes https://github.com/subzeroid/instagrapi/issues/1340

## Tests
- `.venv/bin/python -m ruff check instagrapi/mixins/track.py tests/regression/test_track.py tests/live/test_track.py pyproject.toml`
- `.venv/bin/python -m pytest -q tests/regression` (545 passed, 3 skipped, 7 subtests passed)
- `.venv/bin/python -m build`
- Clean-clone verification: `pytest -q tests/regression/test_track.py tests/live/test_track.py -rs` (14 passed)