### PR TITLE
Add hashtag medias pagination helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ finally:
 * Includes helpers for current location search and Direct message workflows
 * Supports mobile follower sorting with `date_followed_latest` and `date_followed_earliest`
 * App-side discovery surfaces: `chaining`, `fetch_suggestion_details`, `discover_recommended_accounts_for_category_v1`, `user_stream_*`, `user_web_profile_info_v1`
-* v2 search SERPs: `fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`
+* v2 search SERPs: `media_search`, `fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`
 * Alternative media-info path (`media_info_v2`) for ad-tagged / sponsored media that the canonical endpoint refuses
 * Experimental Realtime MQTT helpers for live events, Direct message sync, lightweight Direct actions, and FBNS push callbacks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Support chat in Telegram: [aiograpi_support](https://t.me/aiograpi_support)
 7. [Insights](https://subzeroid.github.io/instagrapi/usage-guide/insight.html) by account, posts and stories
 8. [Build stories](https://subzeroid.github.io/instagrapi/usage-guide/story.html) with custom background, font animation, link stickers, and mentions
 9. App-side discovery: `chaining`, `fetch_suggestion_details`, `discover_recommended_accounts_for_category_v1`, `user_stream_*`, `user_web_profile_info_v1`
-10. v2 search SERPs ([Search](https://subzeroid.github.io/instagrapi/usage-guide/search.html)): `fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`
+10. v2 search SERPs ([Search](https://subzeroid.github.io/instagrapi/usage-guide/search.html)): `media_search`, `fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`
 11. Alternative media-info path `media_info_v2` for ad-tagged / sponsored media
 
 ## Example
@@ -141,7 +141,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`DirectMessage`](usage-guide/direct.md) - Message in Direct Message
   * [`Insight`](usage-guide/insight.md) - Insights for a post
   * [`Track`](usage-guide/track.md) - Music track (for Reels/Clips)
-* [Search](usage-guide/search.md) — v2 SERP endpoints (`fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`) and existing search helpers
+* [Search](usage-guide/search.md) — v2 SERP endpoints (`media_search`, `fbsearch_accounts_v2`, `fbsearch_reels_v2`, `fbsearch_topsearch_v2`, `fbsearch_typehead`) and existing search helpers
 * [Best Practices](usage-guide/best-practices.md)
 * [Development Guide](development-guide.md)
 * [Handle Exceptions](usage-guide/handle_exception.md)

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -9,6 +9,7 @@ Pass hashtag names without the leading `#`, for example `pizza`. If a leading `#
 | hashtag_info(name: str) | Hashtag | Return hashtag info (`id`, `name`, `media_count`, `profile_pic_url`) |
 | hashtag_medias_top(name: str, amount: int = 9) | List[Media] | Return top posts for a hashtag |
 | hashtag_medias_recent(name: str, amount: int = 27) | List[Media] | Return recent posts for a hashtag |
+| hashtag_medias_paginated(name: str, amount: int = 27, tab_key: str = "recent", end_cursor: str = None) | Tuple[List[Media], str] | Return one hashtag media page plus the next cursor; authenticated sessions use private/mobile pagination first |
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Return reels/clips for a hashtag via private API |
 | hashtag_follow(hashtag: str, unfollow: bool = False) | bool | Follow a hashtag |
 | hashtag_following(amount: int = 0) | List[Hashtag] | Return hashtags followed by the authenticated account |
@@ -122,6 +123,8 @@ Low level methods:
 | ---------------------------------------------- | ------- | --------------------------------------------
 | hashtag_info_gql(name: str, amount: int = 12, end_cursor: str = None) | Hashtag | Get information about a hashtag by Public Graphql API
 | hashtag_info_v1(name: str) | Hashtag | Get information about a hashtag by Private Mobile API
+| hashtag_medias_paginated_gql(name: str, amount: int = 27, end_cursor: str = None) | Tuple[List[Media], str] | Get one recent hashtag media page by Public GraphQL API
+| hashtag_medias_paginated_v1(name: str, amount: int = 27, tab_key: str = "top\|recent\|clips", end_cursor: str = None) | Tuple[List[Media], str] | Get one hashtag media page by Private Mobile API
 | hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
 | hashtag_medias_v1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by Private Mobile API
 | hashtag_medias_top_v1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Private Mobile API
@@ -131,6 +134,9 @@ Low level methods:
 Example for [Request for loading every next time new posts from hashtag](https://github.com/subzeroid/instagrapi/issues/79):
 
 ``` python
+>>> medias, cursor = cl.hashtag_medias_paginated('test', amount=32, tab_key='recent')
+>>> next_medias, cursor = cl.hashtag_medias_paginated('test', amount=32, tab_key='recent', end_cursor=cursor)
+
 >>> medias, cursor = cl.hashtag_medias_v1_chunk('test', max_amount=32, tab_key='recent')
 >>> len(medias)
 32
@@ -160,5 +166,5 @@ Notes:
 * Instagram's old public hashtag web page JSON (`?__a=1`) is no longer reliable and the `_a1` helpers were removed. Use the high-level hashtag methods or the authenticated private/mobile `_v1` helpers.
 * High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` use the private/mobile helpers.
 * `hashtag_following()` returns the authenticated following-list hashtag preview. Instagram may limit how many followed hashtags are included.
-* For resumable pagination, use `hashtag_medias_v1_chunk()` and persist the encoded `max_id` cursor.
+* For resumable pagination, prefer `hashtag_medias_paginated()` and persist the returned cursor. Use `hashtag_medias_v1_chunk()` only when you need the low-level private/mobile helper.
 * `hashtag_medias_v1_chunk()` accepts `top`, `recent`, or `clips` as `tab_key`.

--- a/docs/usage-guide/search.md
+++ b/docs/usage-guide/search.md
@@ -15,6 +15,7 @@ The `*_v2` methods hit the same `fbsearch/<tab>_serp/` endpoints the official In
 | `fbsearch_keyword_typeahead(query: str, timezone_offset: int = 0, count: int = 30)` | `dict` | Raw keyword/typeahead suggestions via `fbsearch/keyword_typeahead/`. |
 | `fbsearch_typeahead_stream(query: str, timezone_offset: int = 0, count: int = 30)` | `dict` | Raw streaming typeahead payload via `fbsearch/typeahead_stream/`. |
 | `fbsearch_typehead(query: str)` | `List[dict]` | Typeahead user suggestions, flattened from the `stream_rows` envelope returned by `fbsearch/typeahead_stream/`. |
+| `media_search(query: str, amount: int = 27)` | `List[Media]` | Typed media search from the private Top blended fbsearch SERP, including media-grid cursor pagination. |
 
 Example:
 
@@ -32,6 +33,9 @@ page2 = cl.fbsearch_reels_v2("python", reels_max_id=page1["reels_max_id"])
 
 # Typeahead — flat list of user dicts
 users = cl.fbsearch_typehead("py")
+
+# Top media — typed Media objects
+medias = cl.media_search("python", amount=3)
 ```
 
 ## Other search helpers

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -3,10 +3,11 @@ import json
 import warnings
 from typing import List, Tuple
 
-from instagrapi.exceptions import HashtagNotFound, WrongCursorError
+from instagrapi.exceptions import ClientError, ClientLoginRequired, HashtagNotFound, PrivateError, WrongCursorError
 from instagrapi.extractors import (
     extract_hashtag_gql,
     extract_hashtag_v1,
+    extract_media_gql,
     extract_media_v1,
 )
 from instagrapi.types import Hashtag, Media
@@ -185,6 +186,140 @@ class HashtagMixin:
         if not result["more_available"]:
             next_max_id = None  # stop
         return medias, next_max_id
+
+    def _is_hashtag_v1_cursor(self, cursor: str) -> bool:
+        if not cursor:
+            return False
+        try:
+            value = json.loads(base64.b64decode(cursor))
+        except Exception:
+            return False
+        return isinstance(value, list) and len(value) == 2
+
+    def hashtag_medias_paginated_gql(
+        self, name: str, amount: int = 27, end_cursor: str = None
+    ) -> Tuple[List[Media], str]:
+        """
+        Get a page of medias for a hashtag by Public GraphQL API
+
+        Parameters
+        ----------
+        name: str
+            Name of the hashtag
+        amount: int, optional
+            Maximum number of media to return, default is 27
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+
+        Returns
+        -------
+        Tuple[List[Media], str]
+            A tuple containing a list of medias and the next end_cursor value
+        """
+        name = self._normalize_hashtag_name(name)
+        amount = int(amount)
+        variables = {"tag_name": name, "show_ranked": False, "first": amount}
+        if end_cursor:
+            variables["after"] = end_cursor
+        data = self.public_graphql_request(variables, query_hash="f92f56d47dc7a55b606908374b43a314")
+        if not data.get("hashtag"):
+            raise HashtagNotFound(name=name, **data)
+        media_edge = data["hashtag"].get("edge_hashtag_to_media") or {}
+        page_info = media_edge.get("page_info") or {}
+        next_cursor = page_info.get("end_cursor") if page_info.get("has_next_page") else None
+        medias = []
+        for edge in media_edge.get("edges") or []:
+            try:
+                medias.append(extract_media_gql(edge["node"]))
+            except (KeyError, AttributeError, TypeError) as exc:
+                self.logger.warning("Skipping malformed hashtag GraphQL node: %s", exc)
+        if amount:
+            medias = medias[:amount]
+        return medias, next_cursor
+
+    def hashtag_medias_paginated_v1(
+        self, name: str, amount: int = 27, tab_key: str = "recent", end_cursor: str = None
+    ) -> Tuple[List[Media], str]:
+        """
+        Get a page of medias for a hashtag by Private Mobile API
+
+        Parameters
+        ----------
+        name: str
+            Name of the hashtag
+        amount: int, optional
+            Maximum number of media to return, default is 27
+        tab_key: str, optional
+            Tab key: "top", "recent" or "clips", default is "recent"
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+
+        Returns
+        -------
+        Tuple[List[Media], str]
+            A tuple containing a list of medias and the next end_cursor value
+        """
+        name = self._normalize_hashtag_name(name)
+        amount = int(amount)
+        return self.hashtag_medias_v1_chunk(name, max_amount=amount, tab_key=tab_key, max_id=end_cursor)
+
+    def hashtag_medias_paginated(
+        self, name: str, amount: int = 27, tab_key: str = "recent", end_cursor: str = None
+    ) -> Tuple[List[Media], str]:
+        """
+        Get a page of medias for a hashtag
+
+        Parameters
+        ----------
+        name: str
+            Name of the hashtag
+        amount: int, optional
+            Maximum number of media to return, default is 27
+        tab_key: str, optional
+            Tab key: "top", "recent" or "clips", default is "recent". Public GraphQL only supports "recent".
+        end_cursor: str, optional
+            Cursor value to start at, obtained from previous call to this method
+
+        Returns
+        -------
+        Tuple[List[Media], str]
+            A tuple containing a list of medias and the next end_cursor value
+        """
+        name = self._normalize_hashtag_name(name)
+        amount = int(amount)
+        end_cursor_is_v1 = self._is_hashtag_v1_cursor(end_cursor)
+        private_required = tab_key != "recent" or end_cursor_is_v1
+
+        def public_lookup():
+            try:
+                return self.hashtag_medias_paginated_gql(name, amount=amount, end_cursor=end_cursor)
+            except ClientLoginRequired as e:
+                if not self.inject_sessionid_to_public():
+                    raise e
+                return self.hashtag_medias_paginated_gql(name, amount=amount, end_cursor=end_cursor)
+
+        def private_lookup():
+            return self.hashtag_medias_paginated_v1(name, amount=amount, tab_key=tab_key, end_cursor=end_cursor)
+
+        if self._has_private_auth() or private_required:
+            try:
+                return private_lookup()
+            except PrivateError:
+                raise
+            except Exception as e:
+                if private_required:
+                    raise e
+                if not isinstance(e, ClientError):
+                    self.logger.exception(e)
+                return public_lookup()
+        try:
+            return public_lookup()
+        except PrivateError:
+            raise
+        except Exception as e:
+            if not isinstance(e, ClientError):
+                self.logger.exception(e)
+            return private_lookup()
 
     def hashtag_medias_v1(self, name: str, amount: int = 27, tab_key: str = "") -> List[Media]:
         """

--- a/tests/live/test_hashtag.py
+++ b/tests/live/test_hashtag.py
@@ -1,5 +1,45 @@
+import os
+import unittest
+
 from tests import helpers as _helpers
 from tests.helpers import *
+
+
+class ClientHashtagReusableSessionLiveTestCase(unittest.TestCase):
+    def live_client(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for reusable hashtag live tests")
+        last_error = None
+        for account in _helpers.fetch_test_accounts(count=20):
+            try:
+                cl = Client(settings=dict(account["client_settings"]), proxy=os.getenv("IG_PROXY") or account["proxy"])
+                cl._user_id = account.get("user_id")
+                cl.hashtag_info("instagram")
+                return cl
+            except Exception as exc:
+                last_error = f"{type(exc).__name__}: {str(exc)[:120]}"
+        self.skipTest(f"Could not build a usable hashtag test client: {last_error}")
+
+    def test_hashtag_medias_paginated_recent_live(self):
+        cl = self.live_client()
+
+        medias, max_id = cl.hashtag_medias_paginated("instagram", amount=12, tab_key="recent")
+        self.assertGreater(len(medias), 0)
+        self.assertLessEqual(len(medias), 12)
+        self.assertIsInstance(medias[0], Media)
+        if not max_id:
+            self.skipTest("instagram hashtag did not return next cursor")
+
+        next_medias, next_max_id = cl.hashtag_medias_paginated(
+            "instagram",
+            amount=12,
+            tab_key="recent",
+            end_cursor=max_id,
+        )
+
+        self.assertGreater(len(next_medias), 0)
+        self.assertNotEqual(max_id, next_max_id)
+        self.assertTrue({media.pk for media in medias}.isdisjoint({media.pk for media in next_medias}))
 
 
 class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -2,6 +2,24 @@ from tests.helpers import *
 
 
 class HashtagRegressionTestCase(unittest.TestCase):
+    def _media_gql_payload(self, pk="1"):
+        return {
+            "__typename": "GraphImage",
+            "id": pk,
+            "shortcode": f"code-{pk}",
+            "taken_at_timestamp": 1710000000,
+            "owner": {
+                "id": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "display_resources": [{"src": f"https://example.com/{pk}.jpg", "config_width": 100, "config_height": 100}],
+            "edge_media_to_comment": {"count": 0},
+            "edge_media_preview_like": {"count": 0},
+            "edge_media_to_caption": {"edges": []},
+            "edge_media_to_tagged_user": {"edges": []},
+        }
+
     def test_dead_public_a1_methods_are_removed(self):
         client = Client()
         removed_methods = (
@@ -123,6 +141,73 @@ class HashtagRegressionTestCase(unittest.TestCase):
 
         self.assertEqual([media.pk for media in medias], ["1", "2", "3", "4", "5"])
         self.assertIsNone(next_max_id)
+
+    def test_hashtag_medias_paginated_gql_returns_page_and_cursor(self):
+        client = Client()
+        payload = self._media_gql_payload()
+
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            return_value={
+                "hashtag": {
+                    "edge_hashtag_to_media": {
+                        "page_info": {"has_next_page": True, "end_cursor": "next-page"},
+                        "edges": [{"node": payload}],
+                    }
+                }
+            },
+        ) as public_graphql_request:
+            medias, end_cursor = client.hashtag_medias_paginated_gql("python", amount=1, end_cursor="cursor-1")
+
+        public_graphql_request.assert_called_once_with(
+            {"tag_name": "python", "show_ranked": False, "first": 1, "after": "cursor-1"},
+            query_hash="f92f56d47dc7a55b606908374b43a314",
+        )
+        self.assertEqual(end_cursor, "next-page")
+        self.assertEqual([media.pk for media in medias], ["1"])
+
+    def test_hashtag_medias_paginated_v1_delegates_to_chunk(self):
+        client = Client()
+
+        with mock.patch.object(client, "hashtag_medias_v1_chunk", return_value=(["m1"], "next-page")) as chunk:
+            medias, end_cursor = client.hashtag_medias_paginated_v1(
+                "#python",
+                amount=2,
+                tab_key="recent",
+                end_cursor="cursor-1",
+            )
+
+        chunk.assert_called_once_with("python", max_amount=2, tab_key="recent", max_id="cursor-1")
+        self.assertEqual(medias, ["m1"])
+        self.assertEqual(end_cursor, "next-page")
+
+    def test_authorized_hashtag_medias_paginated_uses_private_before_public(self):
+        client = Client()
+        client.authorization_data = {"sessionid": "sid"}
+
+        with mock.patch.object(client, "hashtag_medias_paginated_v1", return_value=(["m1"], "next-page")) as v1:
+            with mock.patch.object(client, "hashtag_medias_paginated_gql") as gql:
+                medias, end_cursor = client.hashtag_medias_paginated("python", amount=5, end_cursor="cursor-1")
+
+        v1.assert_called_once_with("python", amount=5, tab_key="recent", end_cursor="cursor-1")
+        gql.assert_not_called()
+        self.assertEqual(medias, ["m1"])
+        self.assertEqual(end_cursor, "next-page")
+
+    def test_hashtag_medias_paginated_falls_back_to_private(self):
+        client = Client()
+
+        with mock.patch.object(
+            client, "hashtag_medias_paginated_gql", side_effect=ClientError("public unavailable")
+        ) as gql:
+            with mock.patch.object(client, "hashtag_medias_paginated_v1", return_value=(["m1"], "next-page")) as v1:
+                medias, end_cursor = client.hashtag_medias_paginated("python", amount=5, end_cursor="cursor-1")
+
+        gql.assert_called_once_with("python", amount=5, end_cursor="cursor-1")
+        v1.assert_called_once_with("python", amount=5, tab_key="recent", end_cursor="cursor-1")
+        self.assertEqual(medias, ["m1"])
+        self.assertEqual(end_cursor, "next-page")
 
     def test_hashtag_following_fetches_current_account_hashtags(self):
         client = Client()


### PR DESCRIPTION
## Summary
- add `Client.hashtag_medias_paginated(...)`, `hashtag_medias_paginated_gql(...)`, and `hashtag_medias_paginated_v1(...)`
- document `media_search(...)` and hashtag pagination helpers
- add regression and reusable-session live coverage

Fixes https://github.com/subzeroid/instagrapi/issues/613

## Tests
- `.venv/bin/python -m ruff check instagrapi/mixins/hashtag.py tests/regression/test_hashtag.py tests/live/test_hashtag.py`
- `.venv/bin/python -m pytest -q tests/regression/test_hashtag.py`
- `.venv/bin/python -m mkdocs build --strict`
- fresh-clone `sk.test`: ruff, `tests/regression/test_hashtag.py`, `tests/live/test_hashtag.py::ClientHashtagReusableSessionLiveTestCase::test_hashtag_medias_paginated_recent_live`, mkdocs strict