### PR TITLE
Add coauthor user IDs to feed uploads

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -331,9 +331,9 @@ Upload medias to your feed. Common arguments:
 
 | Method                                                                                                                                 | Return  | Description
 | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------
-| photo_upload(path: Path, caption: str, upload_id: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None)             | Media   | Upload photo (Support JPG files)
-| video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None)            | Media   | Upload video (Support MP4 files)
-| album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None)                      | Media   | Upload Album (Support JPG/MP4 files)
+| photo_upload(path: Path, caption: str, upload_id: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)             | Media   | Upload photo (Support JPG files)
+| video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)            | Media   | Upload video (Support MP4 files)
+| album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)                      | Media   | Upload Album (Support JPG/MP4 files)
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
 | clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual", share_to_facebook: bool = False) | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts. Set `share_to_facebook=True` to cross-post to a linked Facebook destination
 | clip_change_cover(media_pk: str, cover_path: Path) | bool | Change the cover image for a published Reel
@@ -364,7 +364,7 @@ In `extra_data`, you can pass additional media settings, for example:
 | custom_accessibility_caption  | String | [Set alternative text](https://github.com/subzeroid/instagrapi/issues/351) `{"custom_accessibility_caption": "ALT TEXT HERE"}`
 | like_and_view_counts_disabled | Int    | [Disable like and view counts](https://github.com/subzeroid/instagrapi/issues/382) `{"like_and_view_counts_disabled": 1}`
 | disable_comments              | Int    | Disable comments `{"disable_comments": 1}`
-| invite_coauthor_user_id       | Int    | Add a coauthor to the post `{"invite_coauthor_user_id": "USER ID OF COAUTHOR HERE"}`. You also need to add this user to `usertags`
+| invite_coauthor_user_ids      | List   | Low-level coauthor invite field. Prefer `coauthor_user_ids=[...]` on `photo_upload`, `video_upload`, or `album_upload`
 
 Trial Reels are available only for accounts where Instagram has enabled the feature. Use `clip_trial_eligible()` as a
 lightweight preflight if you process multiple accounts and want to avoid uploading video bytes for accounts where the

--- a/instagrapi/mixins/album.py
+++ b/instagrapi/mixins/album.py
@@ -12,6 +12,7 @@ from instagrapi.exceptions import (
 from instagrapi.types import Location, Media, Track, Usertag
 from instagrapi.utils.serialization import dumps
 from instagrapi.utils.timing import date_time_original
+from instagrapi.utils.upload import with_coauthor_user_ids
 
 
 class DownloadAlbumMixin:
@@ -134,6 +135,7 @@ class UploadAlbumMixin:
         to_story=False,
         extra_data: Dict[str, str] = {},
         schedule_at: Optional[Union[int, datetime]] = None,
+        coauthor_user_ids: Optional[List[Union[int, str]]] = None,
     ) -> Media:
         """
         Upload album to feed
@@ -161,6 +163,8 @@ class UploadAlbumMixin:
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
         schedule_at: int or datetime, optional
             Unix timestamp in seconds or datetime when the album should be published.
+        coauthor_user_ids: List[int | str], optional
+            Instagram user IDs to invite as post coauthors.
 
         Returns
         -------
@@ -169,6 +173,7 @@ class UploadAlbumMixin:
         """
         if not paths:
             raise AlbumUnknownFormat("Album upload requires at least one media path.")
+        extra_data = with_coauthor_user_ids(extra_data, coauthor_user_ids)
         extra_data = self._scheduled_extra_data(extra_data, schedule_at)
         children = []
         for path in paths:

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -32,6 +32,7 @@ from instagrapi.types import (
 )
 from instagrapi.utils.serialization import dumps
 from instagrapi.utils.timing import date_time_original
+from instagrapi.utils.upload import with_coauthor_user_ids
 
 try:
     from PIL import Image
@@ -226,6 +227,7 @@ class UploadPhotoMixin:
         location: Location = None,
         extra_data: Dict[str, str] = {},
         schedule_at: Optional[Union[int, datetime]] = None,
+        coauthor_user_ids: Optional[List[Union[int, str]]] = None,
     ) -> Media:
         """
         Upload photo and configure to feed
@@ -246,6 +248,8 @@ class UploadPhotoMixin:
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
         schedule_at: int or datetime, optional
             Unix timestamp in seconds or datetime when the photo should be published.
+        coauthor_user_ids: List[int | str], optional
+            Instagram user IDs to invite as post coauthors.
 
         Returns
         -------
@@ -257,6 +261,7 @@ class UploadPhotoMixin:
         if path.suffix.lower() not in valid_extensions:
             raise ValueError("Invalid file format. Only JPG/JPEG/PNG/WEBP files are supported.")
 
+        extra_data = with_coauthor_user_ids(extra_data, coauthor_user_ids)
         extra_data = self._scheduled_extra_data(extra_data, schedule_at)
         previous_media_ids = self._current_media_ids()
         upload_id, width, height = self.photo_rupload(path, upload_id)

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -33,6 +33,7 @@ from instagrapi.types import (
 )
 from instagrapi.utils.serialization import dumps
 from instagrapi.utils.timing import date_time_original
+from instagrapi.utils.upload import with_coauthor_user_ids
 from instagrapi.utils.video import MOVIEPY_2_INSTALL_MESSAGE, analyze_video_for_upload
 
 
@@ -438,6 +439,7 @@ class UploadVideoMixin:
         location: Location = None,
         extra_data: Dict[str, str] = {},
         schedule_at: Optional[Union[int, datetime]] = None,
+        coauthor_user_ids: Optional[List[Union[int, str]]] = None,
     ) -> Media:
         """
         Upload video and configure to feed
@@ -458,6 +460,8 @@ class UploadVideoMixin:
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
         schedule_at: int or datetime, optional
             Unix timestamp in seconds or datetime when the video should be published.
+        coauthor_user_ids: List[int | str], optional
+            Instagram user IDs to invite as post coauthors.
 
         Returns
         -------
@@ -467,6 +471,7 @@ class UploadVideoMixin:
         path = Path(path)
         if thumbnail is not None:
             thumbnail = Path(thumbnail)
+        extra_data = with_coauthor_user_ids(extra_data, coauthor_user_ids)
         extra_data = self._scheduled_extra_data(extra_data, schedule_at)
         upload_id, width, height, duration, thumbnail = self.video_rupload(path, thumbnail, to_story=False)
         for attempt in range(50):

--- a/instagrapi/utils/upload.py
+++ b/instagrapi/utils/upload.py
@@ -1,0 +1,19 @@
+from typing import Dict, List, Optional, Union
+
+COAUTHOR_EXTRA_DATA_KEYS = ("invite_coauthor_user_ids", "invite_coauthor_user_id")
+
+
+def with_coauthor_user_ids(
+    extra_data: Dict,
+    coauthor_user_ids: Optional[List[Union[int, str]]],
+) -> Dict:
+    data = dict(extra_data or {})
+    if coauthor_user_ids is None:
+        return data
+    if not isinstance(coauthor_user_ids, list):
+        raise ValueError("coauthor_user_ids must be a list of user IDs.")
+    for key in COAUTHOR_EXTRA_DATA_KEYS:
+        if key in data:
+            raise ValueError(f"Use either coauthor_user_ids or extra_data['{key}'], not both.")
+    data["invite_coauthor_user_ids"] = [str(user_id) for user_id in coauthor_user_ids]
+    return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.8"
+version = "2.10.9"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -610,6 +610,90 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(extra_data, {"disable_comments": 1})
         self.assertEqual(album_upload.call_args.kwargs["schedule_at"], schedule_at)
 
+    def test_photo_upload_adds_coauthor_user_ids_without_mutating_extra_data(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=1)
+        extra_data = {"disable_comments": 1}
+
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(
+                client,
+                "photo_configure",
+                return_value={"status": "ok", "media": media_payload},
+            ) as configure:
+                with mock.patch("time.sleep"):
+                    media = client.photo_upload(
+                        Path("example.jpg"),
+                        "caption",
+                        extra_data=extra_data,
+                        coauthor_user_ids=[123, "456"],
+                    )
+
+        self.assertIsInstance(media, Media)
+        self.assertEqual(extra_data, {"disable_comments": 1})
+        configure_extra = configure.call_args.kwargs["extra_data"]
+        self.assertEqual(configure_extra["disable_comments"], 1)
+        self.assertEqual(configure_extra["invite_coauthor_user_ids"], ["123", "456"])
+
+    def test_video_upload_adds_coauthor_user_ids(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=2)
+
+        with mock.patch.object(
+            client,
+            "video_rupload",
+            return_value=("1", 720, 1280, 5, Path("/tmp/thumb.jpg")),
+        ):
+            with mock.patch.object(
+                client,
+                "video_configure",
+                return_value={"status": "ok", "media": media_payload},
+            ) as configure:
+                with mock.patch("time.sleep"):
+                    media = client.video_upload(
+                        Path("example.mp4"),
+                        "caption",
+                        coauthor_user_ids=["123", "456"],
+                    )
+
+        self.assertIsInstance(media, Media)
+        self.assertEqual(configure.call_args.kwargs["extra_data"]["invite_coauthor_user_ids"], ["123", "456"])
+
+    def test_album_upload_adds_coauthor_user_ids(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=8)
+        media_payload["carousel_media"] = [self.build_media_payload(media_type=1)]
+
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(
+                client,
+                "album_configure",
+                return_value={"status": "ok", "media": media_payload},
+            ) as configure:
+                with mock.patch("time.sleep"):
+                    media = client.album_upload(
+                        [Path("one.jpg")],
+                        "caption",
+                        coauthor_user_ids=["123", "456"],
+                    )
+
+        self.assertIsInstance(media, Media)
+        self.assertEqual(configure.call_args.kwargs["extra_data"]["invite_coauthor_user_ids"], ["123", "456"])
+
+    def test_coauthor_user_ids_rejects_conflicting_extra_data_key(self):
+        client = self.build_client()
+
+        with self.assertRaises(ValueError) as ctx:
+            client.photo_upload(
+                Path("example.jpg"),
+                "caption",
+                extra_data={"invite_coauthor_user_ids": ["789"]},
+                coauthor_user_ids=["123"],
+            )
+
+        self.assertIn("coauthor_user_ids", str(ctx.exception))
+        self.assertIn("invite_coauthor_user_ids", str(ctx.exception))
+
     def test_video_upload_raises_clear_error_when_configure_has_no_media(self):
         client = self.build_client()
 


### PR DESCRIPTION
Closes https://github.com/subzeroid/instagrapi/issues/1319

Async mirror: https://github.com/subzeroid/aiograpi/pull/351

## Summary
- add `coauthor_user_ids` to `photo_upload`, `video_upload`, and `album_upload`
- map the high-level argument to Instagram's `invite_coauthor_user_ids` configure payload without mutating `extra_data`
- bump package version to `2.10.9` and update media upload docs

## Verification
- `ruff check . && ruff format --check .`
- `python -m pytest -q tests/regression`
- `python -m build`
- `mkdocs build --strict`
- `bandit -c pyproject.toml -r instagrapi`
- `sk.test`: `python -m pytest -q tests/regression/test_upload.py`