### PR TITLE
Mark stories seen before liking

### DIFF
--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -13,7 +13,7 @@
 | story_likers(story_pk: int, amount: int = 0)                           | List[UserShort] | List of story likers (via Private API)
 | archive_story_days(amount: int = 0, include_memories: bool = True)      | List[StoryArchiveDay] | Get your story archive day shells
 | archive_stories(amount: int = 0)                                        | List[Story]     | Get your archived stories
-| story_like(story_id: str, revert: bool = False)                        | bool            | Like a story
+| story_like(story_id: str, revert: bool = False, mark_seen: bool = True) | bool            | Like a story
 | story_unlike(story_id: str)                                            | bool            | Unlike a story
 | story_poll_vote(story_id: str, poll_id: str, vote: int)                | bool            | Vote in a story poll by option index
 

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -555,7 +555,7 @@ class StoryMixin:
             likers = likers[:amount]
         return likers
 
-    def story_like(self, story_id: str, revert: bool = False) -> bool:
+    def story_like(self, story_id: str, revert: bool = False, mark_seen: bool = True) -> bool:
         """
         Like a story
 
@@ -565,6 +565,8 @@ class StoryMixin:
             Unique identifier of a Story
         revert: bool, optional
             If liked, whether or not to unlike. Default is False
+        mark_seen: bool, optional
+            Mark story as seen before liking. Default is True
 
         Returns
         -------
@@ -573,6 +575,8 @@ class StoryMixin:
         """
         assert self.user_id, "Login required"
         media_id = self.media_id(story_id)
+        if mark_seen and not revert:
+            self.story_seen([self.media_pk(media_id)])
         data = {
             "media_id": media_id,
             "_uid": str(self.user_id),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.13.0"
+version = "2.13.1"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/live/test_story.py
+++ b/tests/live/test_story.py
@@ -624,14 +624,12 @@ def _run_story_likers_live(result_queue):
         author, liker = clients[:2]
         story = author.photo_upload_to_story(Path("examples/background.png"), "Story likers live test")
         _story_payload_for_viewer(liker, author.user_id, story)
-        seen = liker.story_seen([story.pk])
         liked = liker.story_like(story.id)
         likers = _story_likers_until_contains(author, story.pk, liker.user_id)
         result_queue.put(
             {
                 "status": "ok",
                 "story_id": story.id,
-                "seen": seen,
                 "liked": liked,
                 "liker_user_id": str(liker.user_id),
                 "liker_ids": [str(user.pk) for user in likers],
@@ -672,7 +670,6 @@ class ClientStoryLikersLiveTestCase(unittest.TestCase):
         if result["status"] == "error":
             self.fail(result["traceback"])
         self.assertTrue(result["story_id"])
-        self.assertTrue(result["seen"])
         self.assertTrue(result["liked"])
         self.assertIn(result["liker_user_id"], result["liker_ids"])
 

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -259,3 +259,39 @@ class StoryMixinRegressionTestCase(unittest.TestCase):
             likers = client.story_likers("1234567890_1")
 
         self.assertEqual(likers, [])
+
+    def test_story_like_marks_story_seen_before_liking(self):
+        client = self.build_private_client()
+        client._user_id = "1"
+
+        with mock.patch.object(client, "story_seen", return_value=True) as story_seen:
+            with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+                result = client.story_like("1234567890_1")
+
+        self.assertTrue(result)
+        story_seen.assert_called_once_with(["1234567890"])
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "story_interactions/send_story_like")
+
+    def test_story_like_can_skip_mark_seen(self):
+        client = self.build_private_client()
+        client._user_id = "1"
+
+        with mock.patch.object(client, "story_seen", return_value=True) as story_seen:
+            with mock.patch.object(client, "private_request", return_value={"status": "ok"}):
+                result = client.story_like("1234567890_1", mark_seen=False)
+
+        self.assertTrue(result)
+        story_seen.assert_not_called()
+
+    def test_story_unlike_does_not_mark_story_seen(self):
+        client = self.build_private_client()
+        client._user_id = "1"
+
+        with mock.patch.object(client, "story_seen", return_value=True) as story_seen:
+            with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+                result = client.story_unlike("1234567890_1")
+
+        self.assertTrue(result)
+        story_seen.assert_not_called()
+        self.assertEqual(private_request.call_args.args[0], "story_interactions/unsend_story_like")


### PR DESCRIPTION
`story_like()` now marks the story as seen before sending the like by default, matching the behavior needed for the author-side viewer row to appear with `has_liked=True`. `story_like(..., mark_seen=False)` keeps the old low-level behavior, and `story_unlike()` does not create a seen event.

Fixes https://github.com/subzeroid/instagrapi/issues/912

Related: https://github.com/subzeroid/instagrapi/issues/913

Verification:
- `.venv/bin/python -m pytest -q tests/regression/test_story.py`
- `.venv/bin/python -m ruff check instagrapi/mixins/story.py tests/regression/test_story.py tests/live/test_story.py`
- `.venv/bin/python -m build`
- Remote fresh-clone live verification: `.venv/bin/python -m pytest -q -s tests/live/test_story.py::ClientStoryLikersLiveTestCase::test_story_likers_live` -> `1 passed`