### PR TITLE
Close thumbnail handles after video upload

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -1150,13 +1150,15 @@ def crop_thumbnail(path: Path) -> bool:
     bool
         A boolean value
     """
-    im = Image.open(str(path))
-    width, height = im.size
-    offset = (height / 1.78) / 2
-    center = width / 2
-    # Crop the center of the image
-    im = im.crop((center - offset, 0, center + offset, height))
-    with open(path, "w") as fp:
-        im.save(fp)
-        im.close()
+    with Image.open(str(path)) as im:
+        width, height = im.size
+        offset = (height / 1.78) / 2
+        center = width / 2
+        # Crop the center of the image
+        cropped = im.crop((center - offset, 0, center + offset, height))
+        try:
+            with open(path, "wb") as fp:
+                cropped.save(fp)
+        finally:
+            cropped.close()
     return True

--- a/instagrapi/mixins/igtv.py
+++ b/instagrapi/mixins/igtv.py
@@ -301,13 +301,15 @@ def crop_thumbnail(path: Path) -> bool:
     bool
         A boolean value
     """
-    im = Image.open(str(path))
-    width, height = im.size
-    offset = (height / 1.78) / 2
-    center = width / 2
-    # Crop the center of the image
-    im = im.crop((center - offset, 0, center + offset, height))
-    with open(path, "w") as fp:
-        im.save(fp)
-        im.close()
+    with Image.open(str(path)) as im:
+        width, height = im.size
+        offset = (height / 1.78) / 2
+        center = width / 2
+        # Crop the center of the image
+        cropped = im.crop((center - offset, 0, center + offset, height))
+        try:
+            with open(path, "wb") as fp:
+                cropped.save(fp)
+        finally:
+            cropped.close()
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.6"
+version = "2.10.7"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1794,6 +1794,62 @@ class UploadRegressionTestCase(unittest.TestCase):
 
         self.assertTrue(closed["value"])
 
+    def _assert_crop_thumbnail_closes_images(self, module):
+        source_image = None
+        cropped_image = None
+
+        class FakeImage:
+            def __init__(self, size=(1780, 1000)):
+                self.size = size
+                self.closed = False
+                self.saved = False
+                self.crop_box = None
+                self.crop_result = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.close()
+
+            def crop(self, box):
+                self.crop_box = box
+                return self.crop_result
+
+            def save(self, fp):
+                self.saved = True
+
+            def close(self):
+                self.closed = True
+
+        source_image = FakeImage()
+        cropped_image = FakeImage()
+        source_image.crop_result = cropped_image
+
+        with mock.patch.object(module.Image, "open", return_value=source_image) as image_open:
+            with mock.patch("builtins.open", mock.mock_open()) as output_open:
+                result = module.crop_thumbnail(Path("thumb.jpg"))
+
+        self.assertTrue(result)
+        image_open.assert_called_once_with("thumb.jpg")
+        output_open.assert_called_once_with(Path("thumb.jpg"), "wb")
+        expected_box = (609.1011235955056, 0, 1170.8988764044943, 1000)
+        for actual, expected in zip(source_image.crop_box, expected_box):
+            self.assertAlmostEqual(actual, expected)
+        self.assertTrue(source_image.closed)
+        self.assertTrue(cropped_image.saved)
+        self.assertTrue(cropped_image.closed)
+
+    def test_clip_crop_thumbnail_closes_source_and_cropped_images(self):
+        import instagrapi.mixins.clip as clip_mixin
+
+        self._assert_crop_thumbnail_closes_images(clip_mixin)
+
+    def test_igtv_crop_thumbnail_closes_source_and_cropped_images(self):
+        import instagrapi.mixins.igtv as igtv_mixin
+
+        self._assert_crop_thumbnail_closes_images(igtv_mixin)
+
     def test_video_story_sticker_ids_include_all_stickers(self):
         client = self.build_client()
 


### PR DESCRIPTION
## Summary
- close generated Reel/IGTV thumbnail source images with `Image.open(...)` context managers
- save cropped thumbnails in binary mode and close cropped image objects in `finally`
- add regression coverage for both thumbnail crop helpers
- bump package version to 2.10.7

Fixes https://github.com/subzeroid/instagrapi/issues/948

## Tests
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q tests/regression` -> 556 passed, 3 skipped, 7 subtests passed
- `.venv/bin/python -m build`
- sk.test: `PYTHONPATH=$PWD /home/test/instagrapi/.venv/bin/python -m pytest -q tests/regression/test_upload.py -k "crop_thumbnail_closes_source"` -> 2 passed

## Live note
I also attempted a real Reel upload/delete smoke test on sk.test, but the fresh-account pool had no usable login in that run (`Client.bloks_versioning_id` empty before upload). The targeted regression covers the Windows handle leak directly.
