### PR TITLE
Add Reel topic upload support

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -340,10 +340,11 @@ Upload medias to your feed. Common arguments:
 | video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)            | Media   | Upload video (Support MP4 files)
 | album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)                      | Media   | Upload Album (Support JPG/MP4 files)
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
-| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual", share_to_facebook: bool = False) | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts. Set `share_to_facebook=True` to cross-post to a linked Facebook destination
+| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual", share_to_facebook: bool = False, topics: List[int \| str] = None) | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts. Set `share_to_facebook=True` to cross-post to a linked Facebook destination. Pass Reel topic `fit_id` values with `topics=[...]`
 | clip_change_cover(media_pk: str, cover_path: Path) | bool | Change the cover image for a published Reel
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
+| clip_interest_topics() | List[dict] | Get Reel topic catalog items with `name` and `fit_id` values for `clip_upload(..., topics=...)`
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
 | clip_share_to_fb_unified_config() | dict | Get the Android cross-posting unified config used by the Reel composer
 | clip_share_to_fb_unified_destination(config: Dict = None) | dict | Resolve confirmed Reel Facebook destination fields from the unified cross-posting config
@@ -377,6 +378,8 @@ Reel composer does not report Trial Reels enabled. Instagram can still reject Tr
 configure, so keep upload-side error handling for backend eligibility decisions. When `trial=True`, `clip_upload` sends
 `trial_params={"graduation_strategy": "manual"}` by default and disables feed preview for the upload.
 
+Reel topics use Instagram's interest topic `fit_id` values. Call `clip_interest_topics()` to get the current catalog, then pass selected ids with `clip_upload(..., topics=[topic["fit_id"]])`; instagrapi sends them as the Android `interest_topics` configure field.
+
 Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as `share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
 
 `clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. When `clip_upload(..., share_to_facebook=True)` has no manual destination override, instagrapi now falls back to Android's `CrosspostingUnifiedConfigsQuery` via `clip_share_to_fb_unified_config()` and uses `clip_share_to_fb_unified_destination()` only if that response contains confirmed Reel-to-Facebook destination fields. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but automatic discovery still has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. If neither the preflight/unified config data nor the caller provides a destination, instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
@@ -404,6 +407,14 @@ Facebook Reel sharing requires a Facebook account/page linked in the Instagram a
 ...         "Trying a new Reel format",
 ...         trial=True,
 ...     )
+
+>>> topics = cl.clip_interest_topics()
+>>> technology_topic = next(topic for topic in topics if topic["name"] == "Technology")
+>>> reel = cl.clip_upload(
+...     "/app/reel.mp4",
+...     "Reel with a topic",
+...     topics=[technology_topic["fit_id"]],
+... )
 
 >>> reel = cl.clip_upload(
 ...     "/app/reel.mp4",

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -294,6 +294,22 @@ class UploadClipMixin:
             params={"device_status": json.dumps(device_status)},
         )
 
+    def clip_interest_topics(self) -> List[Dict[str, object]]:
+        """
+        Get Reel topic catalog items accepted by ``clip_upload(..., topics=...)``.
+
+        Returns
+        -------
+        List[Dict]
+            Reel topic dictionaries, each including ``name`` and ``fit_id``.
+        """
+        result = self.private_request(
+            "interest_nux/list_all/",
+            params={"caller": "INTEREST_NUX"},
+            with_signature=False,
+        )
+        return result.get("sub_interests") or []
+
     def clip_trial_eligible(self) -> bool:
         """
         Check whether Reel creation preflight reports Trial Reels enabled.
@@ -648,6 +664,7 @@ class UploadClipMixin:
         fb_destination_audience_type: Optional[str] = None,
         fb_xpost_surface: str = "IG_REELS_COMPOSER",
         fb_validation_check_bypass: Optional[bool] = None,
+        topics: Optional[List[Union[str, int]]] = None,
     ) -> Media:
         """
         Upload CLIP to Instagram
@@ -690,6 +707,8 @@ class UploadClipMixin:
             Cross-posting surface reported by the Instagram app.
         fb_validation_check_bypass: bool, optional
             Override the validation bypass value from share_to_fb_config.
