### PR TITLE
Add fit resize mode for story uploads

### DIFF
--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -75,11 +75,12 @@ Common arguments:
 * `stickers` - Add stickers to story
 * `medias` - Reshared feed media stickers
 * `polls` - Add polls to story
+* `resize_mode` - Story media sizing mode: `"fill"` keeps the current crop/fill behavior, `"fit"` renders the full source media on a Story canvas without cropping
 
 | Method                               | Return   | Description
 | ------------------------------------ | -------- | -------------
-| photo_upload_to_story(path: Path, caption: str = "", upload_id: str = "", mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {})  | Story  | Upload photo to story
-| video_upload_to_story(path: Path, caption: str = "", thumbnail: Path = None, mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}) | Story  | Upload video to story
+| photo_upload_to_story(path: Path, caption: str = "", upload_id: str = "", mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: str = "fill")  | Story  | Upload photo to story
+| video_upload_to_story(path: Path, caption: str = "", thumbnail: Path = None, mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: str = "fill") | Story  | Upload video to story
 | media_share_to_story(media_id: str, background: Path = None, caption: str = "") | Story | Share an existing post to your story with a generated or provided background
 | photo_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, duration: float = 15.0, extra_data: Dict = {}) | Story | Upload photo to story as a short video with the selected music track muxed into it
 | video_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Story | Upload video to story with the selected music track muxed into it
@@ -96,7 +97,7 @@ Notes:
 * `links`, `hashtags`, `locations`, `stickers`, `medias`, and `polls` are all part of the story sticker payload.
 * `media_share_to_story()` is a convenience wrapper for the feed media sticker flow. It uploads a generated black 9:16 background unless you pass your own `background`.
 * Link stickers are supported through `StoryLink`; this is no longer the old Instagram "swipe up" flow.
-* For story uploads, use a 9:16 asset or build one with `StoryBuilder`.
+* For story uploads, use a 9:16 asset, pass `resize_mode="fit"` to keep the full source media visible on a Story canvas, or build one manually with `StoryBuilder`.
 * Android users should pass `thumbnail=...` for video stories or install the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg. See [Pydroid and ffmpeg](pydroid.md) and [Termux](termux.md).
 * Story music helpers require the optional video dependencies, MoviePy `2.2.1`, and executable ffmpeg because they render a local MP4 before upload.
 * Story music helpers add Story music metadata and bake the selected track into the uploaded media. They do not expose Instagram's native interactive lyrics/music sticker UI.
@@ -128,6 +129,13 @@ cl.video_upload_to_story(
 )
 
 cl.media_share_to_story(media_pk, caption="Shared to story")
+```
+
+Fit a landscape photo or video into a Story without cropping:
+
+``` python
+cl.photo_upload_to_story(Path("/app/landscape.jpg"), resize_mode="fit")
+cl.video_upload_to_story(Path("/app/landscape.mp4"), resize_mode="fit")
 ```
 
 ## Upload Story with Music
@@ -174,6 +182,7 @@ MoviePy `2.2.1` currently declares `Pillow<12`, but instagrapi keeps `Pillow>=12
 | ----------------------------------------------------- | ---------- | ---------------------------------------- |
 | StoryBuilder.build_clip(clip: moviepy.Clip, max_duration: int = 0) | StoryBuild | Build CompositeVideoClip with background and mentioned users. Return MP4 file and mentions with coordinates |
 | StoryBuilder.video(max_duration: int = 0)            | StoryBuild | Call build_clip(VideoClip, max_duration) |
+| StoryBuilder.video_fit(max_duration: int = 0)        | StoryBuild | Build a 720x1280 Story video canvas that fits the full source video without cropping |
 | StoryBuilder.photo(max_duration: int = 0)            | StoryBuild | Call build_clip(ImageClip, max_duration) |
 
 Example:

--- a/examples/upload_story.py
+++ b/examples/upload_story.py
@@ -8,14 +8,27 @@ from _common import env, make_client
 from instagrapi.types import StoryLink
 
 
-def upload_story(kind: str, path: Path, caption: str, thumbnail: Path | None = None, link: str | None = None):
+def upload_story(
+    kind: str,
+    path: Path,
+    caption: str,
+    thumbnail: Path | None = None,
+    link: str | None = None,
+    resize_mode: str = "fill",
+):
     cl = make_client()
     links = [StoryLink(webUri=link)] if link else []
 
     if kind == "photo":
