### PR TITLE
Add story poll voting support

### DIFF
--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -14,6 +14,7 @@
 | archive_stories(amount: int = 0)                                        | List[Story]     | Get your archived stories
 | story_like(story_id: str, revert: bool = False)                        | bool            | Like a story
 | story_unlike(story_id: str)                                            | bool            | Unlike a story
+| story_poll_vote(story_id: str, poll_id: str, vote: int)                | bool            | Vote in a story poll by option index
 
 Example:
 
@@ -36,6 +37,10 @@ PosixPath('/app/191260083_2908005872746895_8988438451809588865_n.jpg')
 >>> archived = cl.archive_stories(amount=5)
 >>> [story.pk for story in archived]
 ['3155832952940083788']
+
+>>> story = cl.user_stories(USER_ID, amount=1)[0]
+>>> cl.story_poll_vote(story.id, story.polls[0].id, 0)  # vote for the first option
+True
 ```
 
 ## Story Archive
@@ -101,7 +106,7 @@ Examples:
 
 ``` python
 from instagrapi import Client
-from instagrapi.types import StoryMention, StoryMedia, StoryLink, StoryHashtag
+from instagrapi.types import StoryMention, StoryMedia, StoryLink, StoryHashtag, StoryPoll
 
 cl = Client()
 cl.login(USERNAME, PASSWORD)

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -31,6 +31,7 @@ from .types import (
     StoryLocation,
     StoryMedia,
     StoryMention,
+    StoryPoll,
     Track,
     User,
     UserShort,
@@ -551,6 +552,35 @@ def extract_story_v1(data):
     story["locations"] = [StoryLocation(**location) for location in story.get("story_locations", [])]
     story["hashtags"] = [StoryHashtag(**hashtag) for hashtag in story.get("story_hashtags", [])]
     story["stickers"] = data.get("story_link_stickers") or []
+    story["polls"] = []
+    for poll in story.get("story_polls") or []:
+        poll_sticker = poll.get("poll_sticker") or poll
+        tallies = poll_sticker.get("tallies") or []
+        options = [item.get("text") for item in tallies if item.get("text") is not None]
+        story["polls"].append(
+            StoryPoll(
+                id=poll_sticker.get("poll_id") or poll_sticker.get("id"),
+                type=poll.get("type") or poll_sticker.get("type") or "poll",
+                x=poll.get("x", poll_sticker.get("x", 0.5)),
+                y=poll.get("y", poll_sticker.get("y", 0.5)),
+                z=poll.get("z", poll_sticker.get("z", 0)),
+                width=poll.get("width", poll_sticker.get("width", 0.0)),
+                height=poll.get("height", poll_sticker.get("height", 0.0)),
+                rotation=poll.get("rotation", poll_sticker.get("rotation", 0.0)),
+                is_multi_option=poll_sticker.get(
+                    "is_multi_option",
+                    poll_sticker.get("is_multi_option_poll", True),
+                ),
+                is_shared_result=poll_sticker.get("is_shared_result", False),
+                viewer_can_vote=poll_sticker.get("viewer_can_vote", True),
+                finished=poll_sticker.get("finished", False),
+                color=poll_sticker.get("color", "black"),
+                poll_type=poll_sticker.get("poll_type", ""),
+                question=poll_sticker.get("question", ""),
+                options=options or poll_sticker.get("options") or [],
+                extra=poll_sticker,
+            )
+        )
     feed_medias = []
     story_feed_medias = data.get("story_feed_media") or []
     for feed_media in story_feed_medias:

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -557,6 +557,39 @@ class StoryMixin:
         """
         return self.story_like(story_id, revert=True)
 
+    def story_poll_vote(self, story_id: str, poll_id: str, vote: int) -> bool:
+        """
+        Vote in a story poll
+
+        Parameters
+        ----------
+        story_id: str
+            Unique identifier of a Story
+        poll_id: str
+            Unique identifier of a story poll sticker
+        vote: int
+            Poll option index, starting from 0
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        assert self.user_id, "Login required"
+        if not isinstance(vote, int) or vote < 0:
+            raise ValueError("vote must be a non-negative option index")
+        media_id = self.media_id(story_id)
+        data = {
+            "_uid": str(self.user_id),
+            "_csrftoken": self.token,
+            "vote": str(vote),
+        }
+        result = self.private_request(
+            f"media/{media_id}/{poll_id}/story_poll_vote/",
+            self.with_action_data(data),
+        )
+        return result["status"] == "ok"
+
     def sticker_tray(self) -> dict:
         """
         Getting a sticker tray from Instagram

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -4,6 +4,7 @@ import queue
 import traceback
 from urllib.parse import parse_qs, urlparse
 
+from instagrapi.types import StoryPoll
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -452,6 +453,146 @@ class ClientStoryInteractiveMetadataLiveTestCase(unittest.TestCase):
         self.assertTrue(result["location_names"])
         self.assertIn("instagram", result["hashtag_names"])
         self.assertTrue(any(_is_instagrapi_github_link(url) for url in result["link_urls"]))
+
+
+def _client_from_reusable_test_account(acc):
+    settings = dict(acc["client_settings"])
+    settings.pop("totp_seed", None)
+    client = Client(
+        settings=settings,
+        proxy=os.getenv("IG_PROXY") or acc["proxy"],
+        override_app_version=True,
+    )
+    client._user_id = acc.get("user_id")
+    client.account_info()
+    return client
+
+
+def _fresh_reusable_story_clients(count=10):
+    clients = []
+    seen_user_ids = set()
+    for acc in fetch_test_accounts(count=count, timeout=30):
+        try:
+            client = _client_from_reusable_test_account(acc)
+        except Exception as exc:
+            print(f"Reusable story account skipped: {exc.__class__.__name__} {exc}")
+            continue
+        if client.user_id in seen_user_ids:
+            continue
+        seen_user_ids.add(client.user_id)
+        clients.append(client)
+        if len(clients) >= 2:
+            return clients
+    return clients
+
+
+def _story_payload_for_viewer(client, user_id, story, attempts=12, delay=5):
+    last_item_ids = []
+    for attempt in range(attempts):
+        if attempt:
+            time.sleep(delay)
+        result = client.private_request(f"feed/user/{user_id}/story/")
+        items = (result.get("reel") or {}).get("items") or []
+        last_item_ids = [item.get("id") for item in items[:5]]
+        for item in items:
+            if str(item.get("id")) == str(story.id) or str(item.get("pk")) == str(story.pk):
+                return item
+    raise RuntimeError(f"Story payload was not visible after {attempts} attempts: {last_item_ids}")
+
+
+def _first_poll_sticker(item):
+    story_polls = item.get("story_polls") or []
+    if not story_polls:
+        raise RuntimeError("Story payload did not include story_polls")
+    return story_polls[0].get("poll_sticker") or story_polls[0]
+
+
+def _run_story_poll_vote_live(result_queue):
+    if not TEST_ACCOUNTS_URL:
+        result_queue.put({"status": "skip", "reason": "TEST_ACCOUNTS_URL is required for story poll vote live tests"})
+        return
+
+    author = None
+    story = None
+    try:
+        clients = _fresh_reusable_story_clients()
+        if len(clients) < 2:
+            result_queue.put(
+                {"status": "skip", "reason": "At least two reusable TEST_ACCOUNTS_URL sessions are required"}
+            )
+            return
+        author, voter = clients[:2]
+        story = author.photo_upload_to_story(
+            Path("examples/background.png"),
+            "Story poll vote live test",
+            polls=[
+                StoryPoll(
+                    x=0.5,
+                    y=0.5,
+                    width=0.7,
+                    height=0.3,
+                    question="Poll vote live?",
+                    options=["Yes", "No"],
+                )
+            ],
+        )
+        author_item = _story_payload_for_viewer(author, author.user_id, story)
+        author_poll = _first_poll_sticker(author_item)
+        poll_id = author_poll.get("poll_id") or author_poll.get("id")
+        voter_before = _first_poll_sticker(_story_payload_for_viewer(voter, author.user_id, story))
+        voted = voter.story_poll_vote(story.id, poll_id, 0)
+        voter_after = _first_poll_sticker(_story_payload_for_viewer(voter, author.user_id, story))
+        result_queue.put(
+            {
+                "status": "ok",
+                "story_id": story.id,
+                "poll_id": poll_id,
+                "voted": voted,
+                "viewer_vote_before": voter_before.get("viewer_vote"),
+                "viewer_vote_after": voter_after.get("viewer_vote"),
+                "tallies_after": voter_after.get("tallies") or [],
+            }
+        )
+    except Exception:
+        result_queue.put({"status": "error", "traceback": traceback.format_exc()})
+    finally:
+        if author and story:
+            try:
+                author.story_delete(story.id)
+            except Exception as exc:
+                print(f"Story poll vote live cleanup story_delete failed: {exc.__class__.__name__} {exc}")
+
+
+class ClientStoryPollVoteLiveTestCase(unittest.TestCase):
+    def test_story_poll_vote_live(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for story poll vote live tests")
+        ctx = multiprocessing.get_context("spawn")
+        result_queue = ctx.Queue()
+        process = ctx.Process(target=_run_story_poll_vote_live, args=(result_queue,))
+        process.start()
+        timeout = int(os.getenv("INSTAGRAPI_STORY_POLL_VOTE_LIVE_TIMEOUT", "240"))
+        process.join(timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join(10)
+            self.skipTest(f"Story poll vote live workflow timed out after {timeout} seconds")
+        try:
+            result = result_queue.get(timeout=5)
+        except queue.Empty:
+            if process.exitcode:
+                self.fail(f"Story poll vote live workflow exited with code {process.exitcode}")
+            self.fail("Story poll vote live workflow did not return a result")
+        if result["status"] == "skip":
+            self.skipTest(result["reason"])
+        if result["status"] == "error":
+            self.fail(result["traceback"])
+        self.assertTrue(result["story_id"])
+        self.assertTrue(result["poll_id"])
+        self.assertTrue(result["voted"])
+        self.assertIsNone(result["viewer_vote_before"])
+        self.assertEqual(result["viewer_vote_after"], 0)
+        self.assertGreaterEqual(result["tallies_after"][0]["count"], 1)
 
 
 class ClientStoryMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -95,3 +95,69 @@ class StoryMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(users[0].pk, "123")
         self.assertEqual(len(users[0].stories), 1)
         self.assertEqual(users[0].stories[0].id, "1234567890_123")
+
+    def test_extract_story_v1_reads_poll_stickers(self):
+        story = extract_story_v1(
+            {
+                "pk": "1",
+                "id": "1_2",
+                "code": "abc",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": "https://example.com/thumbnail.jpg",
+                            "width": 720,
+                            "height": 1280,
+                        }
+                    ]
+                },
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "story_polls": [
+                    {
+                        "x": 0.5,
+                        "y": 0.5,
+                        "z": 0,
+                        "width": 0.7,
+                        "height": 0.3,
+                        "rotation": 0.0,
+                        "poll_sticker": {
+                            "poll_id": "17895695668004550",
+                            "question": "Pick one",
+                            "viewer_can_vote": True,
+                            "finished": False,
+                            "tallies": [
+                                {"text": "Yes", "count": 1},
+                                {"text": "No", "count": 0},
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(len(story.polls), 1)
+        self.assertEqual(story.polls[0].id, "17895695668004550")
+        self.assertEqual(story.polls[0].question, "Pick one")
+        self.assertEqual(story.polls[0].options, ["Yes", "No"])
+        self.assertTrue(story.polls[0].viewer_can_vote)
+
+    def test_story_poll_vote_posts_vote_to_poll_endpoint(self):
+        client = self.build_private_client()
+        client._user_id = "1"
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.story_poll_vote("1234567890_1", "17895695668004550", 1)
+
+        self.assertTrue(result)
+        private_request.assert_called_once()
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/1234567890_1/17895695668004550/story_poll_vote/")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["vote"], "1")
+        self.assertEqual(data["radio_type"], "wifi-none")


### PR DESCRIPTION
## Summary
- Adds `Client.story_poll_vote(story_id, poll_id, vote)` for private API story poll voting by option index.
- Extracts private API `story_polls` into `Story.polls`, including poll id, question, options, and viewer vote capability.
- Adds regression coverage, a reusable-session live poll vote workflow, and story usage docs.

## Tests
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m pytest -q tests/live/test_story.py::ClientStoryPollVoteLiveTestCase::test_story_poll_vote_live`
- sk.test: `PYTHONPATH=/tmp/instagrapi-1123 /home/test/instagrapi/.venv/bin/python -m pytest -q -rs tests/live/test_story.py::ClientStoryPollVoteLiveTestCase::test_story_poll_vote_live`

Closes https://github.com/subzeroid/instagrapi/issues/1123