### PR TITLE
Preserve media coauthor producers

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -264,6 +264,7 @@ Notes:
 * `usertag_medias()` and `usertag_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
+* Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.
 
 ## Download media

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -86,7 +86,7 @@ def extract_media_v1(data):
     media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags") or []]
     media["view_count"] = media.get("view_count", media.get("video_view_count", 0))
     media["play_count"] = media.get("play_count", media.get("video_play_count", 0))
-    media["coauthor_producers"] = media.get("coauthor_producers", [])
+    media["coauthor_producers"] = [extract_user_short(user) for user in media.get("coauthor_producers", [])]
     return Media(
         caption_text=(media.get("caption") or {}).get("text", ""),
         resources=[extract_resource_v1(edge) for edge in media.get("carousel_media") or []],

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -489,6 +489,7 @@ class Media(TypesBaseModel):
     caption_text: str
     accessibility_caption: Optional[str] = None
     usertags: List[Usertag]
+    coauthor_producers: List[UserShort] = []
     sponsor_tags: List[UserShort]
     video_url: Optional[HttpUrl] = None  # for Video and IGTV
     view_count: Optional[int] = 0  # for Video and IGTV

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -147,6 +147,28 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         self.assertEqual(media.resources[1].usertags[0].user.pk, "200")
         self.assertEqual(media.resources[1].usertags[0].y, 0.5)
 
+    def test_extract_media_v1_preserves_coauthor_producers(self):
+        payload = self._media_or_ad_payload()
+        payload["coauthor_producers"] = [
+            {
+                "id": "100",
+                "username": "collab_user",
+                "full_name": "Collab User",
+                "profile_pic_url": "https://example.com/collab.jpg",
+                "is_private": False,
+                "is_verified": True,
+            }
+        ]
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(len(media.coauthor_producers), 1)
+        coauthor = media.coauthor_producers[0]
+        self.assertIsInstance(coauthor, UserShort)
+        self.assertEqual(coauthor.pk, "100")
+        self.assertEqual(coauthor.username, "collab_user")
+        self.assertTrue(coauthor.is_verified)
+
     def test_extract_media_v1_does_not_default_missing_clips_shared_to_fb_to_false(self):
         payload = self._media_or_ad_payload()
         payload["media_type"] = 2


### PR DESCRIPTION
## Summary
- Add `Media.coauthor_producers` as typed `List[UserShort]` for accepted Instagram Collabs/coauthor users returned by private media payloads.
- Normalize private `coauthor_producers` entries through `extract_user_short(...)` instead of dropping the field.
- Document that reading `media.coauthor_producers` is separate from upload-time `coauthor_user_ids` invitations.

## Tests
- `.venv/bin/python -m pytest -q tests/regression/test_media.py`
- `.venv/bin/ruff check instagrapi tests/regression/test_media.py`
- `.venv/bin/ruff format --check instagrapi tests/regression/test_media.py`
- `.venv/bin/mkdocs build --strict`

Refs https://github.com/subzeroid/instagrapi/issues/629
