### PR TITLE
Add public comments helper

### DIFF
--- a/docs/usage-guide/comment.md
+++ b/docs/usage-guide/comment.md
@@ -12,6 +12,8 @@ Post comment, viewing, like and unlike comments
 | media_stream_comments_v1_chunk(media_id: str, min_id: str = "", max_id: str = "") | Tuple[List\[Comment], str, str] | Get one streamed comments page and both cursors |
 | media_comments_gql(media_pk: str, amount: int = 50, max_requests: int = 0) | List\[dict] | Get comments through the web GraphQL doc_id endpoint |
 | media_comments_gql_chunk(media_pk: str, end_cursor: str = "") | Tuple[List\[dict], str] | Get one web GraphQL comments page |
+| media_comments_public_gql(code: str, amount: int = 50, max_requests: int = 0) | List\[dict] | Get public web GraphQL comments by media shortcode |
+| media_comments_public_gql_chunk(code: str, end_cursor: str = "") | Tuple[List\[dict], str] | Get one public web GraphQL comments page by media shortcode |
 | media_comments_threaded_gql(media_pk: str, comment_pk: str, amount: int = 0) | List\[dict] | Get threaded replies through the web GraphQL doc_id endpoint |
 | media_comments_threaded_gql_chunk(media_pk: str, comment_pk: str, end_cursor: str = "") | Tuple[List\[dict], str] | Get one threaded GraphQL comments page |
 | media_comment_infos(media_ids: List[str]) | dict | Bulk-fetch comment summaries for media ids |
@@ -90,6 +92,10 @@ QVFBQmZCa1dxaFB5eFpBY2luVFMwLWdmN2ZCcUV6OF9hQWlIQk12ZWZqUlctZ2pOa1J5YjJ6bFY5Q1do
 >>> next_min_id
 QVFEbHpIWmpFc3BNUkgzUFVuOGZOQlhDQ1hHeWlVWHlJSnBhb2FHbFB3YlJtNThnOUlrd01JUWdKRmRwZTRpWWU0bnZmX3VMNHlwcDBkWTJpZjQ2NE9SeQ==
 
+>>> public_comments = cl.media_comments_public_gql("CjPUjEvDKT4", amount=40)
+>>> public_comments[0]["text"]
+'Example public comment'
+
 >>> parent_comment = cl.media_comments(media_id)[0]
 >>> replies = cl.media_comment_replies(media_id, parent_comment.pk)
 >>> replies[0].dict()
@@ -127,6 +133,7 @@ Notes:
 
 * `media_comments()` fetches both regular and headload comment pages until `amount` is reached.
 * `media_comments_chunk()` is the better choice when you want to store and resume the server cursor manually.
+* `media_comments_public_gql()` accepts a media shortcode and automatically builds the current public GraphQL `doc_id` request and post referer. Public web endpoints are still Instagram-gated and may return 401/403/429 depending on IP, TLS fingerprint, cookies, or session state.
 * `media_comment_replies()` fetches `inline_child_comments` for a parent comment and paginates with the returned child cursor.
 * `media_check_offensive_comment_v2()` can be used as an explicit lightweight preflight before `media_comment()`. `media_comment()` does not run extra preflight requests automatically, so callers can choose the request volume and handle the raw response.
 * `comment_pin()` / `comment_unpin()` only work on media owned by the authenticated account.

--- a/instagrapi/mixins/comment.py
+++ b/instagrapi/mixins/comment.py
@@ -8,6 +8,8 @@ from instagrapi.types import Comment
 from instagrapi.utils.auth import generate_jazoest
 from instagrapi.utils.serialization import dumps
 
+MEDIA_COMMENTS_DOC_ID = "6974885689225067"
+
 
 class CommentMixin:
     """
@@ -102,8 +104,8 @@ class CommentMixin:
             A list of objects of Comment
         """
         media_pk = str(self.media_pk(media_pk))
+        shortcode = self.media_code_from_pk(media_pk)
         comments = []
