### PR TITLE
Fix photo downloads to prefer public web resources

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -269,8 +269,8 @@ Notes:
 
 | Method                                                       | Return  | Description                                                         |
 | ------------------------------------------------------------ | ------- | ------------------------------------------------------------------- |
-| photo_download(media_pk: int, folder: Path, overwrite: bool = True)                  | Path    | Download photo (path to photo with best resoluton)                  |
-| photo_download_by_url(url: str, filename: str, folder: Path, overwrite: bool = True) | Path    | Download photo by URL (path to photo with best resoluton)           |
+| photo_download(media_pk: int, folder: Path, overwrite: bool = True)                  | Path    | Download photo (path to photo with best resolution)                  |
+| photo_download_by_url(url: str, filename: str, folder: Path, overwrite: bool = True) | Path    | Download photo by URL (path to photo with best resolution)           |
 | video_download(media_pk: int, folder: Path, overwrite: bool = True)                  | Path    | Download video (path to video with best resoluton)                  |
 | video_download_by_url(url: str, filename: str, folder: Path, overwrite: bool = True) | Path    | Download Video by URL (path to video with best resoluton)           |
 | album_download(media_pk: int, folder: Path, overwrite: bool = True)                  | Path    | Download Album (multiple paths to photo/video with best resolutons) |
@@ -279,6 +279,10 @@ Notes:
 | igtv_download_by_url(url: str, filename: str, folder: Path)  | Path    | Download IGTV by URL (path to video with best resoluton)            |
 | clip_download(media_pk: int, folder: Path)                   | Path    | Download Reels Clip (path to video with best resoluton)             |
 | clip_download_by_url(url: str, filename: str, folder: Path)  | Path    | Download Reels Clip by URL (path to video with best resoluton)      |
