### PR TITLE
Use Literal aliases directly

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, List, Literal, Union
 from uuid import uuid4
 
 import requests
@@ -31,23 +31,14 @@ from instagrapi.utils.auth import gen_token, generate_jazoest
 from instagrapi.utils.serialization import dumps
 
 # from instagrapi.zones import CET
-TIMELINE_FEED_REASONS = (
+TIMELINE_FEED_REASON = Literal[
     "cold_start_fetch",
     "warm_start_fetch",
     "pagination",
     "pull_to_refresh",
     "auto_refresh",
-)
-REELS_TRAY_REASONS = ("cold_start", "pull_to_refresh")
-try:
-    from typing import Literal
-
-    TIMELINE_FEED_REASON = Literal[TIMELINE_FEED_REASONS]
-    REELS_TRAY_REASON = Literal[REELS_TRAY_REASONS]
-except ImportError:
-    # python <= 3.8
-    TIMELINE_FEED_REASON = str
-    REELS_TRAY_REASON = str
+]
+REELS_TRAY_REASON = Literal["cold_start", "pull_to_refresh"]
 
 
 class PreLoginFlowMixin:

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -4,7 +4,7 @@ import secrets
 import time
 import uuid
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 from instagrapi.exceptions import (
     ClientError,
@@ -50,20 +50,17 @@ def _direct_id_list(ids) -> List[int]:
     return [int(item) for item in ids]
 
 
-try:
-    from typing import Literal
-
-    SELECTED_FILTER = Literal[SELECTED_FILTERS]
-    SEARCH_MODE = Literal[SEARCH_MODES]
-    SEND_ATTRIBUTE = Literal[SEND_ATTRIBUTES]
-    SEND_ATTRIBUTE_MEDIA = Literal[SEND_ATTRIBUTES_MEDIA]
-    BOX = Literal[BOXES]
-except ImportError:
-    # python <= 3.8
-    SELECTED_FILTER = str
-    SEARCH_MODE = str
-    SEND_ATTRIBUTE = str
-    BOX = str
+SELECTED_FILTER = Literal["flagged", "unread"]
+SEARCH_MODE = Literal["raven", "universal"]
+SEND_ATTRIBUTE = Literal["message_button", "inbox_search"]
+SEND_ATTRIBUTE_MEDIA = Literal[
+    "feed_timeline",
+    "feed_contextual_chain",
+    "feed_short_url",
+    "feed_contextual_self_profile",
+    "feed_contextual_profile",
+]
+BOX = Literal["general", "primary"]
 
 
 class DirectMixin:
@@ -158,9 +155,8 @@ class DirectMixin:
             "push_disabled": self._bool_to_ig_string(self.push_disabled),
         }
         if selected_filter:
-            assert selected_filter in SELECTED_FILTERS, (
-                f'Unsupported selected_filter="{selected_filter}" {SELECTED_FILTERS}'
-            )
+            if selected_filter not in SELECTED_FILTERS:
+                raise ValueError(f"selected_filter must be one of {SELECTED_FILTERS}")
             params.update({"selected_filter": selected_filter})
         if box:
             assert box in BOXES, f'Unsupported box="{box}" {BOXES}'

--- a/instagrapi/mixins/insights.py
+++ b/instagrapi/mixins/insights.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, List
+from typing import Dict, List, Literal
 
 from instagrapi.exceptions import ClientError, MediaError, UserError
 from instagrapi.utils.serialization import json_value
@@ -27,15 +27,27 @@ DATA_ORDERS = (
 )
 EMPTY_GRAPHQL_QUERY_PARAM = ""  # Instagram GraphQL uses this as an empty access_token placeholder.
 
-try:
-    from typing import Literal
-
-    POST_TYPE = Literal[POST_TYPES]
-    TIME_FRAME = Literal[TIME_FRAMES]
-    DATA_ORDERING = Literal[DATA_ORDERS]
-except ImportError:
-    # python <= 3.8
-    POST_TYPE = TIME_FRAME = DATA_ORDERING = str
+POST_TYPE = Literal["ALL", "CAROUSEL_V2", "IMAGE", "SHOPPING", "VIDEO"]
+TIME_FRAME = Literal[
+    "ONE_WEEK",
+    "ONE_MONTH",
+    "THREE_MONTHS",
+    "SIX_MONTHS",
+    "ONE_YEAR",
+    "TWO_YEARS",
+]
+DATA_ORDERING = Literal[
+    "REACH_COUNT",
+    "LIKE_COUNT",
+    "FOLLOW",
+    "SHARE_COUNT",
+    "BIO_LINK_CLICK",
+    "COMMENT_COUNT",
+    "IMPRESSION_COUNT",
+    "PROFILE_VIEW",
+    "VIDEO_VIEW_COUNT",
+    "SAVE_COUNT",
+]
 
 
 class InsightsMixin:

--- a/instagrapi/mixins/notification.py
+++ b/instagrapi/mixins/notification.py
@@ -1,15 +1,10 @@
+from typing import Literal
+
 MUTE_ALL_ITEMS = ("cancel", "15_minutes", "1_hour", "2_hour", "4_hour", "8_hour")
 SETTING_VALUE_ITEMS = ("off", "following_only", "everyone")
 