-        doc_id = "6974885689225067"
         variables = {
             "after": end_cursor or None,
             "before": None,
@@ -112,15 +114,12 @@ class CommentMixin:
             "media_id": media_pk,
             "sort_order": "popular",
         }
-        data = {
-            "variables": dumps(variables),
-            "doc_id": doc_id,
-            "fb_dtsg": self.fb_dtsg,
-            "jazoest": generate_jazoest(self.phone_id),
-            **GQL_STUFF,
-        }
-        resp = self.graphql_request(data=data)
-        if data := resp["data"]:
+        data = self.public_doc_id_graphql_request(
+            MEDIA_COMMENTS_DOC_ID,
+            variables,
+            referer=f"https://www.instagram.com/p/{shortcode}/",
+        )
+        if data:
             key = None
             for key in data.keys():
                 if "comments" in key:
@@ -129,7 +128,7 @@ class CommentMixin:
             for edge in item.get("edges", []):
                 comments.append(edge["node"])
             page_info = item.get("page_info", {})
-            end_cursor = page_info.get("end_cursor") if page_info.get("has_next_page") else None
+            end_cursor = str(page_info.get("end_cursor") or "") if page_info.get("has_next_page") else ""
             return comments, end_cursor
         return [], ""
 
@@ -154,6 +153,18 @@ class CommentMixin:
         if amount:
             comments = comments[:amount]
         return comments
+
+    def media_comments_public_gql_chunk(self, code: str, end_cursor: str = "") -> Tuple[List[dict], str]:
+        """
+        Get one public GraphQL comments page by media shortcode.
+        """
+        return self.media_comments_gql_chunk(self.media_pk_from_code(code), end_cursor=end_cursor)
+
+    def media_comments_public_gql(self, code: str, amount: int = 50, max_requests: int = 0) -> List[dict]:
+        """
+        Get public GraphQL comments by media shortcode.
+        """
+        return self.media_comments_gql(self.media_pk_from_code(code), amount=amount, max_requests=max_requests)
 
     def media_stream_comments_v1_chunk(
         self, media_id: str, min_id: str = "", max_id: str = ""

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -476,7 +476,7 @@ class PublicRequestMixin:
             "Accept-Language": "en-US,en;q=0.8",
             "Referer": referer or "https://www.instagram.com/",
             "User-Agent": (
-                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+                "Instagram 273.0.0.16.70 (iPhone15,2; iOS 17_5_1; en_US; en-US; scale=3.00; 1290x2796; 470085518)"
             ),
         }
         csrftoken = self.public.cookies.get("csrftoken")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.9"
+version = "2.10.10"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_comments.py
+++ b/tests/live/test_comments.py
@@ -1,5 +1,47 @@
+from instagrapi.exceptions import (
+    ClientForbiddenError,
+    ClientGraphqlError,
+    ClientLoginRequired,
+    ClientThrottledError,
+    ClientUnauthorizedError,
+)
 from tests import helpers as _helpers
 from tests.helpers import *
+
+
+class ClientPublicCommentTestCase(unittest.TestCase):
+    def test_media_comments_public_gql_live(self):
+        code = "C_BM2yAN4Rm"
+        transports = ["requests"]
+        try:
+            import curl_adapter  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            transports.append("curl")
+
+        errors = []
+        for transport in transports:
+            client = Client(public_transport=transport, request_timeout=0, public_request_retries_count=1)
+            try:
+                comments = client.media_comments_public_gql(code, amount=3, max_requests=1)
+            except (
+                ClientForbiddenError,
+                ClientGraphqlError,
+                ClientLoginRequired,
+                ClientThrottledError,
+                ClientUnauthorizedError,
+            ) as exc:
+                errors.append(f"{transport}: {exc.__class__.__name__}")
+                continue
+            break
+        else:
+            self.skipTest("Instagram public comments endpoint is gated: " + "; ".join(errors))
+
+        self.assertTrue(comments)
+        self.assertLessEqual(len(comments), 3)
+        self.assertTrue(comments[0].get("id") or comments[0].get("pk"))
+        self.assertTrue(comments[0].get("text"))
 
 
 class ClientCommentTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/regression/test_comments.py