+
+`photo_download()` resolves photo metadata through the public/web media-info path first so it can use the largest
+display resource Instagram exposes for the post, then falls back to private/mobile metadata when the public web
+endpoint is gated. It does not rewrite CDN URLs manually.
 
 ### Example:
 

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -11,6 +11,7 @@ import requests
 
 from instagrapi import config
 from instagrapi.exceptions import (
+    ClientError,
     PhotoConfigureError,
     PhotoConfigureStoryError,
     PhotoNotUpload,
@@ -45,7 +46,16 @@ class DownloadPhotoMixin:
     Helpers for downloading photo
     """
 
-    def photo_download(self, media_pk: int, folder: Path = "", overwrite: bool = True) -> Path:
+    def _photo_download_media_info(self, media_pk: str) -> Media:
+        try:
+            media = self.media_info_gql(media_pk)
+        except ClientError:
+            media = None
+        if media and media.media_type == 1 and media.thumbnail_url:
+            return media
+        return self.media_info(media_pk)
+
+    def photo_download(self, media_pk: Union[int, str], folder: Path = "", overwrite: bool = True) -> Path:
         """
         Download photo using media pk
 
@@ -65,10 +75,13 @@ class DownloadPhotoMixin:
         Path
             Path for the file downloaded
         """
-        media = self.media_info(media_pk)
+        media_pk_str = self.media_pk(str(media_pk))
+        media = self._photo_download_media_info(media_pk_str)
         assert media.media_type == 1, "Must been photo"
-        filename = "{username}_{media_pk}".format(username=media.user.username, media_pk=media_pk)
-        return self.photo_download_by_url(media.thumbnail_url, filename, folder, overwrite=overwrite)
+        if not media.thumbnail_url:
+            raise Exception("Photo thumbnail URL is empty")
+        filename = "{username}_{media_pk}".format(username=media.user.username, media_pk=media_pk_str)
+        return self.photo_download_by_url(str(media.thumbnail_url), filename, folder, overwrite=overwrite)
 
     def photo_download_by_url(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.10"
+version = "2.10.11"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_download.py
+++ b/tests/live/test_download.py
@@ -1,0 +1,79 @@
+import os
+import tempfile
+
+from PIL import Image
+
+from instagrapi.exceptions import ClientError
+from tests import helpers as _helpers
+from tests.helpers import *
+
+
+class ClientPhotoDownloadLiveTestCase(unittest.TestCase):
+    def photo_clients(self):
+        try:
+            import curl_adapter  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            yield (
+                "anonymous/curl",
+                Client(
+                    public_transport="curl",
+                    request_timeout=1,
+                    public_request_retries_count=1,
+                ),
+            )
+
+        yield (
+            "anonymous/requests",
+            Client(
+                public_transport="requests",
+                request_timeout=1,
+                public_request_retries_count=1,
+            ),
+        )
+
+        if not TEST_ACCOUNTS_URL:
+            return
+
+        for idx, account in enumerate(_helpers.fetch_test_accounts(count=3, timeout=20)[:3], start=1):
+            settings = dict(account["client_settings"])
+            settings.pop("totp_seed", None)
+            yield (
+                f"saved-session/{idx}",
+                Client(
+                    settings=settings,
+                    proxy=os.getenv("IG_PROXY") or account.get("proxy"),
+                    override_app_version=True,
+                    request_timeout=1,
+                    public_request_retries_count=1,
+                ),
+            )
+
+    def test_photo_download_public_highest_resolution_live(self):
+        media_pk = Client().media_pk_from_code("Ci_fQ5YsS0m")
+        errors = []
+        for label, cl in self.photo_clients():
+            try:
+                media = cl.media_info_gql(media_pk)
+                self.assertEqual(media.media_type, 1)
+                self.assertTrue(media.thumbnail_url)
+                cl.request_timeout = 20
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    with (
+                        mock.patch.object(cl, "media_info_gql", return_value=media) as media_info_gql,
+                        mock.patch.object(cl, "media_info", side_effect=AssertionError("media_info fallback used")),
+                    ):
+                        path = cl.photo_download(media_pk, folder=tmpdir)
+                    media_info_gql.assert_called_once_with(media_pk)
+                    with Image.open(path) as image:
+                        width, height = image.size
+            except ClientError as exc:
+                errors.append(f"{label}: {exc.__class__.__name__}")
+                continue
+            break
+        else:
+            self.skipTest("Instagram public media info endpoint is gated: " + "; ".join(errors))
+
+        self.assertGreaterEqual(width, 1080)
+        self.assertGreaterEqual(height, 1080)

--- a/tests/regression/test_download.py
+++ b/tests/regression/test_download.py
@@ -1,6 +1,6 @@
 import io
 
-from instagrapi.exceptions import ClientIncompleteReadError
+from instagrapi.exceptions import ClientForbiddenError, ClientIncompleteReadError
 from tests.helpers import *
 
 
@@ -23,6 +23,25 @@ class _DownloadResponse:
 
 
 class DownloadRegressionTestCase(unittest.TestCase):
+    def _photo_media(self, media_pk="2936202982639873318", thumbnail_url="https://example.com/photo.jpg"):
+        return Media(
+            pk=media_pk,
+            id=f"{media_pk}_50838397751",
+            code="Ci_fQ5YsS0m",
+            taken_at=datetime(2026, 1, 1),
+            media_type=1,
+            user=UserShort(
+                pk="50838397751",
+                username="example",
+                profile_pic_url="https://example.com/profile.jpg",
+            ),
+            like_count=0,
+            caption_text="",
+            usertags=[],
+            sponsor_tags=[],
+            thumbnail_url=thumbnail_url,
+        )
+
     def _video_media(self, media_pk="3903542582802212941"):
         return Media(
             pk=media_pk,
@@ -59,6 +78,49 @@ class DownloadRegressionTestCase(unittest.TestCase):
         download_by_url.assert_called_once_with(
             media.video_url,
             f"example_{media.pk}",
+            "/tmp",
+            overwrite=False,
+        )
+        self.assertEqual(result, expected)
+
+    def test_photo_download_prefers_public_gql_media_info_lookup(self):
+        client = Client()
+        media_pk = "2936202982639873318"
+        public_media = self._photo_media(media_pk, "https://example.com/public-1440.jpg")
+        private_media = self._photo_media(media_pk, "https://example.com/private-1080.jpg")
+        expected = Path("/tmp/example.jpg")
+
+        with mock.patch.object(client, "media_info_gql", return_value=public_media) as media_info_gql:
+            with mock.patch.object(client, "media_info", return_value=private_media) as media_info:
+                with mock.patch.object(client, "photo_download_by_url", return_value=expected) as download_by_url:
+                    result = client.photo_download(media_pk, folder="/tmp", overwrite=False)
+
+        media_info_gql.assert_called_once_with(media_pk)
+        media_info.assert_not_called()
+        download_by_url.assert_called_once_with(
+            str(public_media.thumbnail_url),
+            f"example_{media_pk}",
+            "/tmp",
+            overwrite=False,
+        )
+        self.assertEqual(result, expected)
+
+    def test_photo_download_falls_back_to_media_info_when_public_gql_is_gated(self):
+        client = Client()
+        media_pk = "2936202982639873318"
+        private_media = self._photo_media(media_pk, "https://example.com/private-1080.jpg")
+        expected = Path("/tmp/example.jpg")
+
+        with mock.patch.object(client, "media_info_gql", side_effect=ClientForbiddenError("gated")) as media_info_gql:
+            with mock.patch.object(client, "media_info", return_value=private_media) as media_info:
+                with mock.patch.object(client, "photo_download_by_url", return_value=expected) as download_by_url:
+                    result = client.photo_download(media_pk, folder="/tmp", overwrite=False)
+
+        media_info_gql.assert_called_once_with(media_pk)
+        media_info.assert_called_once_with(media_pk)
+        download_by_url.assert_called_once_with(
+            str(private_media.thumbnail_url),
+            f"example_{media_pk}",
             "/tmp",
             overwrite=False,
         )


### PR DESCRIPTION
## Summary
- Make `photo_download(...)` resolve photo metadata through public/web `media_info_gql(...)` first so it can use the largest display resource Instagram exposes.
- Keep private/mobile `media_info(...)` as the fallback when public web metadata is gated.
- Add regression and live coverage for the issue shortcode, and bump the package to 2.10.11.

Closes https://github.com/subzeroid/instagrapi/issues/924

## Tests
- `.venv/bin/python -m ruff check instagrapi tests/live/test_download.py tests/regression/test_download.py docs/usage-guide/media.md pyproject.toml`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m pytest -q -rs tests/live/test_download.py::ClientPhotoDownloadLiveTestCase::test_photo_download_public_highest_resolution_live`
- `sk.test`: same live test with `TEST_ACCOUNTS_URL` -> 1 passed
- `.venv/bin/python -m build`