### PR TITLE
Normalize XDT sidecar media resources

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -47,6 +47,10 @@ XDT_MEDIA_TYPES_GQL = {
 }
 
 
+def _normalize_media_gql_typename(data):
+    data["__typename"] = XDT_MEDIA_TYPES_GQL.get(data.get("__typename"), data.get("__typename"))
+
+
 def extract_media_v1(data):
     """Extract media from Private API"""
     media = deepcopy(data)
@@ -114,7 +118,7 @@ def extract_media_v1_xma(data):
 def extract_media_gql(data):
     """Extract media from GraphQL"""
     media = deepcopy(data)
-    media["__typename"] = XDT_MEDIA_TYPES_GQL.get(media.get("__typename"), media.get("__typename"))
+    _normalize_media_gql_typename(media)
     user = extract_user_short(media["owner"])
     # if "full_name" in user:
     #     user = extract_user_short(user)
@@ -200,6 +204,8 @@ def extract_resource_v1(data):
 
 
 def extract_resource_gql(data):
+    data = deepcopy(data)
+    _normalize_media_gql_typename(data)
     data["media_type"] = MEDIA_TYPES_GQL[data["__typename"]]
     return Resource(pk=data["id"], thumbnail_url=data["display_url"], **data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.1"
+version = "2.10.2"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_public.py
+++ b/tests/live/test_public.py
@@ -44,6 +44,17 @@ class ClientPublicTestCase(_helpers.ClientPrivateTestCase):
         self.assertTrue(m.thumbnail_url)
         self.assertTrue(m.video_url)
 
+    def test_media_info_gql_xdt_sidecar_children_live(self):
+        media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/Cu59OMFPQde/")
+        m = self.cl.media_info_gql(media_pk)
+
+        self.assertIsInstance(m, Media)
+        self.assertEqual(m.pk, "3150818670205011806")
+        self.assertEqual(m.code, "Cu59OMFPQde")
+        self.assertEqual(m.media_type, 8)
+        self.assertGreaterEqual(len(m.resources), 1)
+        self.assertTrue(all(resource.media_type in {1, 2} for resource in m.resources))
+
 
 class ClientClipMashupInfoLiveTestCase(unittest.TestCase):
     def live_client(self):

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -203,6 +203,61 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertEqual(media.view_count, 7694)
         self.assertFalse(media.has_liked)
 
+    def test_media_info_gql_normalizes_xdt_sidecar_children(self):
+        client = Client()
+        child_payload = {
+            "__typename": "XDTGraphImage",
+            "id": "3150818668564738953",
+            "shortcode": "Cu59OMFPQde",
+            "display_url": "https://example.com/child.jpg",
+            "edge_media_to_tagged_user": {"edges": []},
+        }
+        media_payload = {
+            "__typename": "XDTGraphSidecar",
+            "id": "3150818670205011806",
+            "shortcode": "Cu59OMFPQde",
+            "taken_at_timestamp": 1690160400,
+            "owner": {
+                "id": "1903424587",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+                "is_private": False,
+            },
+            "display_resources": [
+                {
+                    "src": "https://example.com/thumbnail.jpg",
+                    "config_width": 360,
+                    "config_height": 640,
+                }
+            ],
+            "is_video": False,
+            "edge_media_preview_comment": {"count": 3, "edges": []},
+            "edge_media_preview_like": {"count": -1, "edges": []},
+            "edge_media_to_caption": {"edges": [{"node": {"text": "caption"}}]},
+            "edge_media_to_tagged_user": {"edges": []},
+            "edge_media_to_sponsor_user": {"edges": []},
+            "edge_sidecar_to_children": {"edges": [{"node": child_payload}]},
+            "viewer_has_liked": False,
+        }
+
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            side_effect=ClientForbiddenError("blocked", response=Mock(status_code=403)),
+        ):
+            with mock.patch.object(
+                client,
+                "public_doc_id_graphql_request",
+                return_value={"xdt_shortcode_media": media_payload},
+            ):
+                media = client.media_info_gql("3150818670205011806")
+
+        self.assertEqual(media.media_type, 8)
+        self.assertEqual(media.pk, "3150818670205011806")
+        self.assertEqual(len(media.resources), 1)
+        self.assertEqual(media.resources[0].media_type, 1)
+        self.assertEqual(str(media.resources[0].thumbnail_url), "https://example.com/child.jpg")
+
     def test_public_head_defaults_to_no_redirect_follow(self):
         client = Client()
         before = client.public_requests_count


### PR DESCRIPTION
## Summary
- Normalize XDT GraphQL media typenames before extracting both top-level media and sidecar resources.
- Fix `media_info_gql(...)` doc_id fallback responses where `XDTGraphSidecar` contains `XDTGraphImage`/`XDTGraphVideo` children.
- Add regression coverage and live coverage for the shortcode from the reported issue.
- Bump the package version to 2.10.2.

Fixes https://github.com/subzeroid/instagrapi/issues/1481

## Tests
- `.venv/bin/python -m ruff check instagrapi/extractors.py tests/regression/test_public.py tests/live/test_public.py pyproject.toml`
- `.venv/bin/python -m pytest -q tests/regression/test_public.py::PublicRegressionTestCase::test_media_info_gql_normalizes_xdt_sidecar_children tests/regression/test_public.py::PublicRegressionTestCase::test_media_info_gql_falls_back_to_doc_id_on_public_404`
- `.venv/bin/python -m pytest -q tests/regression/test_public.py tests/regression/test_media.py` (55 passed, 2 subtests passed)
- `.venv/bin/python -m pytest -q tests/regression` (546 passed, 3 skipped, 7 subtests passed)
- `.venv/bin/python -m build`
- Clean-clone regression verification: `pytest -q tests/regression/test_public.py::PublicRegressionTestCase::test_media_info_gql_normalizes_xdt_sidecar_children -rs` (1 passed)
- Clean-clone live verification: `media_info_gql("Cu59OMFPQde")` returned media `3150818670205011806`, type `8`, with 8 resources