+++ b/tests/regression/test_comments.py
@@ -79,27 +79,40 @@ class CommentRepliesRegressionTestCase(unittest.TestCase):
 
     def test_media_comments_gql_chunk_posts_doc_id_query(self):
         client = Client()
-        client._fb_dtsg = "token"
         with mock.patch.object(
             client,
-            "graphql_request",
+            "public_doc_id_graphql_request",
             return_value={
-                "data": {
-                    "xdt_media_comments": {
-                        "edges": [{"node": {"pk": "101", "text": "hello"}}],
-                        "page_info": {"has_next_page": True, "end_cursor": "cursor-2"},
-                    }
+                "xdt_media_comments": {
+                    "edges": [{"node": {"pk": "101", "text": "hello"}}],
+                    "page_info": {"has_next_page": True, "end_cursor": "cursor-2"},
                 }
             },
-        ) as graphql_request:
-            comments, cursor = client.media_comments_gql_chunk("123", end_cursor="cursor-1")
+        ) as doc_id_request:
+            comments, cursor = client.media_comments_gql_chunk("3441088131388376166", end_cursor="cursor-1")
 
         self.assertEqual(comments, [{"pk": "101", "text": "hello"}])
         self.assertEqual(cursor, "cursor-2")
-        data = graphql_request.call_args.kwargs["data"]
-        self.assertEqual(data["doc_id"], "6974885689225067")
-        self.assertIn('"media_id":"123"', data["variables"])
-        self.assertIn('"after":"cursor-1"', data["variables"])
+        doc_id_request.assert_called_once_with(
+            "6974885689225067",
+            {
+                "after": "cursor-1",
+                "before": None,
+                "first": 50,
+                "last": None,
+                "media_id": "3441088131388376166",
+                "sort_order": "popular",
+            },
+            referer="https://www.instagram.com/p/C_BM2yAN4Rm/",
+        )
+
+    def test_media_comments_public_gql_uses_shortcode_without_manual_graphql_params(self):
+        client = Client()
+        with mock.patch.object(client, "media_comments_gql", return_value=[{"pk": "101"}]) as comments_gql:
+            comments = client.media_comments_public_gql("C_BM2yAN4Rm", amount=12, max_requests=2)
+
+        self.assertEqual(comments, [{"pk": "101"}])
+        comments_gql.assert_called_once_with("3441088131388376166", amount=12, max_requests=2)
 
     def test_media_comments_threaded_gql_chunk_posts_parent_comment_id(self):
         client = Client()

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -66,6 +66,7 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertEqual(kwargs["data"]["variables"], '{"shortcode":"C_BM2yAN4Rm"}')
         self.assertEqual(kwargs["data"]["server_timestamps"], "true")
         self.assertEqual(kwargs["headers"]["Referer"], "https://www.instagram.com/p/C_BM2yAN4Rm/")
+        self.assertIn("Instagram 273.0.0.16.70", kwargs["headers"]["User-Agent"])
         self.assertFalse(kwargs["update_headers"])
         self.assertTrue(kwargs["return_json"])
 


### PR DESCRIPTION
## Summary
- add `media_comments_public_gql(...)` and chunk helper for public comments by shortcode
- switch `media_comments_gql_chunk(...)` to the public doc_id GraphQL path with an automatic post referer
- refresh the public doc_id User-Agent and add regression/live coverage

Fixes https://github.com/subzeroid/instagrapi/issues/1255

## Verification
- `ruff check . && ruff format --check .`
- `python -m pytest -q tests/regression`
- `mkdocs build --strict`
- `python -m build`
- `bandit -c pyproject.toml -r instagrapi`
- local live: `tests/live/test_comments.py::ClientPublicCommentTestCase::test_media_comments_public_gql_live`
- sk.test live: `tests/live/test_comments.py::ClientPublicCommentTestCase::test_media_comments_public_gql_live`

Async mirror: https://github.com/subzeroid/aiograpi/pull/353