-        return cl.photo_upload_to_story(path, caption=caption, links=links)
+        return cl.photo_upload_to_story(path, caption=caption, links=links, resize_mode=resize_mode)
     if kind == "video":
-        return cl.video_upload_to_story(path, caption=caption, thumbnail=thumbnail, links=links)
+        return cl.video_upload_to_story(
+            path,
+            caption=caption,
+            thumbnail=thumbnail,
+            links=links,
+            resize_mode=resize_mode,
+        )
 
     raise ValueError(f"Unsupported story kind: {kind}")
 
@@ -27,9 +40,10 @@ def main() -> None:
     parser.add_argument("--caption", default=env("IG_CAPTION", ""))
     parser.add_argument("--thumbnail", type=Path, default=None)
     parser.add_argument("--link", default=env("IG_STORY_LINK"))
+    parser.add_argument("--resize-mode", choices=["fill", "fit"], default="fill")
     args = parser.parse_args()
 
-    story = upload_story(args.kind, args.path, args.caption, args.thumbnail, args.link)
+    story = upload_story(args.kind, args.path, args.caption, args.thumbnail, args.link, args.resize_mode)
     print(f"Uploaded story {story.pk}")
 
 

--- a/instagrapi/image_util.py
+++ b/instagrapi/image_util.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import tempfile
+from typing import Union
 
 try:
     from PIL import Image