-try:
-    from typing import Literal
-
-    MUTE_ALL = Literal[MUTE_ALL_ITEMS]
-    SETTING_VALUE = Literal[SETTING_VALUE_ITEMS]
-except ImportError:
-    # python <= 3.8
-    MUTE_ALL = str
-    SETTING_VALUE = str
+MUTE_ALL = Literal["cancel", "15_minutes", "1_hour", "2_hour", "4_hour", "8_hour"]
+SETTING_VALUE = Literal["off", "following_only", "everyone"]
 
 
 class NotificationMixin:

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -27,6 +27,7 @@ from instagrapi.types import (
     StoryMedia,
     StoryMention,
     StoryPoll,
+    StoryResizeMode,
     StorySticker,
     Track,
     Usertag,
@@ -151,7 +152,7 @@ class UploadPhotoMixin:
         upload_id: str = "",
         to_album: bool = False,
         for_story: bool = False,
-        resize_mode: str = "fill",
+        resize_mode: StoryResizeMode = "fill",
     ) -> tuple:
         """
         Upload photo to Instagram
@@ -489,7 +490,7 @@ class UploadPhotoMixin:
         medias: List[StoryMedia] = [],
         polls: List[StoryPoll] = [],
         extra_data: Dict[str, str] = {},
-        resize_mode: str = "fill",
+        resize_mode: StoryResizeMode = "fill",
     ) -> Story:
         """
         Upload photo as a story and configure it

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -2,7 +2,7 @@ import json
 import logging
 from copy import deepcopy
 from json.decoder import JSONDecodeError
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Literal, Sequence, Tuple, Union
 
 from requests.exceptions import RequestException
 
@@ -37,14 +37,8 @@ ADDRESS_BOOK_DEFAULT_INCLUDE = ("extra_display_name", "thumbnails")
 
 logger = logging.getLogger(__name__)
 
-try:
-    from typing import Literal
-
-    INFO_FROM_MODULE = Literal[INFO_FROM_MODULES]
-    FOLLOWERS_ORDER = Literal[FOLLOWERS_ORDERS]
-except Exception:
-    INFO_FROM_MODULE = str
-    FOLLOWERS_ORDER = str
+INFO_FROM_MODULE = Literal["self_profile", "feed_timeline", "reel_feed_timeline"]
+FOLLOWERS_ORDER = Literal["date_followed_latest", "date_followed_earliest"]
 
 
 class UserMixin:

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -28,6 +28,7 @@ from instagrapi.types import (
     StoryMedia,
     StoryMention,
     StoryPoll,
+    StoryResizeMode,
     StorySticker,
     Track,
     Usertag,
@@ -617,7 +618,7 @@ class UploadVideoMixin:
         medias: List[StoryMedia] = [],
         polls: List[StoryPoll] = [],
         extra_data: Dict[str, str] = {},
-        resize_mode: str = "fill",
+        resize_mode: StoryResizeMode = "fill",
     ) -> Story:
         """
         Upload video as a story and configure it

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -14,6 +14,9 @@ from pydantic import (
 
 class TypesBaseModel(BaseModel):
     model_config = ConfigDict(coerce_numbers_to_str=True)  # (jarrodnorwell) fixed city_id issue
+
+
+StoryResizeMode = Literal["fill", "fit"]
 
 
 def validate_external_url(cls, v):

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -144,6 +144,16 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(params["push_disabled"], "false")
         self.assertFalse(client.get_settings()["push_disabled"])
 
+    def test_direct_threads_chunk_rejects_unsupported_selected_filter(self):
+        client = self.build_client()
+
+        with self.assertRaises(ValueError) as ctx:
+            client.direct_threads_chunk(selected_filter="archived")
+
+        self.assertIn("selected_filter", str(ctx.exception))
+        self.assertIn("flagged", str(ctx.exception))
+        self.assertIn("unread", str(ctx.exception))
+
     def test_direct_search_sends_current_ranked_recipient_limits(self):
         client = self.build_client()
 


### PR DESCRIPTION
This removes legacy `try: from typing import Literal` fallback blocks from the existing narrow string type aliases. The package now requires Python 3.10+, so these Python 3.8 compatibility branches are dead code.

It also types the new Story upload `resize_mode` parameter as `StoryResizeMode = Literal["fill", "fit"]` while keeping the existing runtime `ValueError` validation for callers that pass dynamic strings.

Verification:
- `.venv/bin/ruff check instagrapi tests examples docs` -> passed
- `.venv/bin/python -m pytest -q tests/regression/test_direct.py tests/regression/test_user.py tests/regression/test_upload.py::UploadRegressionTestCase::test_photo_story_fit_resize_letterboxes_without_cropping tests/regression/test_upload.py::UploadRegressionTestCase::test_video_story_fit_resize_renders_canvas_before_upload tests/regression/test_story_configure.py` -> 133 passed
- `.venv/bin/python -m build` -> success
- remote fresh-clone verification on `sk.test` -> ruff passed, 133 regression tests passed, build success
