### PR TITLE
Expose inline media comment previews

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -263,10 +263,32 @@ Notes:
 * `user_medias()` and `user_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * `usertag_medias()` and `usertag_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
-* Extended media metadata from Instagram payloads is available on `Media` when returned by the source API, including caption edit state, dimensions, audio presence, hidden count state, viewer save/reshare state, paid partnership/affiliate flags, DASH video info, and clips music attribution.
+* Extended media metadata from Instagram payloads is available on `Media` when returned by the source API, including caption edit state, dimensions, audio presence, hidden count state, viewer save/reshare state, paid partnership/affiliate flags, DASH video info, clips music attribution, and inline comment previews.
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.
+
+Extended `Media` metadata fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `comments_preview` | `MediaCommentsPreview` or `None` | Inline public/web comment preview when Instagram includes `edge_media_to_parent_comment` or preview comment edges. Use full comments helpers for complete pagination. |
+| `hoisted_comments` | `List[MediaInlineComment]` | Comments Instagram hoists separately from the regular preview list. Usually empty. |
+| `comments_preview.count` | `int` | Total count reported for the inline preview edge. |
+| `comments_preview.has_next_page` | `bool` | Whether the inline preview edge has more comments after `end_cursor`. |
+| `comments_preview.end_cursor` | `str` or `None` | Cursor reported by the inline preview edge. |
+| `comments_preview.comments` | `List[MediaInlineComment]` | Inline parent comments already present in the media payload. |
+| `MediaInlineComment.pk` | `str` | Comment id. |
+| `MediaInlineComment.text` | `str` | Comment text. |
+| `MediaInlineComment.user` | `UserShort` | Comment author. |
+| `MediaInlineComment.created_at_utc` | `datetime` | Comment creation time. |
+| `MediaInlineComment.has_liked` | `bool` or `None` | Current viewer like state when Instagram sends it. |
+| `MediaInlineComment.like_count` | `int` or `None` | Inline like count from the comment edge. |
+| `MediaInlineComment.replied_to_comment_id` | `str` or `None` | Parent comment id for inline replies. |
+| `MediaInlineComment.did_report_as_spam` | `bool` or `None` | Viewer report state when Instagram sends it. |
+| `MediaInlineComment.is_restricted_pending` | `bool` or `None` | Restricted/pending state when Instagram sends it. |
+| `MediaInlineComment.replies_count` | `int` | Number of threaded replies reported inline. |
+| `MediaInlineComment.replies` | `List[MediaInlineComment]` | Inline threaded replies already present in the media payload. |
 
 ## Download media
 

--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -179,8 +179,45 @@ def extract_media_gql(data):
             extract_user_short(edge["node"]["sponsor"])
             for edge in media.get("edge_media_to_sponsor_user", {}).get("edges", [])
         ],
+        comments_preview=extract_media_comments_preview_gql(
+            media.get("edge_media_to_parent_comment") or media.get("edge_media_preview_comment")
+        ),
+        hoisted_comments=[
+            extract_media_inline_comment_gql(edge["node"])
+            for edge in media.get("edge_media_to_hoisted_comment", {}).get("edges", [])
+        ],
         **media,
     )
+
+
+def extract_media_comments_preview_gql(data):
+    if not data:
+        return None
+    page_info = data.get("page_info") or {}
+    return {
+        "count": data.get("count", 0),
+        "has_next_page": page_info.get("has_next_page", False),
+        "end_cursor": page_info.get("end_cursor"),
+        "comments": [extract_media_inline_comment_gql(edge["node"]) for edge in data.get("edges", [])],
+    }
+
+
+def extract_media_inline_comment_gql(data, replied_to_comment_id=None):
+    comment = deepcopy(data)
+    comment["pk"] = str(comment.get("id"))
+    comment["user"] = extract_user_short(comment.get("owner"))
+    comment["created_at_utc"] = comment.get("created_at")
+    comment["has_liked"] = comment.get("has_liked", comment.get("viewer_has_liked"))
+    comment["like_count"] = json_value(comment, "edge_liked_by", "count")
+    if replied_to_comment_id is not None:
+        comment["replied_to_comment_id"] = str(replied_to_comment_id)
+    threaded_comments = comment.get("edge_threaded_comments") or {}
+    comment["replies_count"] = threaded_comments.get("count", 0)
+    comment["replies"] = [
+        extract_media_inline_comment_gql(edge["node"], replied_to_comment_id=comment["pk"])
+        for edge in threaded_comments.get("edges", [])
+    ]
+    return comment
 
 
 def extract_resource_v1(data):

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -489,6 +489,27 @@ class ClipsMusicAttributionInfo(TypesBaseModel):
     audio_id: Optional[str] = None
 
 
+class MediaInlineComment(TypesBaseModel):
+    pk: str
+    text: str
+    user: UserShort
+    created_at_utc: datetime
+    has_liked: Optional[bool] = None
+    like_count: Optional[int] = None
+    replied_to_comment_id: Optional[str] = None
+    did_report_as_spam: Optional[bool] = None
+    is_restricted_pending: Optional[bool] = None
+    replies_count: Optional[int] = 0
+    replies: List["MediaInlineComment"] = []
+
+
+class MediaCommentsPreview(TypesBaseModel):
+    count: Optional[int] = 0
+    has_next_page: Optional[bool] = False
+    end_cursor: Optional[str] = None
+    comments: List[MediaInlineComment] = []
+
+
 class Media(TypesBaseModel):
     pk: Union[str, int]
     id: str
