### PR TITLE
Add clip seen helper

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -54,6 +54,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_unpin(media_pk: str) | bool | Unpin media from profile |
 | media_template_v1(media_id: str) | dict | Fetch a clip template payload for a Reel/clip media |
 | clip_mashup_info(media_pk: str) | dict | Fetch Reel remix/reuse availability metadata |
+| clip_seen(media_ids: List[str], blend_media_ids: List[str] = None) | bool | Mark Reels/Clips as seen through the Clips seen-state endpoint |
 | clip_pin(media_pk: str) | bool | Pin Reel to the Reels tab/profile Reels grid |
 | clip_unpin(media_pk: str) | bool | Unpin Reel from the Reels tab/profile Reels grid |
 | clip_change_cover(media_pk: str, cover_path: Path) | bool | Change the cover image for a published Reel |
@@ -67,6 +68,10 @@ In terms of Instagram, this is called Media, usually users call it publications 
 Media notes are separate from Direct inbox Notes. Use `media_note_create()` and
 `media_note_delete()` for the note surface attached to a post or Reel; use the
 [Notes guide](notes.md) for Direct inbox Notes.
+
+Use `clip_seen()` for Reels/Clips. `media_seen()` keeps the older story/reel-tray
+seen payload. Instagram still decides whether a seen-state event is counted in
+view analytics.
 
 Low level methods:
 

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -118,6 +118,36 @@ class ClipMixin:
             },
         )
 
+    def clip_seen(self, media_ids: List[str], blend_media_ids: Optional[List[str]] = None) -> bool:
+        """
+        Mark Clips/Reels as seen using Instagram's Clips seen-state endpoint.
+
+        Parameters
+        ----------
+        media_ids: List[str]
+            Clip/Reel media ids or pks.
+        blend_media_ids: List[str], optional
+            Clip/Reel media ids or pks seen from Blend surfaces.
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        assert self.user_id, "Login required"
+        media_pks = [self.media_pk(media_id) for media_id in media_ids]
+        blend_media_pks = [self.media_pk(media_id) for media_id in (blend_media_ids or [])]
+        result = self.private_request(
+            "clips/write_seen_state/",
+            data={
+                "impressions": json.dumps(media_pks, separators=(",", ":")),
+                "_uid": str(self.user_id),
+                "_uuid": self.uuid,
+                "blend_impressions": json.dumps(blend_media_pks, separators=(",", ":")),
+            },
+        )
+        return result.get("status") == "ok"
+
     def clip_pin(self, media_pk: str, revert: bool = False) -> bool:
         """
         Pin Reel to the Reels tab/profile Reels grid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.11"
+version = "2.10.12"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -297,6 +297,32 @@ class ClientMediaCountAliasLiveTestCase(unittest.TestCase):
         self.assertEqual(media.play_count, captured_payload["video_play_count"])
 
 
+class ClientClipSeenLiveTestCase(unittest.TestCase):
+    def live_client(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for clip seen live tests")
+        last_error = None
+        for account in _helpers.fetch_test_accounts(count=20, timeout=30):
+            try:
+                cl = _helpers.client_from_test_account(account)
+                cl.request_timeout = 0
+                return cl
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
+        self.skipTest(f"Could not login with any test account: {last_error}")
+
+    def test_clip_seen_live(self):
+        cl = self.live_client()
+        try:
+            medias = cl.user_clips_v1("25025320", amount=3)
+        except Exception as exc:
+            self.skipTest(f"Could not fetch public Instagram clips: {type(exc).__name__}: {str(exc)[:120]}")
+        if not medias:
+            self.skipTest("Public Instagram clips feed returned no media")
+
+        self.assertTrue(cl.clip_seen([medias[0].id]))
+
+
 class ClientExtractTestCase(_helpers.ClientPrivateTestCase):
     def test_extract_media_photo(self):
         media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")

--- a/tests/regression/test_clip.py
+++ b/tests/regression/test_clip.py
@@ -2,6 +2,26 @@ from tests.helpers import *
 
 
 class ClipPinRegressionTestCase(unittest.TestCase):
+    def test_clip_seen_posts_write_seen_state_payload(self):
+        client = Client()
+        client.private.cookies.set("ds_user_id", "29060001803")
+        client.uuid = "uuid"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.clip_seen(
+                ["3917361171492779700_25025320", "3917361171492779701"],
+                blend_media_ids=["3917361171492779702_25025320"],
+            )
+
+        self.assertTrue(result)
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "clips/write_seen_state/")
+        payload = private_request.call_args.kwargs["data"]
+        self.assertEqual(json.loads(payload["impressions"]), ["3917361171492779700", "3917361171492779701"])
+        self.assertEqual(json.loads(payload["blend_impressions"]), ["3917361171492779702"])
+        self.assertEqual(payload["_uid"], "29060001803")
+        self.assertEqual(payload["_uuid"], "uuid")
+
     def test_clip_info_for_creation_sends_device_status(self):
         client = Client()
         expected = {"status": "ok", "trial_config": {"is_enabled": True}}


### PR DESCRIPTION
## Summary
- add `Client.clip_seen(...)` for Reels/Clips seen-state through `clips/write_seen_state/`
- normalize full media ids and bare pks into the `impressions` payload expected by the mobile endpoint
- document the Reels/Clips path separately from legacy `media_seen(...)` and add regression plus live coverage
- bump package version to `2.10.12`

Fixes https://github.com/subzeroid/instagrapi/issues/1169

## Testing
- `.venv/bin/python -m ruff check instagrapi tests`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m pytest -q tests/live/test_media.py::ClientClipSeenLiveTestCase::test_clip_seen_live -rs`
- `sk.test`: `/home/test/instagrapi/.venv/bin/python -m pytest -q -rs tests/live/test_media.py::ClientClipSeenLiveTestCase::test_clip_seen_live` -> `1 passed`
- `.venv/bin/python -m build`
