### PR TITLE
Handle Bloks redirect challenge resume

### DIFF
--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -20,6 +20,7 @@ from instagrapi.exceptions import (
 )
 
 WAIT_SECONDS = 5
+BLOKS_REDIRECT_ACTION = "com.bloks.www.ig.challenge.redirect.async"
 
 
 class ChallengeChoice(Enum):
@@ -69,6 +70,73 @@ class ChallengeResolveMixin:
             "Challenge code was not provided before the retry window expired.",
             **error_context,
         )
+
+    def _challenge_error_context(self) -> Dict:
+        return {key: value for key, value in self.last_json.items() if key != "message"}
+
+    def _raise_bloks_redirect_required(self) -> None:
+        raise ChallengeRequired(
+            "Manual verification required via Instagram Bloks redirect checkpoint. "
+            "Please confirm the login in the official Instagram app or web flow on a trusted device, "
+            "then retry with the same saved client settings, device identifiers, and proxy/IP.",
+            **self._challenge_error_context(),
+        )
+
+    def _challenge_resolve_change_password(self) -> bool:
+        challenge_context = self.last_json.get("challenge_context")
+        if not challenge_context:
+            raise ChallengeRequired(
+                "Password change required, but Instagram did not return a challenge context. "
+                "Complete the flow manually.",
+                **self._challenge_error_context(),
+            )
+        wait_seconds = 5
+        pwd = None
+        for attempt in range(24):
+            pwd = self.change_password_handler(self.username)
+            if pwd:
+                break
+            time.sleep(wait_seconds)
+        if not pwd:
+            raise ChallengeRequired(
+                "Password change required. Provide a new password via "
+                "change_password_handler or complete the flow manually.",
+                **self._challenge_error_context(),
+            )
+        self.logger.info(
+            "New password (%d chars) entered for %s (%d attempts by %d seconds)",
+            len(pwd),
+            self.username,
+            attempt,
+            wait_seconds,
+        )
+        return self.bloks_change_password(pwd, challenge_context)
+
+    def challenge_bloks_redirect_dismiss(self) -> bool:
+        """
+        Acknowledge a pending Bloks redirect checkpoint after manual approval.
+
+        Call this after approving the login in the official Instagram app while
+        keeping the same client instance/settings alive.
+        """
+        if self.last_json.get("bloks_action") != BLOKS_REDIRECT_ACTION or not self.last_json.get("challenge_context"):
+            raise ChallengeRequired(
+                "No pending Bloks redirect challenge context found. "
+                "Retry the original login/request first, then approve it in the official app.",
+                **self._challenge_error_context(),
+            )
+        result = self.bloks_challenge_take_challenge(
+            challenge_context=self.last_json["challenge_context"],
+        )
+        if isinstance(result, dict):
+            self.last_json = result
+        if self.last_json.get("status") != "ok":
+            self._raise_bloks_redirect_required()
+        if self.last_json.get("action") == "close" or self.last_json.get("type") == "CHALLENGE_REDIRECTION":
+            return True
+        if self.last_json.get("bloks_action") == BLOKS_REDIRECT_ACTION:
+            self._raise_bloks_redirect_required()
+        return True
 
     def challenge_resolve(self, last_json: Dict) -> bool:
         """
@@ -496,14 +564,27 @@ class ChallengeResolveMixin:
             if self.last_json.get("step_name") == step_name:
                 raise ChallengeError(f"submit_phone challenge did not advance after phone submission: {self.last_json}")
             return self.challenge_resolve_simple(challenge_url)
-        elif self.last_json.get("bloks_action") == "com.bloks.www.ig.challenge.redirect.async":
-            raise ChallengeRequired(
-                "Manual verification required via Instagram Bloks redirect checkpoint. "
-                "Please confirm the login in the official Instagram app or web flow on a trusted device, "
-                "then retry with the same saved client settings, device identifiers, and proxy/IP. "
-                "This challenge flow is not currently resolved automatically by instagrapi.",
-                **{key: value for key, value in self.last_json.items() if key != "message"},
+        elif self.last_json.get("bloks_action") == BLOKS_REDIRECT_ACTION:
+            if self.last_json.get("challenge_type_enum_str") == "PASSWORD_RESET":
+                return self._challenge_resolve_change_password()
+            challenge_context = self.last_json.get("challenge_context")
+            if not challenge_context:
+                self._raise_bloks_redirect_required()
+            result = self.bloks_challenge_take_challenge(
+                challenge_context=challenge_context,
+                choice=0,
             )
+            if isinstance(result, dict):
+                self.last_json = result
+            if self.last_json.get("status") != "ok":
+                self._raise_bloks_redirect_required()
+            if self.last_json.get("action") == "close" or self.last_json.get("type") == "CHALLENGE_REDIRECTION":
+                return True
+            if self.last_json.get("bloks_action") == BLOKS_REDIRECT_ACTION:
+                self._raise_bloks_redirect_required()
+            if self.last_json.get("step_name"):
+                return self.challenge_resolve_simple(challenge_url)
+            return True
         elif step_name == "":
             assert self.last_json.get("action", "") == "close"
             assert self.last_json.get("status", "") == "ok"
@@ -519,27 +600,7 @@ class ChallengeResolveMixin:
             #      "challenge_type_enum": "PASSWORD_RESET"}',
             #  'challenge_type_enum_str': 'PASSWORD_RESET',
             #  'status': 'ok'}
-            wait_seconds = 5
-            pwd = None
-            for attempt in range(24):
-                pwd = self.change_password_handler(self.username)
-                if pwd:
-                    break
-                time.sleep(wait_seconds)
-            if not pwd:
-                raise ChallengeRequired(
-                    "Password change required. Provide a new password via "
-                    "change_password_handler or complete the flow manually.",
-                    **{key: value for key, value in self.last_json.items() if key != "message"},
-                )
-            self.logger.info(
-                "New password (%d chars) entered for %s (%d attempts by %d seconds)",
-                len(pwd),
-                self.username,
-                attempt,
-                wait_seconds,
-            )
-            return self.bloks_change_password(pwd, self.last_json["challenge_context"])
+            return self._challenge_resolve_change_password()
         elif step_name == "ufac_www_bloks":
             raise ChallengeRequired(
                 "Manual verification required via Instagram UFAC web bloks checkpoint. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.7"
+version = "2.10.8"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_challenge.py
+++ b/tests/regression/test_challenge.py
@@ -79,7 +79,7 @@ class ChallengeRegressionTestCase(unittest.TestCase):
 
         self.assertIn("UFAC web bloks checkpoint", str(cm.exception))
 
-    def test_challenge_resolve_simple_bloks_redirect_step_raises_clear_manual_error(self):
+    def test_challenge_resolve_simple_bloks_redirect_step_acknowledges_context(self):
         client = Client()
         client.username = "example"
         client.last_json = {
@@ -91,14 +91,88 @@ class ChallengeRegressionTestCase(unittest.TestCase):
             "challenge_context": "opaque-context",
             "challenge_type_enum_str": "SUSPICIOUS_LOGIN",
         }
+        client.bloks_challenge_take_challenge = Mock(return_value={"status": "ok", "action": "close"})
+
+        result = client.challenge_resolve_simple("challenge/test/")
+
+        self.assertTrue(result)
+        client.bloks_challenge_take_challenge.assert_called_once_with(
+            challenge_context="opaque-context",
+            choice=0,
+        )
+
+    def test_challenge_resolve_simple_bloks_redirect_password_reset_uses_handler(self):
+        client = Client()
+        client.username = "example"
+        client.last_json = {
+            "message": "challenge_required",
+            "status": "ok",
+            "step_name": "STEP_NAME",
+            "flow_render_type": 3,
+            "bloks_action": "com.bloks.www.ig.challenge.redirect.async",
+            "challenge_context": "opaque-context",
+            "challenge_type_enum_str": "PASSWORD_RESET",
+        }
+        client.change_password_handler = Mock(return_value="new-password")
+
+        with mock.patch.object(client, "bloks_change_password", return_value=True) as change_password:
+            result = client.challenge_resolve_simple("challenge/test/")
+
+        self.assertTrue(result)
+        change_password.assert_called_once_with("new-password", "opaque-context")
+
+    def test_challenge_bloks_redirect_dismiss_posts_pending_context(self):
+        client = Client()
+        client.username = "example"
+        client.last_json = {
+            "message": "challenge_required",
+            "status": "ok",
+            "step_name": "STEP_NAME",
+            "flow_render_type": 3,
+            "bloks_action": "com.bloks.www.ig.challenge.redirect.async",
+            "challenge_context": "opaque-context",
+            "challenge_type_enum_str": "SUSPICIOUS_LOGIN",
+        }
+        client.bloks_challenge_take_challenge = Mock(return_value={"status": "ok", "action": "close"})
+
+        result = client.challenge_bloks_redirect_dismiss()
+
+        self.assertTrue(result)
+        client.bloks_challenge_take_challenge.assert_called_once_with(
+            challenge_context="opaque-context",
+        )
+
+    def test_challenge_bloks_redirect_dismiss_requires_pending_context(self):
+        client = Client()
+        client.last_json = {}
 
         with self.assertRaises(ChallengeRequired) as cm:
-            client.challenge_resolve_simple("challenge/test/")
+            client.challenge_bloks_redirect_dismiss()
+
+        self.assertIn("No pending Bloks redirect challenge", str(cm.exception))
+
+    def test_challenge_bloks_redirect_dismiss_raises_when_checkpoint_still_pending(self):
+        client = Client()
+        client.last_json = {
+            "message": "challenge_required",
+            "status": "ok",
+            "step_name": "STEP_NAME",
+            "bloks_action": "com.bloks.www.ig.challenge.redirect.async",
+            "challenge_context": "opaque-context",
+        }
+        client.bloks_challenge_take_challenge = Mock(
+            return_value={
+                "status": "ok",
+                "step_name": "STEP_NAME",
+                "bloks_action": "com.bloks.www.ig.challenge.redirect.async",
+                "challenge_context": "opaque-context",
+            }
+        )
+
+        with self.assertRaises(ChallengeRequired) as cm:
+            client.challenge_bloks_redirect_dismiss()
 
         self.assertIn("Bloks redirect checkpoint", str(cm.exception))
-        self.assertIn("official Instagram app", str(cm.exception))
-        self.assertEqual(cm.exception.step_name, "STEP_NAME")
-        self.assertEqual(cm.exception.bloks_action, "com.bloks.www.ig.challenge.redirect.async")
 
     def test_challenge_resolve_uses_default_context_when_missing(self):
         client = Client()


### PR DESCRIPTION
## Summary
- add `Client.challenge_bloks_redirect_dismiss()` for acknowledging a pending Bloks redirect checkpoint after manual approval in the official Instagram app
- let `challenge_resolve_simple()` try `bloks_challenge_take_challenge(..., choice=0)` for `com.bloks.www.ig.challenge.redirect.async` before falling back to a manual error
- route `PASSWORD_RESET` Bloks redirects through the configured `change_password_handler` and existing `bloks_change_password(...)` path
- keep the manual error when Instagram still returns the same redirect checkpoint after acknowledgement
- bump package version to 2.10.8

Fixes https://github.com/subzeroid/instagrapi/issues/2649

## Tests
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q tests/regression` -> 560 passed, 3 skipped, 7 subtests passed
- `.venv/bin/python -m build`
- sk.test: `PYTHONPATH=$PWD /home/test/instagrapi/.venv/bin/python -m pytest -q tests/regression/test_challenge.py -k "bloks_redirect"` -> 5 passed

## Live note
There is no deterministic live fixture for this checkpoint: Instagram only returns `com.bloks.www.ig.challenge.redirect.async` after account/session-specific risk enforcement. The regression tests exercise the actual payload shape and helper calls; the same targeted regression also passed on sk.test.
