### PR TITLE
Add story likers

### DIFF
--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -10,6 +10,7 @@
 | story_download(story_pk: int, filename: str = "", folder: Path = "")   | Path            | Download story media by media_type
 | story_download_by_url(url: str, filename: str = "", folder: Path = "") | Path            | Download story media using URL to file (mp4 or jpg)
 | story_viewers(story_pk: int, amount: int = 20)                         | List[UserShort] | List of story viewers (via Private API)
+| story_likers(story_pk: int, amount: int = 0)                           | List[UserShort] | List of story likers (via Private API)
 | archive_story_days(amount: int = 0, include_memories: bool = True)      | List[StoryArchiveDay] | Get your story archive day shells
 | archive_stories(amount: int = 0)                                        | List[Story]     | Get your archived stories
 | story_like(story_id: str, revert: bool = False)                        | bool            | Like a story

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -511,6 +511,50 @@ class StoryMixin:
             viewers = viewers[:amount]
         return viewers
 
+    def story_likers_chunk(self, story_pk: int, max_amount: int = 0, max_id: str = "") -> tuple[list[UserShort], str]:
+        unique_set: set[str] = set()
+        likers: list[UserShort] = []
+        story_pk = self.media_pk(story_pk)
+        params = {"supported_capabilities_new": json.dumps(config.SUPPORTED_CAPABILITIES)}
+
+        while True:
+            if max_id:
+                params["max_id"] = max_id
+            result = self.private_request(f"media/{story_pk}/list_reel_media_viewer/", params=params)
+            for item in result.get("viewers") or []:
+                if not item.get("has_liked"):
+                    continue
+                liker = extract_user_short(item["user"])
+                if liker.pk in unique_set:
+                    continue
+                unique_set.add(liker.pk)
+                likers.append(liker)
+
+            max_id = result.get("next_max_id")
+            if not max_id or (max_amount and len(likers) >= max_amount):
+                break
+        return likers, max_id
+
+    def story_likers(self, story_pk: int, amount: int = 0) -> List[UserShort]:
+        """
+        List of story likers (Private API)
+
+        Parameters
+        ----------
+        story_pk: int
+        amount: int, optional
+            Maximum number of story likers
+
+        Returns
+        -------
+        List[UserShort]
+            A list of objects of UserShort
+        """
+        likers, _ = self.story_likers_chunk(story_pk, amount)
+        if amount:
+            likers = likers[:amount]
+        return likers
+
     def story_like(self, story_id: str, revert: bool = False) -> bool:
         """
         Like a story

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.12.0"
+version = "2.13.0"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -595,6 +595,88 @@ class ClientStoryPollVoteLiveTestCase(unittest.TestCase):
         self.assertGreaterEqual(result["tallies_after"][0]["count"], 1)
 
 
+def _story_likers_until_contains(client, story_pk, expected_user_id, attempts=12, delay=5):
+    last_liker_ids = []
+    for attempt in range(attempts):
+        if attempt:
+            time.sleep(delay)
+        likers = client.story_likers(story_pk, amount=20)
+        last_liker_ids = [str(liker.pk) for liker in likers]
+        if str(expected_user_id) in last_liker_ids:
+            return likers
+    raise RuntimeError(f"Story likers did not include {expected_user_id} after {attempts} attempts: {last_liker_ids}")
+
+
+def _run_story_likers_live(result_queue):
+    if not TEST_ACCOUNTS_URL:
+        result_queue.put({"status": "skip", "reason": "TEST_ACCOUNTS_URL is required for story likers live tests"})
+        return
+
+    author = None
+    story = None
+    try:
+        clients = _fresh_reusable_story_clients()
+        if len(clients) < 2:
+            result_queue.put(
+                {"status": "skip", "reason": "At least two reusable TEST_ACCOUNTS_URL sessions are required"}
+            )
+            return
+        author, liker = clients[:2]
+        story = author.photo_upload_to_story(Path("examples/background.png"), "Story likers live test")
+        _story_payload_for_viewer(liker, author.user_id, story)
+        seen = liker.story_seen([story.pk])
+        liked = liker.story_like(story.id)
+        likers = _story_likers_until_contains(author, story.pk, liker.user_id)
+        result_queue.put(
+            {
+                "status": "ok",
+                "story_id": story.id,
+                "seen": seen,
+                "liked": liked,
+                "liker_user_id": str(liker.user_id),
+                "liker_ids": [str(user.pk) for user in likers],
+            }
+        )
+    except Exception:
+        result_queue.put({"status": "error", "traceback": traceback.format_exc()})
+    finally:
+        if author and story:
+            try:
+                author.story_delete(story.id)
+            except Exception as exc:
+                print(f"Story likers live cleanup story_delete failed: {exc.__class__.__name__} {exc}")
+
+
+class ClientStoryLikersLiveTestCase(unittest.TestCase):
+    def test_story_likers_live(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for story likers live tests")
+        ctx = multiprocessing.get_context("spawn")
+        result_queue = ctx.Queue()
+        process = ctx.Process(target=_run_story_likers_live, args=(result_queue,))
+        process.start()
+        timeout = int(os.getenv("INSTAGRAPI_STORY_LIKERS_LIVE_TIMEOUT", "240"))
+        process.join(timeout)
+        if process.is_alive():
+            process.terminate()
+            process.join(10)
+            self.skipTest(f"Story likers live workflow timed out after {timeout} seconds")
+        try:
+            result = result_queue.get(timeout=5)
+        except queue.Empty:
+            if process.exitcode:
+                self.fail(f"Story likers live workflow exited with code {process.exitcode}")
+            self.fail("Story likers live workflow did not return a result")
+        if result["status"] == "skip":
+            self.skipTest(result["reason"])
+        if result["status"] == "error":
+            self.fail(result["traceback"])
+        self.assertTrue(result["story_id"])
+        self.assertTrue(result["seen"])
+        self.assertTrue(result["liked"])
+        self.assertIn(result["liker_user_id"], result["liker_ids"])
+
+
 class ClientStoryMusicUploadLiveTestCase(_helpers.ClientPrivateTestCase):
     photo_path = Path("examples/background.png")
 

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -161,3 +161,101 @@ class StoryMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["_uid"], "1")
         self.assertEqual(data["vote"], "1")
         self.assertEqual(data["radio_type"], "wifi-none")
+
+    def test_story_likers_chunk_filters_liked_viewers_and_deduplicates_users(self):
+        client = self.build_private_client()
+        responses = [
+            {
+                "viewers": [
+                    {
+                        "has_liked": True,
+                        "user": {
+                            "pk": "10",
+                            "username": "liked_1",
+                            "profile_pic_url": "https://example.com/liked_1.jpg",
+                        },
+                    },
+                    {
+                        "has_liked": False,
+                        "user": {
+                            "pk": "20",
+                            "username": "viewer_only",
+                            "profile_pic_url": "https://example.com/viewer_only.jpg",
+                        },
+                    },
+                ],
+                "next_max_id": "page-2",
+            },
+            {
+                "viewers": [
+                    {
+                        "has_liked": True,
+                        "user": {
+                            "pk": "10",
+                            "username": "liked_1_duplicate",
+                            "profile_pic_url": "https://example.com/liked_1_duplicate.jpg",
+                        },
+                    },
+                    {
+                        "has_liked": True,
+                        "user": {
+                            "pk": "30",
+                            "username": "liked_2",
+                            "profile_pic_url": "https://example.com/liked_2.jpg",
+                        },
+                    },
+                ],
+            },
+        ]
+
+        with mock.patch.object(client, "private_request", side_effect=responses) as private_request:
+            likers, max_id = client.story_likers_chunk("1234567890_1")
+
+        self.assertEqual([liker.pk for liker in likers], ["10", "30"])
+        self.assertEqual([liker.username for liker in likers], ["liked_1", "liked_2"])
+        self.assertIsNone(max_id)
+        self.assertEqual(private_request.call_args_list[0].args[0], "media/1234567890/list_reel_media_viewer/")
+        self.assertIn("supported_capabilities_new", private_request.call_args_list[0].kwargs["params"])
+        self.assertEqual(private_request.call_args_list[1].kwargs["params"]["max_id"], "page-2")
+
+    def test_story_likers_limits_amount(self):
+        client = self.build_private_client()
+        responses = [
+            {
+                "viewers": [
+                    {
+                        "has_liked": True,
+                        "user": {
+                            "pk": "10",
+                            "username": "liked_1",
+                            "profile_pic_url": "https://example.com/liked_1.jpg",
+                        },
+                    },
+                    {
+                        "has_liked": True,
+                        "user": {
+                            "pk": "20",
+                            "username": "liked_2",
+                            "profile_pic_url": "https://example.com/liked_2.jpg",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        with mock.patch.object(client, "private_request", side_effect=responses):
+            likers = client.story_likers("1234567890_1", amount=1)
+
+        self.assertEqual([liker.pk for liker in likers], ["10"])
+
+    def test_story_likers_handles_viewer_payload_without_viewers(self):
+        client = self.build_private_client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"status": "ok", "user_count": 0, "total_viewer_count": 0},
+        ):
+            likers = client.story_likers("1234567890_1")
+
+        self.assertEqual(likers, [])


### PR DESCRIPTION
Adds `Client.story_likers(...)` and `Client.story_likers_chunk(...)` for story likes, using the existing `list_reel_media_viewer` payload and filtering viewer rows where `has_liked` is set.

Fixes https://github.com/subzeroid/instagrapi/issues/833

Verification:
- `.venv/bin/python -m pytest -q tests/regression/test_story.py`
- `.venv/bin/python -m ruff check instagrapi/mixins/story.py tests/regression/test_story.py tests/live/test_story.py`
- `.venv/bin/python -m build`
- Remote fresh-clone live verification: `.venv/bin/python -m pytest -q -s tests/live/test_story.py::ClientStoryLikersLiveTestCase::test_story_likers_live` -> `1 passed`