@@ -138,6 +139,41 @@ def prepare_image(img, max_size=(1080, 1350), aspect_ratios=(4.0 / 5.0, 90.0 / 4
     b = io.BytesIO()
     im.save(b, "JPEG")
     return b.getvalue(), im.size
+
+
+def prepare_story_image_fit(
+    img,
+    max_size=(1080, 1920),
+    background_color: Union[str, tuple] = "black",
+    save_path=None,
+):
+    """
+    Prepare an image for a Story without cropping the source media.
+    """
+    if is_remote(img):
+        res = requests.get(img, timeout=5)
+        source_image = Image.open(io.BytesIO(res.content))
+    else:
+        source_image = Image.open(img)
+
+    im = source_image
+    try:
+        if im.mode != "RGBA":
+            im = im.convert("RGBA")
+        im.thumbnail(max_size, Image.Resampling.LANCZOS)
+        canvas = Image.new("RGB", max_size, background_color)
+        left = int((max_size[0] - im.size[0]) / 2)
+        top = int((max_size[1] - im.size[1]) / 2)
+        canvas.paste(im, (left, top), im)
+        if save_path:
+            canvas.save(save_path)
+        b = io.BytesIO()
+        canvas.save(b, "JPEG")
+        return b.getvalue(), canvas.size
+    finally:
+        if im is not source_image:
+            im.close()
+        source_image.close()
 
 
 def prepare_video(

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -16,7 +16,7 @@ from instagrapi.exceptions import (
     PhotoConfigureStoryError,
     PhotoNotUpload,
 )
-from instagrapi.image_util import prepare_image
+from instagrapi.image_util import prepare_image, prepare_story_image_fit
 from instagrapi.types import (
     Location,
     Media,
@@ -151,6 +151,7 @@ class UploadPhotoMixin:
         upload_id: str = "",
         to_album: bool = False,
         for_story: bool = False,
+        resize_mode: str = "fill",
     ) -> tuple:
         """
         Upload photo to Instagram
@@ -164,6 +165,8 @@ class UploadPhotoMixin:
         to_album: bool, optional
         for_story: bool, optional
             Useful for resize util only
+        resize_mode: str, optional
+            Story resize mode: "fill" crops oversized Story media to fill the canvas, "fit" letterboxes it.
 
         Returns
         -------
@@ -171,6 +174,10 @@ class UploadPhotoMixin:
             (Upload ID for the media, width, height)
         """
         assert isinstance(path, Path), f"Path must been Path, now {path} ({type(path)})"
+        if resize_mode not in {"fill", "fit"}:
+            raise ValueError('resize_mode must be "fill" or "fit"')
+        if resize_mode == "fit" and not for_story:
+            raise ValueError('resize_mode="fit" is only supported for story uploads')
         valid_extensions = [".jpg", ".jpeg", ".png", ".webp"]
         if path.suffix.lower() not in valid_extensions:
             raise ValueError("Invalid file format. Only JPG/JPEG/PNG/WEBP files are supported.")
@@ -196,7 +203,9 @@ class UploadPhotoMixin:
         }
         if to_album:
             rupload_params["is_sidecar"] = "1"
-        if for_story:
+        if for_story and resize_mode == "fit":
+            photo_data, photo_size = prepare_story_image_fit(str(path))
+        elif for_story:
             photo_data, photo_size = prepare_image(
                 str(path),
                 max_side=1080,
@@ -229,8 +238,11 @@ class UploadPhotoMixin:
             self.logger.error("Photo Upload failed with the following response: %s", response)
             last_json = self.last_json  # local variable for read in sentry
             raise PhotoNotUpload(response.text, response=response, **last_json)
-        with Image.open(path) as im:
-            width, height = im.size
+        if for_story and resize_mode == "fit":
+            width, height = photo_size
+        else:
+            with Image.open(path) as im:
+                width, height = im.size
         return upload_id, width, height
 
     def photo_upload(
@@ -477,6 +489,7 @@ class UploadPhotoMixin:
         medias: List[StoryMedia] = [],
         polls: List[StoryPoll] = [],
         extra_data: Dict[str, str] = {},
+        resize_mode: str = "fill",
     ) -> Story:
         """
         Upload photo as a story and configure it
@@ -505,6 +518,8 @@ class UploadPhotoMixin:
             List of polls to be included on this upload, default is empty list.
         extra_data: Dict[str, str], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
+        resize_mode: str, optional
+            Story resize mode: "fill" crops oversized media to fill the Story canvas, "fit" letterboxes it.
 
         Returns
         -------
@@ -512,7 +527,7 @@ class UploadPhotoMixin:
             An object of Media class
         """
         path = Path(path)
-        upload_id, width, height = self.photo_rupload(path, upload_id, for_story=True)
+        upload_id, width, height = self.photo_rupload(path, upload_id, for_story=True, resize_mode=resize_mode)
         previous_story_ids = self._current_story_ids()
         story_kwargs = {
             "links": links,

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -16,6 +16,7 @@ from instagrapi.exceptions import (
     VideoConfigureStoryError,
     VideoNotUpload,
 )
+from instagrapi.story import StoryBuilder
 from instagrapi.types import (
     DirectMessage,
     Location,
@@ -616,6 +617,7 @@ class UploadVideoMixin:
         medias: List[StoryMedia] = [],
         polls: List[StoryPoll] = [],
         extra_data: Dict[str, str] = {},
+        resize_mode: str = "fill",
     ) -> Story:
         """
         Upload video as a story and configure it
@@ -644,6 +646,8 @@ class UploadVideoMixin:
             List of polls to be included on this upload, default is empty list.
         extra_data: Dict[str, str], optional
             Dict of extra data, if you need to add your params, like {"share_to_facebook": 1}.
+        resize_mode: str, optional
+            Story resize mode: "fill" keeps current upload behavior, "fit" renders a Story canvas without cropping.
 
         Returns
         -------
@@ -653,56 +657,75 @@ class UploadVideoMixin:
         path = Path(path)
         if thumbnail is not None:
             thumbnail = Path(thumbnail)
-        upload_id, width, height, duration, thumbnail = self.video_rupload(path, thumbnail, to_story=True)
-        previous_story_ids = self._current_story_ids()
-        story_kwargs = {
-            "links": links,
-            "mentions": mentions,
-            "hashtags": hashtags,
-            "locations": locations,
-            "stickers": stickers,
-            "medias": medias,
-            "polls": polls,
-        }
-        for attempt in range(50):
-            self.logger.debug(f"Attempt #{attempt} to configure Video: {path}")
-            time.sleep(3)
-            try:
-                configured = self.video_configure_to_story(
-                    upload_id,
-                    width,
-                    height,
-                    duration,
-                    thumbnail,
-                    caption,
-                    mentions,
-                    locations,
-                    links,
-                    hashtags,
-                    stickers,
-                    medias,
-                    polls,
-                    extra_data=extra_data,
-                )
-            except Exception as e:
-                if "Transcode not finished yet" in str(e):
-                    """
-                    Response 202 status:
-                    {"message": "Transcode not finished yet.", "status": "fail"}
-                    """
-                    time.sleep(10)
-                    continue
-                raise e
-            if configured:
-                self.expose()
-                return self._extract_configured_story_or_recent(
-                    configured,
-                    VideoConfigureStoryError,
-                    "Video story upload",
-                    previous_story_ids,
-                    story_kwargs,
-                )
-        raise VideoConfigureStoryError(response=self.last_response, **self.last_json)
+        if resize_mode not in {"fill", "fit"}:
+            raise ValueError('resize_mode must be "fill" or "fit"')
+        rendered_story = None
+        upload_path = path
+        upload_thumbnail = thumbnail
+        try:
+            if resize_mode == "fit":
+                rendered_story = StoryBuilder(path).video_fit()
+                upload_path = Path(rendered_story.path)
+                upload_thumbnail = None
+            upload_id, width, height, duration, thumbnail = self.video_rupload(
+                upload_path,
+                upload_thumbnail,
+                to_story=True,
+            )
+            previous_story_ids = self._current_story_ids()
+            story_kwargs = {
+                "links": links,
+                "mentions": mentions,
+                "hashtags": hashtags,
+                "locations": locations,
+                "stickers": stickers,
+                "medias": medias,
+                "polls": polls,
+            }
+            for attempt in range(50):
+                self.logger.debug(f"Attempt #{attempt} to configure Video: {path}")
+                time.sleep(3)
+                try:
+                    configured = self.video_configure_to_story(
+                        upload_id,
+                        width,
+                        height,
+                        duration,
+                        thumbnail,
+                        caption,
+                        mentions,
+                        locations,
+                        links,
+                        hashtags,
+                        stickers,
+                        medias,
+                        polls,
+                        extra_data=extra_data,
+                    )
+                except Exception as e:
+                    if "Transcode not finished yet" in str(e):
+                        """
+                        Response 202 status:
+                        {"message": "Transcode not finished yet.", "status": "fail"}
+                        """
+                        time.sleep(10)
+                        continue
+                    raise e
+                if configured:
+                    self.expose()
+                    return self._extract_configured_story_or_recent(
+                        configured,
+                        VideoConfigureStoryError,
+                        "Video story upload",
+                        previous_story_ids,
+                        story_kwargs,
+                    )
+            raise VideoConfigureStoryError(response=self.last_response, **self.last_json)
+        finally:
+            if rendered_story:
+                for item in [rendered_story.path, *rendered_story.paths, f"{rendered_story.path}.jpg"]:
+                    with contextlib.suppress(OSError):
+                        Path(item).unlink()
 
     def video_upload_to_story_with_music(
         self,

--- a/instagrapi/story.py
+++ b/instagrapi/story.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import tempfile
 from pathlib import Path
@@ -56,6 +57,13 @@ class StoryBuilder:
 
     width = 720
     height = 1280
+
+    @staticmethod
+    def _fit_size(source_size, canvas_size):
+        source_width, source_height = source_size
+        canvas_width, canvas_height = canvas_size
+        scale = min(canvas_width / float(source_width), canvas_height / float(source_height))
+        return int(source_width * scale), int(source_height * scale)
 
     def __init__(
         self,
@@ -252,6 +260,52 @@ class StoryBuilder:
         build = self.build_main(clip, max_duration, font, fontsize, color, link)
         clip.close()
         return build
+
+    def video_fit(
+        self,
+        max_duration: int = 0,
+        background_color=(0, 0, 0),
+    ):
+        """
+        Build a Story video canvas that fits the full source video without cropping.
+        """
+        CompositeVideoClip, _, _, VideoFileClip, _ = _import_moviepy_for_story()
+        source_clip = None
+        work_clip = None
+        resized_clip = None
+        positioned_clip = None
+        canvas_clip = None
+        try:
+            source_clip = VideoFileClip(str(self.path), has_mask=True)
+            duration = float(source_clip.duration or max_duration or 0)
+            if max_duration and duration > max_duration:
+                duration = float(max_duration)
+                work_clip = source_clip.subclipped(0, duration)
+            else:
+                work_clip = source_clip
+            fit_width, fit_height = self._fit_size(work_clip.size, (self.width, self.height))
+            clip_left = int((self.width - fit_width) / 2)
+            clip_top = int((self.height - fit_height) / 2)
+            resized_clip = work_clip.resized(new_size=(fit_width, fit_height))
+            positioned_clip = resized_clip.with_position((clip_left, clip_top))
+            canvas_clip = CompositeVideoClip(
+                [positioned_clip],
+                size=(self.width, self.height),
+                bg_color=background_color,
+            ).with_duration(duration)
+            fps = getattr(source_clip, "fps", None) or 24
+            canvas_clip = canvas_clip.with_fps(fps)
+            destination = _make_tmp_path(".mp4")
+            canvas_clip.write_videofile(destination, codec="libx264", audio=True, audio_codec="aac")
+            return StoryBuild(mentions=[], path=destination, paths=[], stickers=[])
+        finally:
+            closed = set()
+            for clip in (canvas_clip, positioned_clip, resized_clip, work_clip, source_clip):
+                if not clip or id(clip) in closed:
+                    continue
+                closed.add(id(clip))
+                with contextlib.suppress(AttributeError):
+                    clip.close()
 
     def photo(
         self,

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1,7 +1,11 @@
+import io
 from datetime import datetime, timezone
+
+from PIL import Image
 
 from instagrapi.exceptions import ClipNotUpload
 from instagrapi.extractors import extract_media_v1
+from instagrapi.types import StoryBuild
 from tests.helpers import *
 
 
@@ -188,6 +192,33 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(headers["IG-U-DS-USER-ID"], "1")
         self.assertEqual(headers["X-Entity-Length"], "11")
         self.assertEqual(headers["X-Entity-Name"], "upload-id_0_1234567890")
+
+    def test_photo_story_fit_resize_letterboxes_without_cropping(self):
+        client = self.build_client()
+        ok_response = Mock(status_code=200)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "wide.jpg"
+            image = Image.new("RGB", (1280, 720), "green")
+            image.paste("red", (0, 0, 320, 720))
+            image.paste("blue", (960, 0, 1280, 720))
+            image.save(path)
+
+            with mock.patch.object(client.private, "post", return_value=ok_response) as private_post:
+                upload_id, width, height = client.photo_rupload(
+                    path,
+                    upload_id="upload-id",
+                    for_story=True,
+                    resize_mode="fit",
+                )
+
+        self.assertEqual((upload_id, width, height), ("upload-id", 1080, 1920))
+        uploaded = private_post.call_args.kwargs["data"]
+        with Image.open(io.BytesIO(uploaded)) as prepared:
+            self.assertEqual(prepared.size, (1080, 1920))
+            self.assertEqual(prepared.getpixel((10, 960)), (254, 0, 0))
+            self.assertEqual(prepared.getpixel((1070, 960)), (0, 0, 254))
+            self.assertEqual(prepared.getpixel((540, 100)), (0, 0, 0))
 
     def test_clip_share_to_fb_destination_normalizes_current_reel_destination_fields(self):
         client = self.build_client()
@@ -1561,6 +1592,32 @@ class UploadRegressionTestCase(unittest.TestCase):
                         result = client.video_upload_to_story(Path("story.mp4"))
 
         self.assertEqual(result.id, uploaded.id)
+
+    def test_video_story_fit_resize_renders_canvas_before_upload(self):
+        client = self.build_client()
+        existing = self.build_story("20", media_type=2)
+        uploaded = self.build_story("21", media_type=2)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fitted = Path(tmpdir) / "fitted.mp4"
+            fitted.touch()
+            rendered = StoryBuild(path=str(fitted), mentions=[], paths=[], stickers=[])
+            with mock.patch("instagrapi.mixins.video.StoryBuilder") as story_builder:
+                story_builder.return_value.video_fit.return_value = rendered
+                with mock.patch.object(
+                    client,
+                    "video_rupload",
+                    return_value=("1", 720, 1280, 5, Path("/tmp/thumb.jpg")),
+                ) as video_rupload:
+                    with mock.patch.object(client, "video_configure_to_story", return_value={"status": "ok"}):
+                        with mock.patch.object(client, "user_stories", side_effect=[[existing], [uploaded, existing]]):
+                            with mock.patch("time.sleep"):
+                                result = client.video_upload_to_story(Path("wide.mp4"), resize_mode="fit")
+
+        self.assertEqual(result.id, uploaded.id)
+        story_builder.assert_called_once_with(Path("wide.mp4"))
+        story_builder.return_value.video_fit.assert_called_once()
+        video_rupload.assert_called_once_with(Path(rendered.path), None, to_story=True)
 
     def test_video_direct_upload_raises_clear_error_when_configure_has_no_message(self):
         client = self.build_client()

--- a/tests/regression/test_video_metadata.py
+++ b/tests/regression/test_video_metadata.py
@@ -8,6 +8,8 @@ import struct
 import subprocess
 import sys
 
+from PIL import Image
+
 from tests.helpers import *
 
 
@@ -63,6 +65,41 @@ def _write_real_mp4(folder: Path, name: str = "source.mp4", duration: float = 4.
             "lavfi",
             "-i",
             f"color=c=black:s=640x360:d={duration}",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    return path
+
+
+def _write_wide_panel_mp4(folder: Path, name: str = "wide-source.mp4", duration: float = 2.0) -> Path:
+    path = folder / name
+    subprocess.run(
+        [
+            _ffmpeg_exe(),
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=red:s=320x720:r=30:d={duration}",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=green:s=640x720:r=30:d={duration}",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=blue:s=320x720:r=30:d={duration}",
+            "-filter_complex",
+            "[0:v][1:v][2:v]hstack=inputs=3[v]",
+            "-map",
+            "[v]",
+            "-c:v",
+            "libx264",
             "-pix_fmt",
             "yuv420p",
             str(path),
@@ -221,6 +258,41 @@ class VideoMetadataRegressionTestCase(unittest.TestCase):
                 metadata = read_video_metadata(output)
                 self.assertEqual((metadata.width, metadata.height), (720, 1280))
                 self.assertAlmostEqual(metadata.duration, 1.0, delta=0.25)
+            finally:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(build.path)
+
+    def test_story_builder_video_fit_generates_canvas_without_cropping(self):
+        from instagrapi.story import StoryBuilder
+        from instagrapi.utils.video import read_video_metadata
+
+        self.assertEqual(importlib.metadata.version("moviepy"), "2.2.1")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            source = _write_wide_panel_mp4(tmpdir)
+            build = StoryBuilder(source).video_fit(max_duration=1)
+            output = Path(build.path)
+            frame = tmpdir / "frame.jpg"
+            try:
+                self.assertTrue(output.exists())
+                metadata = read_video_metadata(output)
+                self.assertEqual((metadata.width, metadata.height), (720, 1280))
+                self.assertAlmostEqual(metadata.duration, 1.0, delta=0.25)
+                subprocess.run(
+                    [_ffmpeg_exe(), "-y", "-ss", "0.5", "-i", str(output), "-frames:v", "1", str(frame)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=True,
+                )
+                with Image.open(frame) as image:
+                    left_mid = image.getpixel((10, 640))[:3]
+                    center_mid = image.getpixel((360, 640))[:3]
+                    right_mid = image.getpixel((710, 640))[:3]
+                    top_center = image.getpixel((360, 100))[:3]
+                self.assertGreater(left_mid[0], 150)
+                self.assertGreater(center_mid[1], 80)
+                self.assertGreater(right_mid[2], 150)
+                self.assertLess(sum(top_center), 20)
             finally:
                 with contextlib.suppress(FileNotFoundError):
                     os.unlink(build.path)


### PR DESCRIPTION
Adds `resize_mode="fit"` for `photo_upload_to_story()` and `video_upload_to_story()` so landscape or otherwise non-9:16 media can be rendered onto a Story canvas without cropping. Default `resize_mode="fill"` keeps existing behavior.

Video fit uses `StoryBuilder.video_fit()` to render a 720x1280 canvas before the normal rupload/configure path. Photo fit prepares a 1080x1920 image canvas with Pillow before rupload.

Fixes https://github.com/subzeroid/instagrapi/issues/1310

Local verification:
- `.venv/bin/python -m pytest -q tests/regression/test_upload.py tests/regression/test_story_configure.py tests/regression/test_video_metadata.py` -> 85 passed
- `.venv/bin/ruff check instagrapi tests examples docs` -> passed

Remote fresh-clone live verification:
- uploaded a landscape photo Story with `resize_mode="fit"`, downloaded it back, and verified left/right source edges plus black letterbox area were preserved
- uploaded a landscape video Story with `resize_mode="fit"`, downloaded it back, extracted a frame, and verified left/right source edges plus black letterbox area were preserved
- deleted both live Story uploads after verification