### PR TITLE
Preserve v2 UserShort fields

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -90,6 +90,8 @@ each `user_id`; they do not implement an auto-approval policy.
 
 `user_follow()` returns `True` only when it sends a new follow action and Instagram reports either an immediate follow or a new outgoing follow request for a private account. It returns `False` when the current account already follows the target or already has a pending outgoing follow request. Use `user_friendship_v1()` when you need to distinguish `following` from `outgoing_request`.
 
+`UserShort` objects returned from private GraphQL follow-list payloads preserve selected v2-only fields when Instagram sends them: `friendship_status`, `profile_pic_id`, `fbid_v2`, `interop_messaging_user_fbid`, `strong_id__`, and raw `account_badges`. The legacy `latest_reel_media` property is also populated from Instagram's current `1llatest_reel_media` key.
+
 Example:
 
 ``` python

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -221,6 +221,18 @@ def extract_user_short(data):
     """Extract User Short info"""
     data["pk"] = data.get("id", data.get("pk", None))
     assert data["pk"], f'User without pk "{data}"'
+    if "latest_reel_media" not in data and "1llatest_reel_media" in data:
+        data["latest_reel_media"] = data.get("1llatest_reel_media")
+    friendship_status = data.get("friendship_status")
+    if isinstance(friendship_status, dict):
+        friendship_status.setdefault("user_id", str(data["pk"]))
+        friendship_status.setdefault("following", False)
+        friendship_status.setdefault("incoming_request", False)
+        friendship_status.setdefault("is_bestie", False)
+        friendship_status.setdefault("is_feed_favorite", False)
+        friendship_status.setdefault("is_private", False)
+        friendship_status.setdefault("is_restricted", False)
+        friendship_status.setdefault("outgoing_request", False)
     return UserShort(**data)
 
 

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -145,6 +145,17 @@ class Account(TypesBaseModel):
         raise ValidationError("external_url must be a URL or string")
 
 
+class RelationshipShort(TypesBaseModel):
+    user_id: str
+    following: bool
+    incoming_request: bool
+    is_bestie: bool
+    is_feed_favorite: bool
+    is_private: bool
+    is_restricted: bool
+    outgoing_request: bool
+
+
 class UserShort(TypesBaseModel):
     def __hash__(self):
         return hash(self.pk)
@@ -164,6 +175,12 @@ class UserShort(TypesBaseModel):
     is_verified: Optional[bool] = None
     latest_reel_media: Optional[int] = None
     has_anonymous_profile_picture: Optional[bool] = None
+    profile_pic_id: Optional[str] = None
+    fbid_v2: Optional[str] = None
+    interop_messaging_user_fbid: Optional[str] = None
+    strong_id__: Optional[str] = None
+    account_badges: List[dict] = Field(default_factory=list)
+    friendship_status: Optional[RelationshipShort] = None
 
 
 class Viewer(UserShort):
@@ -989,17 +1006,6 @@ class Relationship(TypesBaseModel):
     is_private: bool
     is_restricted: bool
     muting: bool
-    outgoing_request: bool
-
-
-class RelationshipShort(TypesBaseModel):
-    user_id: str
-    following: bool
-    incoming_request: bool
-    is_bestie: bool
-    is_feed_favorite: bool
-    is_private: bool
-    is_restricted: bool
     outgoing_request: bool
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.11.0"
+version = "2.12.0"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -4,6 +4,7 @@ import queue
 import traceback
 
 from instagrapi import types as ig_types
+from instagrapi.extractors import extract_user_short
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -54,6 +55,34 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         followers = self.cl.user_followers_private_gql(user_id, amount=5, order="date_followed_latest")
         self.assertEqual(len(followers), 5)
         self.assertIsInstance(followers[0], UserShort)
+
+
+class ClientPrivateGraphQLV2UserFieldsLiveTestCase(unittest.TestCase):
+    def test_user_followers_private_gql_preserves_v2_user_fields(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for private GraphQL v2 user field live tests")
+        cl = fresh_test_account(count=5, attempts=5, timeout=30)
+        user_id = cl.user_id_from_username("instagram")
+        result = cl.private_graphql_followers_list(user_id, cl.rank_token, order="date_followed_latest")
+        data = result.get("data") or {}
+        followers = next(
+            (value for key, value in data.items() if "xdt_api__v1__friendships__followers" in key),
+            {},
+        )
+        raw_user = next((user for user in followers.get("users", []) if user.get("friendship_status")), None)
+        if raw_user is None:
+            self.skipTest("private GraphQL followers payload did not include friendship_status")
+
+        rich_user = extract_user_short(dict(raw_user))
+
+        self.assertIsInstance(rich_user, UserShort)
+        self.assertIsNotNone(rich_user.latest_reel_media)
+        self.assertIsInstance(rich_user.account_badges, list)
+        self.assertIsInstance(rich_user.friendship_status, ig_types.RelationshipShort)
+        for field in ("profile_pic_id", "fbid_v2", "interop_messaging_user_fbid", "strong_id__"):
+            raw_value = raw_user.get(field)
+            if raw_value is not None:
+                self.assertEqual(getattr(rich_user, field), str(raw_value))
 
 
 def _run_business_email_live(result_queue):

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -123,6 +123,45 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(user.latest_reel_media, 1710000123)
         self.assertFalse(user.has_anonymous_profile_picture)
 
+    def test_extract_user_short_preserves_private_graphql_v2_fields(self):
+        payload = {
+            "id": "123",
+            "strong_id__": "123",
+            "username": "follower",
+            "full_name": "Follower",
+            "is_private": False,
+            "is_verified": True,
+            "1llatest_reel_media": 1710000123,
+            "account_badges": [{"badge_type": "example"}],
+            "fbid_v2": 17841400000000000,
+            "friendship_status": {
+                "following": True,
+                "incoming_request": False,
+                "is_bestie": False,
+                "is_feed_favorite": True,
+                "is_private": False,
+                "is_restricted": False,
+                "outgoing_request": False,
+            },
+            "has_anonymous_profile_picture": False,
+            "interop_messaging_user_fbid": 117943452927407,
+            "profile_pic_id": "3725434617063385984_123",
+            "profile_pic_url": "https://example.com/pic.jpg",
+        }
+
+        user = extract_user_short(payload)
+
+        self.assertEqual(user.pk, "123")
+        self.assertEqual(user.latest_reel_media, 1710000123)
+        self.assertEqual(user.profile_pic_id, "3725434617063385984_123")
+        self.assertEqual(user.fbid_v2, "17841400000000000")
+        self.assertEqual(user.interop_messaging_user_fbid, "117943452927407")
+        self.assertEqual(user.strong_id__, "123")
+        self.assertEqual(user.account_badges, [{"badge_type": "example"}])
+        self.assertEqual(user.friendship_status.user_id, "123")
+        self.assertTrue(user.friendship_status.following)
+        self.assertTrue(user.friendship_status.is_feed_favorite)
+
     def test_user_short_gql_uses_web_profile_doc_id_without_legacy_query_hash(self):
         client = Client()
         web_user = {


### PR DESCRIPTION
## Summary
- Preserve selected v2-only user fields on `UserShort` when private GraphQL follow-list payloads include them.
- Normalize Instagram's current `1llatest_reel_media` key into the existing `latest_reel_media` property.
- Keep existing follow-list APIs returning `UserShort`; this is a typed-data expansion, not a new method surface.
- Bump package version to 2.12.0.

## Links
- Issue: https://github.com/subzeroid/instagrapi/issues/1523

## Verification
- RED: `test_extract_user_short_preserves_private_graphql_v2_fields` failed before implementation because `latest_reel_media` stayed `None` and v2-only fields were not exposed.
- `.venv/bin/python -m pytest -q tests/regression/test_user.py::UserMixinRegressionTestCase::test_extract_user_short_preserves_follower_payload_fields tests/regression/test_user.py::UserMixinRegressionTestCase::test_extract_user_short_preserves_private_graphql_v2_fields tests/regression/test_user.py::UserMixinRegressionTestCase::test_user_followers_private_gql_paginates_until_amount`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q tests/regression`
- Remote fresh-clone live verification passed for `tests/live/test_user.py::ClientPrivateGraphQLV2UserFieldsLiveTestCase::test_user_followers_private_gql_preserves_v2_user_fields`.
- `.venv/bin/python -m build --no-isolation`
