### PR TITLE
Relax runtime dependency pins

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,6 +46,31 @@ jobs:
           ruff check --output-format=github .
           ruff format --check .
 
+  minimum-runtime-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install package with minimum runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            "requests==2.34.2" \
+            "PySocks==1.7.1" \
+            "pydantic==2.12.5" \
+            "Pillow==12.2.0" \
+            "pycryptodomex==3.23.0"
+          python -m pip install .
+          python -m pip check
+          python - <<'PY'
+          from instagrapi import Client
+
+          Client()
+          PY
+
   test-compat:
     runs-on: ubuntu-latest
     strategy:

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -101,6 +101,8 @@ Setuptools is used to package the library through `pyproject.toml`.
 
 * `[project].dependencies` lists runtime dependencies imported by the library.
 * `[project.optional-dependencies].test` lists tools needed for tests, linting, docs, and local development.
+* Runtime dependency lower bounds should stay at the currently tested/security-patched version, with an upper bound before the next major release.
+* Android-specific pins are allowed when the mobile Python ecosystem needs an exact wheel-compatible version, for example the Termux pydantic-core wheel constraint.
 
 Publishing is handled by the tag-based `publish.yml` workflow. Pushes and pull requests run the package workflow first;
 maintainers cut a version tag only after the checks are green.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,12 @@ keywords = [
     "instagram-note",
 ]
 dependencies = [
-    "requests==2.34.2",
-    "PySocks==1.7.1",
+    "requests>=2.34.2,<3",
+    "PySocks>=1.7.1,<2",
     "pydantic==2.12.5; sys_platform == 'android'",
     "pydantic>=2.12.5,<2.14; sys_platform != 'android'",
-    "Pillow==12.2.0",
-    "pycryptodomex==3.23.0",
+    "Pillow>=12.2.0,<13",
+    "pycryptodomex>=3.23.0,<4",
 ]
 
 [project.urls]

--- a/tests/regression/test_packaging.py
+++ b/tests/regression/test_packaging.py
@@ -10,6 +10,21 @@ def test_pydantic_dependency_allows_termux_android_wheel_version():
     assert '"pydantic==2.13.4"' not in required_dependencies
 
 
+def test_runtime_dependencies_use_compatible_ranges():
+    pyproject = Path("pyproject.toml").read_text()
+    required_dependencies = pyproject.split("[project.optional-dependencies]", 1)[0]
+
+    assert '"requests>=2.34.2,<3"' in required_dependencies
+    assert '"PySocks>=1.7.1,<2"' in required_dependencies
+    assert '"Pillow>=12.2.0,<13"' in required_dependencies
+    assert '"pycryptodomex>=3.23.0,<4"' in required_dependencies
+
+    assert '"requests==2.34.2"' not in required_dependencies
+    assert '"PySocks==1.7.1"' not in required_dependencies
+    assert '"Pillow==12.2.0"' not in required_dependencies
+    assert '"pycryptodomex==3.23.0"' not in required_dependencies
+
+
 def test_termux_guide_documents_android_pydantic_core_wheel_index():
     termux_guide = Path("docs/usage-guide/termux.md").read_text()
 


### PR DESCRIPTION
## Summary
- Relax non-Android runtime dependencies from exact pins to conservative compatibility ranges with the current tested versions as lower bounds.
- Keep the Android pydantic pin because that path depends on mobile wheel availability for pydantic-core.
- Add a minimum-runtime-dependencies CI job that installs the lower-bound runtime set, installs instagrapi, runs `pip check`, and imports `Client`.
- Document the runtime dependency policy in the development guide.

Fixes #716

## Tests
- `.venv/bin/python -m pytest -q tests/regression/test_packaging.py`
- `.venv/bin/python -m pytest -q tests/regression/test_packaging.py tests/regression/test_video_metadata.py tests/regression/test_public_transport.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- fresh venv lower-bound install smoke with `pip check` and `Client()` import
- `.venv/bin/python -m build`
- `.venv/bin/mkdocs build --strict`
- `.venv/bin/python -m pytest -q tests/regression`
