### PR TITLE
Fix duplicate user follow action handling

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -88,7 +88,7 @@ Low level methods:
 The batch follow request helpers call the single-user approve/decline endpoints for
 each `user_id`; they do not implement an auto-approval policy.
 
-`user_follow()` returns `True` when Instagram reports either an immediate follow or an outgoing follow request for a private account. Use `user_friendship_v1()` when you need to distinguish `following` from `outgoing_request`.
+`user_follow()` returns `True` only when it sends a new follow action and Instagram reports either an immediate follow or a new outgoing follow request for a private account. It returns `False` when the current account already follows the target or already has a pending outgoing follow request. Use `user_friendship_v1()` when you need to distinguish `following` from `outgoing_request`.
 
 Example:
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -1330,8 +1330,18 @@ class UserMixin:
         """
         assert self.user_id, "Login required"
         user_id = str(user_id)
-        if user_id in self._users_following.get(self.user_id, []):
+        current_user_id = str(self.user_id)
+        following_cache = self._users_following.get(current_user_id)
+        if user_id in (following_cache or {}):
             self.logger.debug("User %s already followed", user_id)
+            return False
+        try:
+            relationship = self.user_friendship_v1(user_id)
+        except Exception as e:
+            logger.debug("Unable to pre-check friendship for %s before follow: %r", user_id, e)
+            relationship = None
+        if relationship and (relationship.following or relationship.outgoing_request):
+            self.logger.debug("User %s already followed or requested", user_id)
             return False
         data = self.with_action_data(
             {
@@ -1342,10 +1352,11 @@ class UserMixin:
             }
         )
         result = self.private_request(f"friendships/create/{user_id}/", data)
-        if self.user_id in self._users_following:
-            self._users_following.pop(self.user_id)  # reset
         friendship_status = result["friendship_status"]
-        return friendship_status.get("following") is True or friendship_status.get("outgoing_request") is True
+        followed = friendship_status.get("following") is True or friendship_status.get("outgoing_request") is True
+        if followed and following_cache is not None:
+            following_cache[user_id] = self._userhorts_cache.get(user_id) or UserShort(pk=user_id)
+        return followed
 
     def user_unfollow(self, user_id: str) -> bool:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.10.14"
+version = "2.11.0"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -430,6 +430,58 @@ class ClientUserExtendTestCase(_helpers.ClientPrivateTestCase):
     #     self.cl.create_note("Hello from Instagrapi!", 0)
 
 
+def _client_from_reusable_test_account(acc):
+    settings = dict(acc["client_settings"])
+    settings.pop("totp_seed", None)
+    client = Client(
+        settings=settings,
+        proxy=os.getenv("IG_PROXY") or acc["proxy"],
+        override_app_version=True,
+    )
+    client._user_id = acc.get("user_id")
+    client.account_info()
+    return client
+
+
+def _fresh_reusable_user_clients(count=20):
+    clients = []
+    seen_user_ids = set()
+    for acc in _helpers.fetch_test_accounts(count=count, timeout=30):
+        try:
+            client = _client_from_reusable_test_account(acc)
+        except Exception:
+            continue
+        if client.user_id in seen_user_ids:
+            continue
+        seen_user_ids.add(client.user_id)
+        clients.append(client)
+        if len(clients) >= 2:
+            return clients
+    return clients
+
+
+class ClientUserFollowActionLiveTestCase(unittest.TestCase):
+    def test_user_follow_returns_false_for_existing_follow_live(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for follow action live tests")
+        clients = _fresh_reusable_user_clients()
+        if len(clients) < 2:
+            self.skipTest("At least two reusable TEST_ACCOUNTS_URL sessions are required")
+        requester, target = clients[:2]
+        target_id = str(target.user_id)
+        try:
+            try:
+                requester.user_unfollow(target_id)
+            except Exception:
+                pass
+            self.assertTrue(requester.user_follow(target_id))
+            relationship = requester.user_friendship_v1(target_id)
+            self.assertTrue(relationship.following or relationship.outgoing_request)
+            self.assertFalse(requester.user_follow(target_id))
+        finally:
+            requester.user_unfollow(target_id)
+
+
 class ClientFollowRequestLiveTestCase(_helpers.ClientPrivateTestCase):
     def __init__(self, *args, **kwargs):
         self.cl = None

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -868,6 +868,45 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         ):
             self.assertTrue(client.user_follow("42"))
 
+    def test_user_follow_skips_create_when_friendship_already_following(self):
+        client = self.build_private_client()
+
+        with mock.patch.object(
+            client,
+            "user_friendship_v1",
+            return_value=mock.Mock(following=True, outgoing_request=False),
+        ) as friendship:
+            with mock.patch.object(
+                client,
+                "private_request",
+                side_effect=AssertionError("already-following users should not receive create requests"),
+            ) as private_request:
+                self.assertFalse(client.user_follow("42"))
+
+        friendship.assert_called_once_with("42")
+        private_request.assert_not_called()
+
+    def test_user_follow_updates_existing_following_cache_after_success(self):
+        client = self.build_private_client()
+        client._users_following = {str(client.user_id): {}}
+
+        with mock.patch.object(
+            client,
+            "user_friendship_v1",
+            return_value=mock.Mock(following=False, outgoing_request=False),
+        ):
+            with mock.patch.object(
+                client,
+                "private_request",
+                return_value={"friendship_status": {"following": True}},
+            ) as private_request:
+                self.assertTrue(client.user_follow("42"))
+                self.assertFalse(client.user_follow("42"))
+
+        private_request.assert_called_once()
+        self.assertIn("42", client._users_following[str(client.user_id)])
+        self.assertIsInstance(client._users_following[str(client.user_id)]["42"], UserShort)
+
     def test_user_unfollow_posts_current_action_context(self):
         client = self.build_private_client()
         client.android_device_id = "android-device"


### PR DESCRIPTION
## Summary
- Make `user_follow(...)` return `False` for targets that are already followed or already have an outgoing follow request, instead of counting duplicate `friendships/create` responses as new actions.
- Preserve and update the current account's following cache after a successful follow instead of clearing the whole cache.
- Bump the package version to `2.11.0` and document the updated `user_follow(...)` return semantics.

## Links
- Fixes https://github.com/subzeroid/instagrapi/issues/1178

## Verification
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q tests/regression` -> `575 passed, 3 skipped, 7 subtests passed`
- `.venv/bin/python -m pytest -q -rs tests/live/test_user.py::ClientUserFollowActionLiveTestCase::test_user_follow_returns_false_for_existing_follow_live` -> `1 passed, 1 warning`
- Remote fresh-clone live verification of `tests/live/test_user.py::ClientUserFollowActionLiveTestCase::test_user_follow_returns_false_for_existing_follow_live` -> `1 passed, 1 warning in 14.66s`
- `.venv/bin/python -m build --no-isolation`