### PR TITLE
test: add fbsearch suggested profiles live coverage

### DIFF
--- a/.github/workflows/live-account-tests.yml
+++ b/.github/workflows/live-account-tests.yml
@@ -15,6 +15,7 @@ on:
           - direct
           - signup
           - timeline
+          - fbsearch
           - story-location
           - location
           - usertag
@@ -81,6 +82,10 @@ jobs:
       - name: Run timeline test
         if: github.event.inputs.test_target == 'timeline' || github.event.inputs.test_target == 'all'
         run: pytest -sv tests/live/test_timeline.py::ClientTimelineLiveTestCase
+
+      - name: Run fbsearch test
+        if: github.event.inputs.test_target == 'fbsearch' || github.event.inputs.test_target == 'all'
+        run: pytest -sv tests/live/test_fbsearch.py::ClientFbSearchLiveTestCase
 
       - name: Run story location sticker live test
         if: github.event.inputs.test_target == 'story-location' || github.event.inputs.test_target == 'all'

--- a/tests/live/test_fbsearch.py
+++ b/tests/live/test_fbsearch.py
@@ -1,0 +1,29 @@
+import unittest
+
+from tests import helpers as _helpers
+from tests.helpers import *
+
+INSTAGRAM_USER_ID = "25025320"
+
+
+class ClientFbSearchLiveTestCase(unittest.TestCase):
+    def live_client(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for fbsearch live tests")
+        last_error = None
+        for account in _helpers.fetch_test_accounts(count=20):
+            try:
+                return _helpers.client_from_test_account(account)
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
+        self.skipTest(f"Could not login with any test account: {last_error}")
+
+    def test_fbsearch_suggested_profiles_returns_user_short_live(self):
+        cl = self.live_client()
+
+        users = cl.fbsearch_suggested_profiles(INSTAGRAM_USER_ID)
+
+        if not users:
+            self.skipTest("Instagram returned no suggested profiles")
+        self.assertIsInstance(users[0], UserShort)
+        self.assertIsInstance(users[0].stories, list)


### PR DESCRIPTION
## Summary
- Add an opt-in live test for `fbsearch_suggested_profiles(...)`.
- Add a `fbsearch` target to the Live Account Tests workflow so this endpoint can be run directly.
- The live test logs in through the pooled account helper, calls the public helper for Instagram's user id, and verifies the result is typed as `UserShort` with a list-backed `stories` field.

No package version bump: test coverage only.

## Verification
- Local deterministic: `env -u TEST_ACCOUNTS_URL .venv/bin/python -m pytest -q -rs tests/live/test_fbsearch.py` -> `1 skipped`
- Local lint/YAML: ruff and YAML hooks passed during commit.
- Live on sk.test: `.venv/bin/python -m pytest -q -rs tests/live/test_fbsearch.py::ClientFbSearchLiveTestCase::test_fbsearch_suggested_profiles_returns_user_short_live` -> `1 passed`.