@@ -516,6 +537,8 @@ class Media(TypesBaseModel):
     is_affiliate: Optional[bool] = False
     dash_info: Optional[MediaDashInfo] = None
     clips_music_attribution_info: Optional[ClipsMusicAttributionInfo] = None
+    comments_preview: Optional[MediaCommentsPreview] = None
+    hoisted_comments: List[MediaInlineComment] = []
     caption_text: str
     accessibility_caption: Optional[str] = None
     usertags: List[Usertag]

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -214,6 +214,8 @@ class ClientCompareExtractTestCase(_helpers.ClientPrivateTestCase):
             "is_affiliate",
             "dash_info",
             "clips_music_attribution_info",
+            "comments_preview",
+            "hoisted_comments",
         ):
             v1.pop(key)
             gql.pop(key)

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -1,6 +1,6 @@
 import json
 
-from instagrapi.extractors import extract_media_v1
+from instagrapi.extractors import extract_media_gql, extract_media_v1
 from tests.helpers import *
 
 
@@ -236,6 +236,77 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
 
                 self.assertIs(media.clips_metadata.is_shared_to_fb, value)
                 self.assertIs(media.model_dump()["clips_metadata"]["is_shared_to_fb"], value)
+
+    def test_extract_media_gql_preserves_inline_comment_preview(self):
+        def comment_node(comment_id, text, user_id, username):
+            return {
+                "id": comment_id,
+                "text": text,
+                "created_at": 1710000000,
+                "did_report_as_spam": False,
+                "owner": {
+                    "id": user_id,
+                    "username": username,
+                    "profile_pic_url": f"https://example.com/{username}.jpg",
+                    "is_verified": False,
+                },
+                "viewer_has_liked": False,
+                "edge_liked_by": {"count": 2},
+                "is_restricted_pending": False,
+                "edge_threaded_comments": {"count": 0, "page_info": {"has_next_page": False}, "edges": []},
+            }
+
+        parent = comment_node("c1", "parent", "10", "parent_user")
+        reply = comment_node("r1", "reply", "11", "reply_user")
+        parent["edge_threaded_comments"] = {
+            "count": 1,
+            "page_info": {"has_next_page": False, "end_cursor": None},
+            "edges": [{"node": reply}],
+        }
+        hoisted = comment_node("h1", "hoisted", "12", "hoisted_user")
+        payload = {
+            "__typename": "GraphImage",
+            "id": "1",
+            "shortcode": "abc",
+            "taken_at_timestamp": 1710000000,
+            "owner": {
+                "id": "2",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+            },
+            "display_resources": [],
+            "edge_media_to_comment": {"count": 1},
+            "edge_media_preview_like": {"count": 0},
+            "edge_media_to_caption": {"edges": []},
+            "edge_media_to_tagged_user": {"edges": []},
+            "edge_sidecar_to_children": {"edges": []},
+            "edge_media_to_sponsor_user": {"edges": []},
+            "edge_media_to_parent_comment": {
+                "count": 1,
+                "page_info": {"has_next_page": True, "end_cursor": "cursor"},
+                "edges": [{"node": parent}],
+            },
+            "edge_media_to_hoisted_comment": {"edges": [{"node": hoisted}]},
+        }
+
+        media = extract_media_gql(payload)
+
+        self.assertEqual(media.comments_preview.count, 1)
+        self.assertTrue(media.comments_preview.has_next_page)
+        self.assertEqual(media.comments_preview.end_cursor, "cursor")
+        comment = media.comments_preview.comments[0]
+        self.assertEqual(comment.pk, "c1")
+        self.assertEqual(comment.text, "parent")
+        self.assertEqual(comment.user.pk, "10")
+        self.assertEqual(comment.user.username, "parent_user")
+        self.assertEqual(comment.like_count, 2)
+        self.assertFalse(comment.has_liked)
+        self.assertFalse(comment.is_restricted_pending)
+        self.assertEqual(comment.replies_count, 1)
+        self.assertEqual(comment.replies[0].pk, "r1")
+        self.assertEqual(comment.replies[0].replied_to_comment_id, "c1")
+        self.assertEqual(media.hoisted_comments[0].pk, "h1")
+        self.assertEqual(media.hoisted_comments[0].text, "hoisted")
 
 
 class MediaInfoPrivateFirstRegressionTestCase(unittest.TestCase):


### PR DESCRIPTION
Summary:
- expose public GraphQL inline comment previews on Media as typed MediaCommentsPreview and MediaInlineComment models
- expose hoisted inline comments separately as Media.hoisted_comments
- document every new field and cover parent comments, nested replies, and hoisted comments with regression tests

Tests:
- .venv/bin/python -m pytest -q tests/regression/test_media.py tests/regression/test_public.py
- .venv/bin/ruff check instagrapi/types.py instagrapi/extractors.py tests/regression/test_media.py tests/live/test_media.py docs/usage-guide/media.md
- .venv/bin/mkdocs build --strict
- live public media_info_gql smoke for C_BM2yAN4Rm