+        topics: List[str or int], optional
+            Reel topic ids to send as Instagram's ``interest_topics`` configure field.
 
         Returns
         -------
@@ -720,6 +739,8 @@ class UploadClipMixin:
                 "trial_params",
                 {"graduation_strategy": trial_graduation_strategy},
             )
+        if topics is not None:
+            configure_extra_data.setdefault("interest_topics", [str(topic) for topic in topics])
         duration_ms = str(int(duration * 1000))
         composer_session_id = str(uuid4())
         asset_id = uuid4().hex[:12].upper()
@@ -779,16 +800,18 @@ class UploadClipMixin:
         }
         upload_settings_data = json.dumps(upload_settings)
         upload_settings_len = str(len(upload_settings_data.encode("utf-8")))
-        headers = {
-            "Accept-Encoding": "gzip",
-            "Content-Type": "application/json",
-            "Content-Length": upload_settings_len,
-            "Offset": "0",
-            "X-Entity-Length": upload_settings_len,
-            "X-Entity-Name": "upload_settings",
-            "X-Entity-Type": "application/json",
-            "X_FB_VIDEO_WATERFALL_ID": f"{composer_session_id}_settings",
-        }
+        headers = self.private_headers(
+            {
+                "Accept-Encoding": "gzip",
+                "Content-Type": "application/json",
+                "Content-Length": upload_settings_len,
+                "Offset": "0",
+                "X-Entity-Length": upload_settings_len,
+                "X-Entity-Name": "upload_settings",
+                "X-Entity-Type": "application/json",
+                "X_FB_VIDEO_WATERFALL_ID": f"{composer_session_id}_settings",
+            }
+        )
         response = self.private.post(
             "https://{domain}/upload_settings/{session_id}".format(
                 domain=config.API_DOMAIN,
@@ -819,14 +842,16 @@ class UploadClipMixin:
             "session_id": upload_id,
             "media_type": "2",
         }
-        headers = {
-            "Accept-Encoding": "gzip",
-            "X-Instagram-Rupload-Params": json.dumps(rupload_params),
-            "X_FB_VIDEO_WATERFALL_ID": f"{composer_session_id}_{asset_id}_Mixed_0",
-            "X-Entity-Type": "video/mp4",
-            "Segment-Start-Offset": "0",
-            "Segment-Type": "3",
-        }
+        headers = self.private_headers(
+            {
+                "Accept-Encoding": "gzip",
+                "X-Instagram-Rupload-Params": json.dumps(rupload_params),
+                "X_FB_VIDEO_WATERFALL_ID": f"{composer_session_id}_{asset_id}_Mixed_0",
+                "X-Entity-Type": "video/mp4",
+                "Segment-Start-Offset": "0",
+                "Segment-Type": "3",
+            }
+        )
         response = self.private.get(
             "https://{domain}/rupload_igvideo/{name}".format(domain=config.API_DOMAIN, name=upload_name),
             headers=headers,

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -206,17 +206,19 @@ class UploadPhotoMixin:
         else:
             photo_data, photo_size = prepare_image(str(path), max_side=1080)
         photo_len = str(len(photo_data))
-        headers = {
-            "Accept-Encoding": "gzip",
-            "X-Instagram-Rupload-Params": json.dumps(rupload_params),
-            "X_FB_PHOTO_WATERFALL_ID": waterfall_id,
-            "X-Entity-Type": image_type,
-            "Offset": "0",
-            "X-Entity-Name": upload_name,
-            "X-Entity-Length": photo_len,
-            "Content-Type": "application/octet-stream",
-            "Content-Length": photo_len,
-        }
+        headers = self.private_headers(
+            {
+                "Accept-Encoding": "gzip",
+                "X-Instagram-Rupload-Params": json.dumps(rupload_params),
+                "X_FB_PHOTO_WATERFALL_ID": waterfall_id,
+                "X-Entity-Type": image_type,
+                "Offset": "0",
+                "X-Entity-Name": upload_name,
+                "X-Entity-Length": photo_len,
+                "Content-Type": "application/octet-stream",
+                "Content-Length": photo_len,
+            }
+        )
         response = self.private.post(
             "https://{domain}/rupload_igphoto/{name}".format(domain=config.API_DOMAIN, name=upload_name),
             data=photo_data,

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -287,6 +287,14 @@ class PrivateRequestMixin:
             headers.update({"X-IG-WWW-Claim": self.ig_www_claim})
         return headers
 
+    def private_headers(self, headers=None):
+        request_headers = dict(self.base_headers)
+        if headers:
+            request_headers.update(headers)
+        if self.authorization and not any(key.lower() == "authorization" for key in request_headers):
+            request_headers["Authorization"] = self.authorization
+        return request_headers
+
     def set_country(self, country: str = "US"):
         """Set you country code (ISO 3166-1/3166-2)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.12"
+version = "2.10.13"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -479,6 +479,31 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             if media:
                 self.assertTrue(self.cl.media_delete(media.id))
 
+    def test_clip_upload_with_topics(self):
+        path = self.make_video_fixture(label="clip topics fixture")
+        self.assertIsInstance(path, Path)
+        topics = self.cl.clip_interest_topics()
+        if not topics:
+            self.skipTest("Instagram did not return Reel topics")
+        topic = next((item for item in topics if item.get("name") == "Technology"), topics[0])
+        topic_id = str(topic["fit_id"])
+        media = None
+        try:
+            caption_text = f"Upload clip with topic {int(time.time())}"
+            media = self.cl.clip_upload(path, caption_text, topics=[topic_id])
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.caption_text, caption_text)
+            payload = self.assertUploadedMediaAccessible(
+                media,
+                media_type=2,
+                product_type="clips",
+                caption_text=caption_text,
+            )
+            self.assertTrue(payload.get("video_versions"))
+        finally:
+            if media:
+                self.assertTrue(self.cl.media_delete(media.id))
+
     def test_clip_change_cover_live(self):
         path = self.make_video_fixture(label="clip cover fixture")
         cover_a = self.make_cover_fixture((220, 20, 20))

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -104,6 +104,25 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertFalse(device_status["hw_av1_dec"])
         self.assertEqual(result, expected)
 
+    def test_clip_interest_topics_requests_reel_topic_catalog(self):
+        client = self.build_client()
+        expected = {
+            "sub_interests": [
+                {"name": "Technology", "fit_id": 607271032992452},
+            ],
+            "status": "ok",
+        }
+
+        with mock.patch.object(client, "private_request", return_value=expected) as private_request:
+            result = client.clip_interest_topics()
+
+        private_request.assert_called_once_with(
+            "interest_nux/list_all/",
+            params={"caller": "INTEREST_NUX"},
+            with_signature=False,
+        )
+        self.assertEqual(result, expected["sub_interests"])
+
     def test_clip_share_to_fb_unified_config_requests_android_cxp_query(self):
         client = self.build_client()
         expected = {"status": "ok", "data": {"xcxp_unified_crossposting_configs_root": {}}}
@@ -144,6 +163,31 @@ class UploadRegressionTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(result, expected)
+
+    def test_photo_rupload_sends_private_auth_headers(self):
+        client = self.build_client()
+        client.authorization_data = {
+            "ds_user_id": "1",
+            "sessionid": "1:session",
+            "should_use_header_over_cookies": True,
+        }
+        response = Mock(status_code=200)
+        opened = Mock()
+        opened.__enter__ = Mock(return_value=Mock(size=(720, 720)))
+        opened.__exit__ = Mock(return_value=False)
+
+        with mock.patch("instagrapi.mixins.photo.prepare_image", return_value=(b"photo-bytes", (720, 720))):
+            with mock.patch("instagrapi.mixins.photo.Image.open", return_value=opened):
+                with mock.patch("random.randint", return_value=1234567890):
+                    with mock.patch.object(client.private, "post", return_value=response) as private_post:
+                        upload_id, width, height = client.photo_rupload(Path("image.jpg"), upload_id="upload-id")
+
+        self.assertEqual((upload_id, width, height), ("upload-id", 720, 720))
+        headers = private_post.call_args.kwargs["headers"]
+        self.assertEqual(headers["Authorization"], client.authorization)
+        self.assertEqual(headers["IG-U-DS-USER-ID"], "1")
+        self.assertEqual(headers["X-Entity-Length"], "11")
+        self.assertEqual(headers["X-Entity-Name"], "upload-id_0_1234567890")
 
     def test_clip_share_to_fb_destination_normalizes_current_reel_destination_fields(self):
         client = self.build_client()
@@ -1226,6 +1270,11 @@ class UploadRegressionTestCase(unittest.TestCase):
     def test_clip_upload_uses_current_reels_rupload_shape(self):
         client = self.build_client()
         client.last_json = {"media": self.build_media_payload()}
+        client.authorization_data = {
+            "ds_user_id": "1",
+            "sessionid": "1:session",
+            "should_use_header_over_cookies": True,
+        }
         ok_response = Mock(status_code=200)
 
         with mock.patch(
@@ -1255,6 +1304,8 @@ class UploadRegressionTestCase(unittest.TestCase):
             r"https://i\.instagram\.com/upload_settings/[0-9a-f-]{36}$",
         )
         settings_headers = upload_settings_call.kwargs["headers"]
+        self.assertEqual(settings_headers["Authorization"], client.authorization)
+        self.assertEqual(settings_headers["IG-U-DS-USER-ID"], "1")
         self.assertEqual(settings_headers["Content-Type"], "application/json")
         self.assertEqual(settings_headers["X-Entity-Name"], "upload_settings")
         self.assertEqual(settings_headers["X-Entity-Type"], "application/json")
@@ -1285,6 +1336,8 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertTrue(private_get.call_args.args[0].endswith(upload_name))
 
         headers = video_upload_call.kwargs["headers"]
+        self.assertEqual(headers["Authorization"], client.authorization)
+        self.assertEqual(headers["IG-U-DS-USER-ID"], "1")
         self.assertEqual(headers["Content-Type"], "application/octet-stream")
         self.assertEqual(headers["X-Entity-Type"], "video/mp4")
         self.assertEqual(headers["X-Entity-Length"], "11")
@@ -1405,6 +1458,40 @@ class UploadRegressionTestCase(unittest.TestCase):
                 "custom_field": "1",
             },
         )
+
+    def test_clip_upload_topics_adds_interest_topics_without_mutating_extra_data(self):
+        client = self.build_client()
+        client.last_json = {"media": self.build_media_payload()}
+        ok_response = Mock(status_code=200)
+        extra_data = {"disable_comments": "1"}
+
+        with mock.patch(
+            "instagrapi.mixins.clip.analyze_video",
+            return_value=(Path("/tmp/thumb.jpg"), 720, 1280, 6.023),
+        ):
+            with mock.patch.object(client.private, "get", return_value=ok_response):
+                with mock.patch.object(
+                    client.private,
+                    "post",
+                    side_effect=[ok_response, ok_response],
+                ):
+                    with mock.patch.object(client, "clip_configure", return_value={"status": "ok"}) as clip_configure:
+                        with mock.patch(
+                            "builtins.open",
+                            mock.mock_open(read_data=b"video-bytes"),
+                        ):
+                            with mock.patch("time.sleep"):
+                                client.clip_upload(
+                                    Path("example.mp4"),
+                                    "caption",
+                                    topics=[123, "456"],
+                                    extra_data=extra_data,
+                                )
+
+        self.assertEqual(extra_data, {"disable_comments": "1"})
+        configure_extra = clip_configure.call_args.kwargs["extra_data"]
+        self.assertEqual(configure_extra["disable_comments"], "1")
+        self.assertEqual(configure_extra["interest_topics"], ["123", "456"])
 
     def test_clip_upload_share_to_facebook_adds_crosspost_params_before_upload(self):
         client = self.build_client()


### PR DESCRIPTION
## Summary
- Add `clip_interest_topics()` for Instagram Reel topic catalog lookup.
- Add `topics=[...]` to `clip_upload()` and send topic `fit_id` values as the Android `interest_topics` configure field.
- Send private auth headers on direct Reel/video setup and photo thumbnail rupload requests so header-auth sessions do not fail with `login_required`.
- Bump instagrapi to `2.10.13`.

## Verification
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/ruff check .`
- `.venv/bin/python -m build`
- Live `tests/live/test_upload.py::ClienUploadTestCase::test_clip_upload_with_topics` passed on a real account.

Refs https://github.com/subzeroid/instagrapi/issues/1215