### PR TITLE
Restore UserShort stories field

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -160,10 +160,10 @@ class UserShort(TypesBaseModel):
     profile_pic_url: Optional[HttpUrl] = None
     profile_pic_url_hd: Optional[HttpUrl] = None
     is_private: Optional[bool] = None
+    stories: List = Field(default_factory=list)
     is_verified: Optional[bool] = None
     latest_reel_media: Optional[int] = None
     has_anonymous_profile_picture: Optional[bool] = None
-    # stories: List = [] # not found in fbsearch_suggested_profiles
 
 
 class Viewer(UserShort):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.3"
+version = "2.10.4"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -64,3 +64,34 @@ class StoryMixinRegressionTestCase(unittest.TestCase):
         with mock.patch.object(client, "user_stories_gql", side_effect=ClientNotFoundError("missing")):
             with self.assertRaises(UserNotFound):
                 client.user_stories("123")
+
+    def test_users_stories_gql_populates_user_short_stories(self):
+        client = Client()
+        story_payload = {
+            "id": "1234567890",
+            "owner": {
+                "id": "123",
+                "username": "alice",
+                "full_name": "Alice",
+                "profile_pic_url": "https://example.com/alice.jpg",
+                "is_private": False,
+            },
+            "display_url": "https://example.com/story.jpg",
+            "taken_at_timestamp": 1_700_000_000,
+            "is_video": False,
+            "tappable_objects": [],
+            "edge_media_to_sponsor_user": {"edges": []},
+        }
+
+        with mock.patch.object(client, "inject_sessionid_to_public", return_value=True):
+            with mock.patch.object(
+                client,
+                "public_graphql_request",
+                return_value={"reels_media": [{"owner": story_payload["owner"], "items": [story_payload]}]},
+            ):
+                users = client.users_stories_gql(["123"])
+
+        self.assertEqual(len(users), 1)
+        self.assertEqual(users[0].pk, "123")
+        self.assertEqual(len(users[0].stories), 1)
+        self.assertEqual(users[0].stories[0].id, "1234567890_123")


### PR DESCRIPTION
Fixes https://github.com/subzeroid/instagrapi/issues/996

## Summary
- restore the `UserShort.stories` field used by bulk public story lookups
- add regression coverage for `users_stories_gql(...)` populating story items
- bump package version to 2.10.4

## Verification
- `.venv/bin/python -m pytest -q tests/regression/test_story.py`
- `.venv/bin/python -m ruff check instagrapi/types.py tests/regression/test_story.py pyproject.toml`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m build`
- live on sk.test: fetched 50 comments from `3735285994514812478_640806256`, found 15 public commenters with `latest_reel_media`, verified `user_stories(...)` returns stories and `users_stories_gql(...)` populates `UserShort.stories`
