### PR TITLE
Handle delta acknowledge challenge step

### DIFF
--- a/instagrapi/mixins/challenge.py
+++ b/instagrapi/mixins/challenge.py
@@ -492,7 +492,7 @@ class ChallengeResolveMixin:
             A boolean value
         """
         step_name = self.last_json.get("step_name", "")
-        if step_name == "delta_login_review" or step_name == "scraping_warning":
+        if step_name in ("delta_login_review", "delta_acknowledge_approved", "scraping_warning"):
             # IT WAS ME (by GEO)
             self._send_private_request(challenge_url, {"choice": "0"})
             return True

--- a/tests/regression/test_challenge.py
+++ b/tests/regression/test_challenge.py
@@ -79,6 +79,24 @@ class ChallengeRegressionTestCase(unittest.TestCase):
 
         self.assertIn("UFAC web bloks checkpoint", str(cm.exception))
 
+    def test_challenge_resolve_simple_delta_acknowledge_approved_posts_ack_choice(self):
+        client = Client()
+        client.username = "example"
+        client.last_json = {
+            "step_name": "delta_acknowledge_approved",
+            "flow_render_type": 3,
+            "bloks_action": "com.instagram.challenge.navigation.take_challenge",
+            "challenge_context": ('{"step_name":"delta_acknowledge_approved","challenge_type_enum":"GENERIC_PHISHED"}'),
+            "challenge_type_enum_str": "GENERIC_PHISHED",
+            "status": "ok",
+        }
+        client._send_private_request = Mock()
+
+        result = client.challenge_resolve_simple("/challenge/test/")
+
+        self.assertTrue(result)
+        client._send_private_request.assert_called_once_with("/challenge/test/", {"choice": "0"})
+
     def test_challenge_resolve_simple_bloks_redirect_step_acknowledges_context(self):
         client = Client()
         client.username = "example"


### PR DESCRIPTION
## Summary
- Treat `delta_acknowledge_approved` as an acknowledgement-style challenge step.
- Post `{"choice": "0"}` through the existing private challenge URL path instead of raising `ChallengeUnknownStep`.
- Add regression coverage for the reported `GENERIC_PHISHED` payload.

## Tests
- `.venv/bin/python -m pytest -q tests/regression/test_challenge.py`
- `.venv/bin/ruff check instagrapi tests/regression/test_challenge.py`
- `.venv/bin/ruff format --check instagrapi tests/regression/test_challenge.py`

Refs https://github.com/subzeroid/instagrapi/issues/630
