### PR TITLE
v2.10.5 fix: return typed suggested profiles

### DIFF
--- a/instagrapi/mixins/fbsearch.py
+++ b/instagrapi/mixins/fbsearch.py
@@ -79,7 +79,7 @@ class FbSearchMixin:
             "include_friendship_status": "true",
         }
         result = self.private_request("fbsearch/accounts_recs/", params=params)
-        return result["users"]
+        return [extract_user_short(item) for item in result["users"]]
 
     def web_search_topsearch_hashtags(self, query: str) -> List[Hashtag]:
         result = self.web_search_topsearch(query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.4"
+version = "2.10.5"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_fbsearch.py
+++ b/tests/regression/test_fbsearch.py
@@ -150,6 +150,37 @@ class FbSearchRegressionTestCase(unittest.TestCase):
         self.assertEqual(hashtags[0].name, "restaurant")
         self.assertEqual(hashtags[0].media_count, 65043150)
 
+    def test_fbsearch_suggested_profiles_extracts_user_short_without_stories(self):
+        client = self._build_client()
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={
+                "users": [
+                    {
+                        "pk": "123",
+                        "username": "alice",
+                        "full_name": "Alice",
+                        "profile_pic_url": "https://example.com/alice.jpg",
+                        "is_private": False,
+                        "has_anonymous_profile_picture": False,
+                    }
+                ]
+            },
+        ) as private_request:
+            users = client.fbsearch_suggested_profiles("999")
+
+        private_request.assert_called_once_with(
+            "fbsearch/accounts_recs/",
+            params={
+                "target_user_id": "999",
+                "include_friendship_status": "true",
+            },
+        )
+        self.assertIsInstance(users[0], UserShort)
+        self.assertEqual(users[0].pk, "123")
+        self.assertEqual(users[0].stories, [])
+
     def test_search_music_skips_non_track_items(self):
         client = self._build_client()
         with mock.patch.object(


### PR DESCRIPTION
## Summary
- Change `fbsearch_suggested_profiles(...)` to return typed `UserShort` objects instead of raw response dictionaries.
- Keep payloads without `stories` valid by relying on the existing `UserShort.stories` default of `[]`.
- Bump the package version to `2.10.5`.

This intentionally aligns runtime behavior with the public return annotation. Users depending on raw dictionaries can stay on an older release or call the lower-level `private_request("fbsearch/accounts_recs/", params=...)` endpoint directly.

## Verification
- RED: the new regression test failed before the implementation because the method returned `dict` instead of `UserShort`.
- `.venv/bin/python -m pytest -q tests/regression/test_fbsearch.py::FbSearchRegressionTestCase::test_fbsearch_suggested_profiles_extracts_user_short_without_stories`
- `.venv/bin/python -m pytest -q tests/regression/test_fbsearch.py` -> `15 passed`
- `.venv/bin/python -m pytest -q tests/regression` -> `551 passed, 3 skipped, 7 subtests passed`
- `.venv/bin/ruff check instagrapi/mixins/fbsearch.py tests/regression/test_fbsearch.py pyproject.toml`
- `.venv/bin/python -m build`
- Authenticated live smoke: `fbsearch_suggested_profiles(...)` returned 30 typed `UserShort` recommendations and defaulted missing `stories` to `[]`.

## Mirror
- Async mirror PR will be opened in `subzeroid/aiograpi` as version `1.4.5`.
