### PR TITLE
Handle collection max_id pagination cursors

### DIFF
--- a/instagrapi/mixins/collection.py
+++ b/instagrapi/mixins/collection.py
@@ -37,7 +37,7 @@ class CollectionMixin:
                 total_items.append(extract_collection(item))
             if not result.get("more_available"):
                 return total_items
-            next_max_id = result.get("next_max_id", "")
+            next_max_id = result.get("next_max_id", "") or result.get("max_id", "")
         return total_items
 
     def collection_pk_by_name(self, name: str) -> int:
@@ -121,7 +121,7 @@ class CollectionMixin:
             params["max_id"] = max_id
         result = self.private_request(private_request_endpoint, params=params)
         items = [extract_media_v1(m.get("media", m)) for m in result["items"]]
-        return items, result.get("next_max_id", "")
+        return items, result.get("next_max_id", "") or result.get("max_id", "")
 
     def collection_medias_v1(self, collection_pk: str, amount: int = 21, last_media_pk: int = 0) -> List[Media]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.5"
+version = "2.10.6"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_collection.py
+++ b/tests/regression/test_collection.py
@@ -1,0 +1,100 @@
+from tests.helpers import *
+
+
+class CollectionRegressionTestCase(unittest.TestCase):
+    @staticmethod
+    def build_media_payload(pk="1", code="abc"):
+        return {
+            "pk": pk,
+            "id": f"{pk}_1",
+            "code": code,
+            "taken_at": 1710000000,
+            "media_type": 1,
+            "caption": {"text": "caption"},
+            "user": {
+                "pk": "1",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "image_versions2": {
+                "candidates": [
+                    {
+                        "url": "https://example.com/thumbnail.jpg",
+                        "width": 720,
+                        "height": 1280,
+                    }
+                ]
+            },
+        }
+
+    def test_collections_uses_max_id_cursor_fallback(self):
+        client = Client()
+        client.private_request = Mock(
+            side_effect=[
+                {
+                    "items": [
+                        {
+                            "collection_id": "1",
+                            "collection_name": "First",
+                            "collection_type": "MEDIA",
+                            "collection_media_count": 1,
+                        }
+                    ],
+                    "more_available": True,
+                    "max_id": "cursor-2",
+                },
+                {
+                    "items": [
+                        {
+                            "collection_id": "2",
+                            "collection_name": "Second",
+                            "collection_type": "MEDIA",
+                            "collection_media_count": 1,
+                        }
+                    ],
+                    "more_available": False,
+                },
+            ]
+        )
+
+        collections = client.collections()
+
+        self.assertEqual([collection.id for collection in collections], ["1", "2"])
+        self.assertEqual(client.private_request.call_count, 2)
+        self.assertEqual(client.private_request.call_args_list[0].kwargs["params"]["max_id"], "")
+        self.assertEqual(client.private_request.call_args_list[1].kwargs["params"]["max_id"], "cursor-2")
+
+    def test_collection_medias_chunk_uses_max_id_cursor_fallback(self):
+        client = Client()
+        client.private_request = Mock(
+            return_value={
+                "items": [{"media": self.build_media_payload()}],
+                "max_id": "cursor-2",
+            }
+        )
+
+        medias, next_max_id = client.collection_medias_v1_chunk("123")
+
+        self.assertEqual([media.pk for media in medias], ["1"])
+        self.assertEqual(next_max_id, "cursor-2")
+
+    def test_collection_medias_uses_max_id_cursor_fallback_for_pagination(self):
+        client = Client()
+        client.private_request = Mock(
+            side_effect=[
+                {
+                    "items": [{"media": self.build_media_payload(pk="1", code="abc")}],
+                    "max_id": "cursor-2",
+                },
+                {
+                    "items": [{"media": self.build_media_payload(pk="2", code="def")}],
+                },
+            ]
+        )
+
+        medias = client.collection_medias("123", amount=2)
+
+        self.assertEqual([media.pk for media in medias], ["1", "2"])
+        self.assertEqual(client.private_request.call_count, 2)
+        self.assertNotIn("max_id", client.private_request.call_args_list[0].kwargs["params"])
+        self.assertEqual(client.private_request.call_args_list[1].kwargs["params"]["max_id"], "cursor-2")


### PR DESCRIPTION
## Summary
- use `max_id` as a fallback cursor when collection list/media responses omit `next_max_id`
- add regression coverage for `collections()`, `collection_medias_v1_chunk(...)`, and high-level `collection_medias(...)` pagination
- bump package version to 2.10.6

Fixes https://github.com/subzeroid/instagrapi/issues/972

## Tests
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m build`
- `sk.test`: `PYTHONPATH=$PWD /home/test/instagrapi/.venv/bin/python -m pytest -q tests/regression/test_collection.py`
- `sk.test`: fresh-account save -> `feed/saved/posts/` -> `collection_medias_v1_chunk("saved")` -> unsave smoke passed

Note: the sk.test fresh-account pool did not contain a prepared multi-page private collection, so the real live smoke verifies the authenticated saved-posts collection endpoint while the cursor fallback itself is covered by deterministic regression tests.