### PR TITLE
Expose extended media metadata fields

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -263,6 +263,7 @@ Notes:
 * `user_medias()` and `user_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * `usertag_medias()` and `usertag_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
+* Extended media metadata from Instagram payloads is available on `Media` when returned by the source API, including caption edit state, dimensions, audio presence, hidden count state, viewer save/reshare state, paid partnership/affiliate flags, DASH video info, and clips music attribution.
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -469,6 +469,26 @@ class ClipsMetadata(TypesBaseModel):
     viewer_interaction_settings: Optional[dict] = None
 
 
+class MediaDimensions(TypesBaseModel):
+    height: Optional[int] = None
+    width: Optional[int] = None
+
+
+class MediaDashInfo(TypesBaseModel):
+    is_dash_eligible: Optional[bool] = False
+    video_dash_manifest: Optional[str] = None
+    number_of_qualities: Optional[int] = 0
+
+
+class ClipsMusicAttributionInfo(TypesBaseModel):
+    artist_name: Optional[str] = None
+    song_name: Optional[str] = None
+    uses_original_audio: Optional[bool] = None
+    should_mute_audio: Optional[bool] = None
+    should_mute_audio_reason: Optional[str] = None
+    audio_id: Optional[str] = None
+
+
 class Media(TypesBaseModel):
     pk: Union[str, int]
     id: str
@@ -486,6 +506,16 @@ class Media(TypesBaseModel):
     like_count: int
     play_count: Optional[int] = None
     has_liked: Optional[bool] = None
+    caption_is_edited: Optional[bool] = False
+    dimensions: Optional[MediaDimensions] = None
+    has_audio: Optional[bool] = False
+    like_and_view_counts_disabled: Optional[bool] = False
+    viewer_can_reshare: Optional[bool] = False
+    viewer_has_saved: Optional[bool] = False
+    is_paid_partnership: Optional[bool] = False
+    is_affiliate: Optional[bool] = False
+    dash_info: Optional[MediaDashInfo] = None
+    clips_music_attribution_info: Optional[ClipsMusicAttributionInfo] = None
     caption_text: str
     accessibility_caption: Optional[str] = None
     usertags: List[Usertag]

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -203,6 +203,20 @@ class ClientCompareExtractTestCase(_helpers.ClientPrivateTestCase):
         self.assertLocation(v1.pop("location"), gql.pop("location"))
         v1.pop("has_liked")
         gql.pop("has_liked")
+        for key in (
+            "caption_is_edited",
+            "dimensions",
+            "has_audio",
+            "like_and_view_counts_disabled",
+            "viewer_can_reshare",
+            "viewer_has_saved",
+            "is_paid_partnership",
+            "is_affiliate",
+            "dash_info",
+            "clips_music_attribution_info",
+        ):
+            v1.pop(key)
+            gql.pop(key)
         self.assertDictEqual(v1, gql)
 
     def media_info(self, media_pk):

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -169,6 +169,50 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         self.assertEqual(coauthor.username, "collab_user")
         self.assertTrue(coauthor.is_verified)
 
+    def test_extract_media_v1_preserves_extended_media_fields(self):
+        payload = self._media_or_ad_payload()
+        payload.update(
+            {
+                "caption_is_edited": True,
+                "dimensions": {"height": 1916, "width": 1080},
+                "has_audio": True,
+                "like_and_view_counts_disabled": True,
+                "viewer_can_reshare": True,
+                "viewer_has_saved": True,
+                "is_paid_partnership": True,
+                "is_affiliate": True,
+                "dash_info": {
+                    "is_dash_eligible": False,
+                    "video_dash_manifest": None,
+                    "number_of_qualities": 0,
+                },
+                "clips_music_attribution_info": {
+                    "artist_name": "example",
+                    "song_name": "Original audio",
+                    "uses_original_audio": True,
+                    "should_mute_audio": False,
+                    "should_mute_audio_reason": "",
+                    "audio_id": "1192260532058807",
+                },
+            }
+        )
+
+        media = extract_media_v1(payload)
+
+        self.assertTrue(media.caption_is_edited)
+        self.assertEqual(media.dimensions.height, 1916)
+        self.assertEqual(media.dimensions.width, 1080)
+        self.assertTrue(media.has_audio)
+        self.assertTrue(media.like_and_view_counts_disabled)
+        self.assertTrue(media.viewer_can_reshare)
+        self.assertTrue(media.viewer_has_saved)
+        self.assertTrue(media.is_paid_partnership)
+        self.assertTrue(media.is_affiliate)
+        self.assertFalse(media.dash_info.is_dash_eligible)
+        self.assertEqual(media.dash_info.number_of_qualities, 0)
+        self.assertEqual(media.clips_music_attribution_info.artist_name, "example")
+        self.assertTrue(media.clips_music_attribution_info.uses_original_audio)
+
     def test_extract_media_v1_does_not_default_missing_clips_shared_to_fb_to_false(self):
         payload = self._media_or_ad_payload()
         payload["media_type"] = 2

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -167,6 +167,27 @@ class PublicRegressionTestCase(unittest.TestCase):
                 }
             ],
             "product_type": "clips",
+            "caption_is_edited": True,
+            "dimensions": {"height": 1916, "width": 1080},
+            "has_audio": True,
+            "like_and_view_counts_disabled": True,
+            "viewer_can_reshare": True,
+            "viewer_has_saved": True,
+            "is_paid_partnership": True,
+            "is_affiliate": True,
+            "dash_info": {
+                "is_dash_eligible": False,
+                "video_dash_manifest": None,
+                "number_of_qualities": 0,
+            },
+            "clips_music_attribution_info": {
+                "artist_name": "example",
+                "song_name": "Original audio",
+                "uses_original_audio": True,
+                "should_mute_audio": False,
+                "should_mute_audio_reason": "",
+                "audio_id": "1192260532058807",
+            },
             "is_video": True,
             "video_url": "https://example.com/video.mp4",
             "video_duration": 13.3,
@@ -203,6 +224,19 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertEqual(media.play_count, 22346)
         self.assertEqual(media.view_count, 7694)
         self.assertFalse(media.has_liked)
+        self.assertTrue(media.caption_is_edited)
+        self.assertEqual(media.dimensions.height, 1916)
+        self.assertEqual(media.dimensions.width, 1080)
+        self.assertTrue(media.has_audio)
+        self.assertTrue(media.like_and_view_counts_disabled)
+        self.assertTrue(media.viewer_can_reshare)
+        self.assertTrue(media.viewer_has_saved)
+        self.assertTrue(media.is_paid_partnership)
+        self.assertTrue(media.is_affiliate)
+        self.assertFalse(media.dash_info.is_dash_eligible)
+        self.assertEqual(media.dash_info.number_of_qualities, 0)
+        self.assertEqual(media.clips_music_attribution_info.artist_name, "example")
+        self.assertTrue(media.clips_music_attribution_info.uses_original_audio)
 
     def test_media_info_gql_normalizes_xdt_sidecar_children(self):
         client = Client()


### PR DESCRIPTION
Summary:
- expose caption edit state, dimensions, audio/count/viewer flags, partnership flags, DASH info, and clips music attribution on Media
- cover private v1 and public GraphQL extraction with regression tests
- keep live private/public equality tests tolerant of source-specific optional metadata

Tests:
- .venv/bin/python -m pytest -q tests/regression/test_media.py tests/regression/test_public.py
- .venv/bin/ruff check instagrapi/types.py tests/regression/test_media.py tests/regression/test_public.py tests/live/test_media.py docs/usage-guide/media.md
- live public media_info_gql smoke for C_BM2yAN4Rm