### PR TITLE
Map account edit failures to typed exceptions

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -54,6 +54,8 @@
 | BadPassword              | PrivateError | Raises when get message=bad_password. See [`BadPassword` troubleshooting](https://instagrapi.com/guides/errors/bad-password/) for proxy/IP/device/session trust cases where the password is correct but Instagram rejects the login context.
 | TwoFactorRequired        | PrivateError | Raises when get message=two_factor_required
 | UnknownError             | PrivateError | Raises when get unknown message (new message from instagram)
+| AccountEditError         | PrivateError | Raises when `accounts/edit_profile/` returns an account edit failure
+| AccountContactPointRequired | AccountEditError | Raises when profile editing requires an email or confirmed phone number
 | BadCredentials           | PrivateError | The login and password pair for your account have not been passed
 | IsRegulatedC18Error      | ClientBadRequestError | The user is limited to 18+
 

--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -183,6 +183,14 @@ class UnknownError(PrivateError):
     pass
 
 
+class AccountEditError(PrivateError):
+    pass
+
+
+class AccountContactPointRequired(AccountEditError):
+    pass
+
+
 class TrackNotFound(NotFoundError):
     pass
 

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -10,6 +10,8 @@ from requests.packages.urllib3.util.retry import Retry
 
 from instagrapi import config
 from instagrapi.exceptions import (
+    AccountContactPointRequired,
+    AccountEditError,
     BadPassword,
     ChallengeRequired,
     ClientBadRequestError,
@@ -50,6 +52,30 @@ _DIRECT_MESSAGE_REQUESTS_DISABLED_MARKERS = (
     "don't allow new message requests",
     "does not allow new message requests",
 )
+
+_ACCOUNT_CONTACT_POINT_REQUIRED_MARKERS = ("need an email or confirmed phone number",)
+
+
+def _private_message_text(message) -> str:
+    if isinstance(message, dict):
+        errors = message.get("errors")
+        if isinstance(errors, (list, tuple)):
+            return " ".join(str(error) for error in errors)
+        return " ".join(str(value) for value in message.values())
+    if isinstance(message, (list, tuple)):
+        return " ".join(str(item) for item in message)
+    return str(message or "")
+
+
+def _is_account_contact_point_required(endpoint: str, message) -> bool:
+    if not endpoint or "accounts/edit_profile" not in endpoint:
+        return False
+    normalized = _private_message_text(message).casefold()
+    return any(marker in normalized for marker in _ACCOUNT_CONTACT_POINT_REQUIRED_MARKERS)
+
+
+def _is_account_edit_error(endpoint: str) -> bool:
+    return bool(endpoint and "accounts/edit_profile" in endpoint)
 
 
 def _is_direct_message_requests_disabled(endpoint: str, message: str) -> bool:
@@ -509,6 +535,10 @@ class PrivateRequestMixin:
                     if not last_json["message"]:
                         last_json["message"] = "Two-factor authentication required"
                     raise TwoFactorRequired(**last_json)
+                elif _is_account_contact_point_required(endpoint, message):
+                    raise AccountContactPointRequired(e, response=e.response, **last_json)
+                elif _is_account_edit_error(endpoint):
+                    raise AccountEditError(e, response=e.response, **last_json)
                 elif _is_direct_message_requests_disabled(endpoint, message):
                     raise DirectMessageRequestsDisabled(e, response=e.response, **last_json)
                 elif "VideoTooLongException" in message:
@@ -570,6 +600,10 @@ class PrivateRequestMixin:
             raise ClientConnectionError("{e.__class__.__name__} {e}".format(e=e))
         if last_json.get("status") == "fail":
             message = last_json.get("message", "")
+            if _is_account_contact_point_required(endpoint, message):
+                raise AccountContactPointRequired(response=response, **last_json)
+            if _is_account_edit_error(endpoint):
+                raise AccountEditError(response=response, **last_json)
             if _is_direct_message_requests_disabled(endpoint, message):
                 raise DirectMessageRequestsDisabled(response=response, **last_json)
             raise ClientError(response=response, **last_json)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.2"
+version = "2.10.3"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_hardening.py
+++ b/tests/regression/test_hardening.py
@@ -1,4 +1,4 @@
-from instagrapi.exceptions import DirectMessageRequestsDisabled
+from instagrapi.exceptions import AccountContactPointRequired, AccountEditError, DirectMessageRequestsDisabled
 from tests.helpers import *
 
 
@@ -153,6 +153,59 @@ class HardeningRegressionTestCase(unittest.TestCase):
         with mock.patch.object(client.private, "post", return_value=response):
             with self.assertRaises(DirectMessageRequestsDisabled) as cm:
                 client._send_private_request("direct_v2/threads/broadcast/text/", data={"text": "hi"})
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
+
+    def test_send_private_request_promotes_account_edit_contact_point_required_http_error(self):
+        client = self._build_private_client()
+        payload = {
+            "message": {"errors": ["You need an email or confirmed phone number."]},
+            "status": "fail",
+        }
+        response = self._make_http_error_response(
+            400,
+            content=json.dumps(payload).encode(),
+            json_body=payload,
+        )
+
+        with mock.patch.object(client.private, "post", return_value=response):
+            with self.assertRaises(AccountContactPointRequired) as cm:
+                client._send_private_request("accounts/edit_profile/", data={"external_url": ""})
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
+
+    def test_send_private_request_promotes_account_edit_contact_point_required_status_fail(self):
+        client = self._build_private_client()
+        payload = {
+            "message": {"errors": ["You need an email or confirmed phone number."]},
+            "status": "fail",
+        }
+        response = self._make_json_response(payload)
+
+        with mock.patch.object(client.private, "post", return_value=response):
+            with self.assertRaises(AccountContactPointRequired) as cm:
+                client._send_private_request("accounts/edit_profile/", data={"external_url": ""})
+
+        self.assertEqual(cm.exception.message, payload["message"])
+        self.assertEqual(cm.exception.status, "fail")
+
+    def test_send_private_request_promotes_account_edit_unknown_server_error(self):
+        client = self._build_private_client()
+        payload = {
+            "message": "Unknown Server Error.",
+            "status": "fail",
+        }
+        response = self._make_http_error_response(
+            400,
+            content=json.dumps(payload).encode(),
+            json_body=payload,
+        )
+
+        with mock.patch.object(client.private, "post", return_value=response):
+            with self.assertRaises(AccountEditError) as cm:
+                client._send_private_request("accounts/edit_profile/", data={"external_url": ""})
 
         self.assertEqual(cm.exception.message, payload["message"])
         self.assertEqual(cm.exception.status, "fail")


### PR DESCRIPTION
## Summary

- add `AccountEditError` for `accounts/edit_profile/` failures
- add `AccountContactPointRequired` for the structured "You need an email or confirmed phone number" profile-edit response
- document the new exceptions and bump the package to 2.10.3

Fixes https://github.com/subzeroid/instagrapi/issues/1358

## Verification

- `python -m ruff check instagrapi/exceptions.py instagrapi/mixins/private.py tests/regression/test_hardening.py`
- `python -m pytest -q tests/regression/test_hardening.py`
- `python -m pytest -q tests/regression/test_account.py tests/regression/test_hardening.py`
- `python -m pytest -q tests/regression`
- `python -m build`
- sk.test targeted regression: account-edit typed exception tests passed
- sk.test live probe: real `accounts/edit_profile/` contact-point failure now raises `AccountContactPointRequired` instead of `UnknownError`
