### PR TITLE
Add iterator helpers for paginated lists

### DIFF
--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -10,6 +10,7 @@ Pass hashtag names without the leading `#`, for example `pizza`. If a leading `#
 | hashtag_medias_top(name: str, amount: int = 9) | List[Media] | Return top posts for a hashtag |
 | hashtag_medias_recent(name: str, amount: int = 27) | List[Media] | Return recent posts for a hashtag |
 | hashtag_medias_paginated(name: str, amount: int = 27, tab_key: str = "recent", end_cursor: str = None) | Tuple[List[Media], str] | Return one hashtag media page plus the next cursor; authenticated sessions use private/mobile pagination first |
+| iter_hashtag_medias(name: str, amount: int = 0, page_size: int = 27, tab_key: str = "recent") | Iterator[Media] | Stream hashtag media page by page without building a full list |
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Return reels/clips for a hashtag via private API |
 | hashtag_follow(hashtag: str, unfollow: bool = False) | bool | Follow a hashtag |
 | hashtag_following(amount: int = 0) | List[Hashtag] | Return hashtags followed by the authenticated account |
@@ -117,6 +118,13 @@ Example:
    'media_type': 1}]}
 ```
 
+Stream hashtag media without storing every fetched page:
+
+``` python
+for media in cl.iter_hashtag_medias("downhill", amount=100, page_size=25, tab_key="recent"):
+    print(media.pk, media.code)
+```
+
 Low level methods:
 
 | Method                                         | Return  | Description
@@ -125,6 +133,7 @@ Low level methods:
 | hashtag_info_v1(name: str) | Hashtag | Get information about a hashtag by Private Mobile API
 | hashtag_medias_paginated_gql(name: str, amount: int = 27, end_cursor: str = None) | Tuple[List[Media], str] | Get one recent hashtag media page by Public GraphQL API
 | hashtag_medias_paginated_v1(name: str, amount: int = 27, tab_key: str = "top\|recent\|clips", end_cursor: str = None) | Tuple[List[Media], str] | Get one hashtag media page by Private Mobile API
+| iter_hashtag_medias(name: str, amount: int = 0, page_size: int = 27, tab_key: str = "recent") | Iterator[Media] | Stream hashtag medias page by page through `hashtag_medias_paginated()`
 | hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
 | hashtag_medias_v1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by Private Mobile API
 | hashtag_medias_top_v1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Private Mobile API
@@ -167,4 +176,5 @@ Notes:
 * High-level `hashtag_info()`, `hashtag_medias_top()`, and `hashtag_medias_recent()` use the private/mobile helpers.
 * `hashtag_following()` returns the authenticated following-list hashtag preview. Instagram may limit how many followed hashtags are included.
 * For resumable pagination, prefer `hashtag_medias_paginated()` and persist the returned cursor. Use `hashtag_medias_v1_chunk()` only when you need the low-level private/mobile helper.
+* Use `iter_hashtag_medias()` when you want to process large hashtag result sets incrementally. It uses the same pagination path as `hashtag_medias_paginated()`.
 * `hashtag_medias_v1_chunk()` accepts `top`, `recent`, or `clips` as `tab_key`.

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -29,6 +29,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_pk_from_code(code: str) | str | Return media PK from shortcode |
 | media_pk_from_url(url: str) | str | Return media PK from media URL; also handles `share/p/...` redirect URLs |
 | user_medias(user_id: str, amount: int = 0) | List\[Media] | Get user feed media |
+| iter_user_medias(user_id: str, amount: int = 0, page_size: int = 0) | Iterator\[Media] | Stream user feed media page by page without building a full list |
 | user_medias_paginated(user_id: str, amount: int = 0, end_cursor: str = "") | Tuple[List\[Media], str] | Get one page of user media and next cursor |
 | user_medias_chunk(user_id: str, end_cursor: str = "") | Tuple[List\[Media], str] | Compatibility alias for one page of user media |
 | user_clips(user_id: str, amount: int = 0) | List\[Media] | Get clips/reels by user |
@@ -239,6 +240,12 @@ True
 ['2019-06-05', '2019-03-23', '2019-03-23', '2018-11-15', '2018-10-16']
 ['2018-10-16', '2018-10-11', '2018-10-09', '2018-10-09', '2018-08-02']
 
+# Stream user media without storing every fetched page
+
+>>> for media in client.iter_user_medias(1903424587, amount=100, page_size=25):
+...     print(media.pk, media.code)
+...
+
 # Resume tagged-media fetches from a stored cursor
 
 >>> tagged, end_cursor = client.usertag_medias_paginated(1903424587, 12, end_cursor="")
@@ -261,6 +268,7 @@ Notes:
 
 * `media_info()` uses private/mobile lookup first when the client has authorization data or a saved `sessionid`, then falls back to public/web lookup. Without authorization, it keeps public/web-first behavior. Explicit `media_info_gql()` still calls the public/web path directly.
 * `user_medias()` and `user_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
+* Use `iter_user_medias()` for large profile media scans when you want each `Media` as soon as its page is fetched. Set `page_size` to control request size; leave it as `0` to keep the endpoint default.
 * `usertag_medias()` and `usertag_medias_paginated()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, they keep public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * For Reels where Instagram hides like/view counts, the public GraphQL path can expose play/view counts but not hidden like totals; `like_count` can be `-1`.
 * Extended media metadata from Instagram payloads is available on `Media` when returned by the source API, including caption edit state, dimensions, audio presence, hidden count state, viewer save/reshare state, paid partnership/affiliate flags, DASH video info, clips music attribution, and inline comment previews.

--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -8,6 +8,8 @@ View a list of a user's medias, following and followers
 |-----------------------------------------------|-----------------------|--------------------------------------------------------------|
 | user_followers(user_id: str, amount: int = 0, order: str = None) | Dict\[int, UserShort] | Get dict of followers users (amount=0 - fetch all followers). Use `order="date_followed_latest"` or `order="date_followed_earliest"` for mobile follower sorting |
 | user_following(user_id: str, amount: int = 0) | Dict\[int, UserShort] | Get dict of following users (amount=0 - fetch all)           |
+| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: str = None) | Iterator[UserShort] | Stream followers from the private/mobile API without building a full dict |
+| iter_user_following_v1(user_id: str, amount: int = 0, page_size: int = 200) | Iterator[UserShort] | Stream following users from the private/mobile API without building a full dict |
 | search_followers(user_id: str, query: str)    | List[UserShort]       | Search by followers                                          |
 | search_following(user_id: str, query: str)    | List[UserShort]       | Search by following                                          |
 | user_info(user_id: str)                       | User                  | Get user info                                                |
@@ -71,9 +73,11 @@ Low level methods:
 | user_followers_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's followers information by Public Graphql API                     |
 | user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "", order: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor). Supports `date_followed_latest` and `date_followed_earliest` |
 | user_followers_v1(user_id: str, amount: int = 0, order: str = None)                 | List[UserShort]             | Get user's followers information by Private Mobile API. Supports `date_followed_latest` and `date_followed_earliest` |
+| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: str = None) | Iterator[UserShort] | Stream followers page by page through `user_followers_v1_chunk()` |
 | user_followers_private_gql_chunk(user_id: str, max_amount: int = 0, max_id: str = None, rank_token: str = None, order: str = None) | Tuple[List[UserShort], str] | Get user's followers through the private mobile GraphQL `FollowersList` surface and max_id cursor |
 | user_followers_private_gql(user_id: str, amount: int = 0, rank_token: str = None, order: str = None) | List[UserShort] | Get user's followers through the private mobile GraphQL `FollowersList` surface |
 | user_following_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's following users information by Private Mobile API               |
+| iter_user_following_v1(user_id: str, amount: int = 0, page_size: int = 200)         | Iterator[UserShort]          | Stream following users page by page through `user_following_v1_chunk()` |
 | user_follow_requests_chunk(max_amount: int = 0, max_id: str = "")                   | Tuple[List[UserShort], str] | Get pending incoming follow requests by Private Mobile API and max_id      |
 | user_following_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's following information by Public Graphql API                     |
 | search_followers_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by followers by Private Mobile API                                  |
@@ -148,6 +152,16 @@ latest_followers = cl.user_followers(cl.user_id, amount=50, order="date_followed
 earliest_followers = cl.user_followers_v1(cl.user_id, amount=50, order="date_followed_earliest")
 ```
 
+Streaming followers/following:
+
+``` python
+for follower in cl.iter_user_followers_v1(cl.user_id, amount=1000, page_size=100, order="date_followed_latest"):
+    print(follower.pk, follower.username)
+
+for user in cl.iter_user_following_v1(cl.user_id, amount=1000, page_size=100):
+    print(user.pk, user.username)
+```
+
 Raw private GraphQL helpers expose the same mobile `order` variable for callers that need the `FollowersList`/`FollowingList` payload directly:
 
 ``` python
@@ -195,3 +209,4 @@ Tip:
 
 * `user_info()`, `user_info_by_username()`, `user_id_from_username()`, and `username_from_user_id()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, these high-level helpers keep the public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
 * `user_followers()` and `user_following()` use private/mobile lookup first when the client has authorization data or a saved `sessionid`, then fall back to public/web lookup. Without authorization, these high-level helpers keep the public/web-first behavior. Explicit `_gql` methods still call the public/web path directly.
+* Use `iter_user_followers_v1()` and `iter_user_following_v1()` when you need to process large follow lists incrementally instead of keeping the full result in memory.

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import warnings
-from typing import List, Tuple
+from typing import Iterator, List, Tuple
 
 from instagrapi.exceptions import ClientError, ClientLoginRequired, HashtagNotFound, PrivateError, WrongCursorError
 from instagrapi.extractors import (
@@ -11,6 +11,7 @@ from instagrapi.extractors import (
     extract_media_v1,
 )
 from instagrapi.types import Hashtag, Media
+from instagrapi.utils.iterators import iter_paginated
 from instagrapi.utils.serialization import dumps
 
 
@@ -320,6 +321,39 @@ class HashtagMixin:
             if not isinstance(e, ClientError):
                 self.logger.exception(e)
             return private_lookup()
+
+    def iter_hashtag_medias(
+        self,
+        name: str,
+        amount: int = 0,
+        page_size: int = 27,
+        tab_key: str = "recent",
+    ) -> Iterator[Media]:
+        """
+        Iterate over medias for a hashtag.
+
+        Parameters
+        ----------
+        name: str
+            Name of the hashtag
+        amount: int, optional
+            Maximum number of media to yield, default is 0 (all medias)
+        page_size: int, optional
+            Maximum number of media to fetch per page, default is 27
+        tab_key: str, optional
+            Tab key: "top", "recent" or "clips", default is "recent". Public GraphQL only supports "recent".
+
+        Returns
+        -------
+        Iterator[Media]
+            Iterator of Media objects
+        """
+        name = self._normalize_hashtag_name(name)
+
+        def fetch_page(end_cursor: str, page_amount: int) -> Tuple[List[Media], str]:
+            return self.hashtag_medias_paginated(name, amount=page_amount, tab_key=tab_key, end_cursor=end_cursor)
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor=None)
 
     def hashtag_medias_v1(self, name: str, amount: int = 27, tab_key: str = "") -> List[Media]:
         """

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -5,7 +5,7 @@ import time
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from instagrapi.exceptions import (
@@ -30,6 +30,7 @@ from instagrapi.mixins.graphql import GQL_STUFF
 from instagrapi.types import Location, Media, Story, StoryMedia, UserShort, Usertag
 from instagrapi.utils.auth import generate_jazoest
 from instagrapi.utils.ids import InstagramIdCodec
+from instagrapi.utils.iterators import iter_paginated
 from instagrapi.utils.serialization import dumps, json_value
 
 MEDIA_INFO_DOC_ID = "8845758582119845"
@@ -1203,6 +1204,30 @@ class MediaMixin:
         Compatibility alias for aiograpi's original chunk naming.
         """
         return self.user_medias_paginated(user_id, amount=0, end_cursor=end_cursor)
+
+    def iter_user_medias(self, user_id: str, amount: int = 0, page_size: int = 0) -> Iterator[Media]:
+        """
+        Iterate over a user's media.
+
+        Parameters
+        ----------
+        user_id: str
+        amount: int, optional
+            Maximum number of media to yield, default is 0 (all medias)
+        page_size: int, optional
+            Maximum number of media to fetch per page. Default value 0 keeps the endpoint default.
+
+        Returns
+        -------
+        Iterator[Media]
+            Iterator of Media objects
+        """
+        user_id = str(user_id)
+
+        def fetch_page(end_cursor: str, page_amount: int) -> Tuple[List[Media], str]:
+            return self.user_medias_paginated(user_id, amount=page_amount, end_cursor=end_cursor)
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor="")
 
     def user_pinned_medias(self, user_id) -> List[Media]:
         """

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -2,7 +2,7 @@ import json
 import logging
 from copy import deepcopy
 from json.decoder import JSONDecodeError
-from typing import Dict, List, Literal, Sequence, Tuple, Union
+from typing import Dict, Iterator, List, Literal, Sequence, Tuple, Union
 
 from requests.exceptions import RequestException
 
@@ -25,6 +25,7 @@ from instagrapi.extractors import (
     extract_user_v1,
 )
 from instagrapi.types import About, AddressBookContact, Guide, Relationship, RelationshipShort, User, UserShort
+from instagrapi.utils.iterators import iter_paginated
 from instagrapi.utils.serialization import dumps, json_value
 
 MAX_USER_COUNT = 200
@@ -819,6 +820,36 @@ class UserMixin:
             users = users[:amount]
         return users
 
+    def iter_user_following_v1(
+        self,
+        user_id: str,
+        amount: int = 0,
+        page_size: int = MAX_USER_COUNT,
+    ) -> Iterator[UserShort]:
+        """
+        Iterate over user's following users by Private Mobile API.
+
+        Parameters
+        ----------
+        user_id: str
+            User id of an instagram account
+        amount: int, optional
+            Maximum number of users to yield, default is 0 - Inf
+        page_size: int, optional
+            Maximum number of users to fetch per page, default is 200
+
+        Returns
+        -------
+        Iterator[UserShort]
+            Iterator of UserShort objects
+        """
+        user_id = str(user_id)
+
+        def fetch_page(max_id: str, max_amount: int) -> Tuple[List[UserShort], str]:
+            return self.user_following_v1_chunk(user_id, max_amount=max_amount, max_id=max_id)
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor="")
+
     def user_following(self, user_id: str, use_cache: bool = True, amount: int = 0) -> Dict[str, UserShort]:
         """
         Get user's following information
@@ -1012,6 +1043,46 @@ class UserMixin:
         if amount:
             users = users[:amount]
         return users
+
+    def iter_user_followers_v1(
+        self,
+        user_id: str,
+        amount: int = 0,
+        page_size: int = MAX_USER_COUNT,
+        order: FOLLOWERS_ORDER = None,
+    ) -> Iterator[UserShort]:
+        """
+        Iterate over user's followers by Private Mobile API.
+
+        Parameters
+        ----------
+        user_id: str
+            User id of an instagram account
+        amount: int, optional
+            Maximum number of users to yield, default is 0 - Inf
+        page_size: int, optional
+            Maximum number of users to fetch per page, default is 200
+        order: str, optional
+            Followers sort order: date_followed_latest or date_followed_earliest
+
+        Returns
+        -------
+        Iterator[UserShort]
+            Iterator of UserShort objects
+        """
+        user_id = str(user_id)
+
+        def fetch_page(max_id: str, max_amount: int) -> Tuple[List[UserShort], str]:
+            if order:
+                return self.user_followers_v1_chunk(
+                    user_id,
+                    max_amount=max_amount,
+                    max_id=max_id,
+                    order=order,
+                )
+            return self.user_followers_v1_chunk(user_id, max_amount=max_amount, max_id=max_id)
+
+        return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor="")
 
     @staticmethod
     def _private_graphql_root(data: Dict, root_field_name: str) -> Dict:

--- a/instagrapi/utils/iterators.py
+++ b/instagrapi/utils/iterators.py
@@ -1,0 +1,40 @@
+from collections.abc import Callable, Iterator, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+Cursor = str | None
+PageFetcher = Callable[[Cursor, int], tuple[Sequence[T], Cursor]]
+
+
+def iter_paginated(
+    fetch_page: PageFetcher[T],
+    amount: int = 0,
+    page_size: int = 0,
+    initial_cursor: Cursor = None,
+) -> Iterator[T]:
+    amount = int(amount)
+    page_size = int(page_size)
+    cursor = initial_cursor
+    yielded = 0
+
+    while True:
+        page_amount = page_size
+        if amount:
+            remaining = amount - yielded
+            if remaining <= 0:
+                return
+            page_amount = min(page_size, remaining) if page_size else remaining
+
+        items, next_cursor = fetch_page(cursor, page_amount)
+        if not items:
+            return
+
+        for item in items:
+            if amount and yielded >= amount:
+                return
+            yield item
+            yielded += 1
+
+        if not next_cursor or next_cursor == cursor:
+            return
+        cursor = next_cursor

--- a/tests/live/test_hashtag.py
+++ b/tests/live/test_hashtag.py
@@ -41,6 +41,15 @@ class ClientHashtagReusableSessionLiveTestCase(unittest.TestCase):
         self.assertNotEqual(max_id, next_max_id)
         self.assertTrue({media.pk for media in medias}.isdisjoint({media.pk for media in next_medias}))
 
+    def test_iter_hashtag_medias_recent_live(self):
+        cl = self.live_client()
+
+        medias = list(cl.iter_hashtag_medias("instagram", amount=5, page_size=2, tab_key="recent"))
+
+        self.assertEqual(len(medias), 5)
+        self.assertIsInstance(medias[0], Media)
+        self.assertEqual(len({media.pk for media in medias}), len(medias))
+
 
 class ClientHashtagTestCase(_helpers.ClientPrivateTestCase):
     REQUIRED_MEDIA_FIELDS = [

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -85,6 +85,66 @@ class ClientPrivateGraphQLV2UserFieldsLiveTestCase(unittest.TestCase):
                 self.assertEqual(getattr(rich_user, field), str(raw_value))
 
 
+class ClientIteratorLiveTestCase(unittest.TestCase):
+    _client = None
+    _username_cache = {}
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for iterator live tests")
+        if self.__class__._client is None:
+            self.__class__._client = self._live_client()
+        self.cl = self.__class__._client
+
+    def _live_client(self):
+        last_exc = None
+        for acc in _helpers.fetch_test_accounts(count=20, timeout=30):
+            try:
+                settings = dict(acc["client_settings"])
+                settings.pop("totp_seed", None)
+                cl = Client(settings=settings, proxy=os.getenv("IG_PROXY") or acc.get("proxy"))
+                cl._user_id = acc.get("user_id")
+                cl.account_info()
+                return cl
+            except Exception as exc:
+                last_exc = exc
+        self.skipTest(f"No usable saved-session account returned: {last_exc}")
+
+    def user_id_from_username(self, username):
+        info = self._username_cache.get(username)
+        if not info:
+            info = self.cl.user_info_by_username_v1(username)
+            self._username_cache[username] = info
+        return str(info.pk)
+
+    def test_iter_user_followers_v1_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        followers = list(self.cl.iter_user_followers_v1(user_id, amount=5, page_size=2))
+
+        self.assertEqual(len(followers), 5)
+        self.assertIsInstance(followers[0], UserShort)
+        self.assertEqual(len({user.pk for user in followers}), len(followers))
+
+    def test_iter_user_following_v1_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        following = list(self.cl.iter_user_following_v1(user_id, amount=5, page_size=2))
+
+        self.assertEqual(len(following), 5)
+        self.assertIsInstance(following[0], UserShort)
+        self.assertEqual(len({user.pk for user in following}), len(following))
+
+    def test_iter_user_medias_live(self):
+        user_id = self.user_id_from_username("instagram")
+
+        medias = list(self.cl.iter_user_medias(user_id, amount=4, page_size=2))
+
+        self.assertEqual(len(medias), 4)
+        self.assertIsInstance(medias[0], Media)
+        self.assertEqual(len({media.pk for media in medias}), len(medias))
+
+
 def _run_business_email_live(result_queue):
     if not TEST_ACCOUNTS_URL:
         result_queue.put({"status": "skip", "reason": "TEST_ACCOUNTS_URL is required for business email live tests"})

--- a/tests/regression/test_hashtag.py
+++ b/tests/regression/test_hashtag.py
@@ -209,6 +209,40 @@ class HashtagRegressionTestCase(unittest.TestCase):
         self.assertEqual(medias, ["m1"])
         self.assertEqual(end_cursor, "next-page")
 
+    def test_iter_hashtag_medias_streams_paginated_pages_and_respects_amount(self):
+        client = Client()
+        medias = [
+            Media(
+                pk=str(i),
+                id=f"{i}_1",
+                code=f"code-{i}",
+                taken_at=datetime.now(UTC()),
+                media_type=1,
+                user=UserShort(pk="1", username="example"),
+                like_count=0,
+                caption_text="",
+                usertags=[],
+                sponsor_tags=[],
+            )
+            for i in range(1, 5)
+        ]
+
+        with mock.patch.object(
+            client,
+            "hashtag_medias_paginated",
+            side_effect=[(medias[:2], "cursor-1"), (medias[2:], "cursor-2")],
+        ) as paginated:
+            result = list(client.iter_hashtag_medias("python", amount=3, page_size=2, tab_key="recent"))
+
+        self.assertEqual([media.pk for media in result], ["1", "2", "3"])
+        paginated.assert_has_calls(
+            [
+                mock.call("python", amount=2, tab_key="recent", end_cursor=None),
+                mock.call("python", amount=1, tab_key="recent", end_cursor="cursor-1"),
+            ]
+        )
+        self.assertEqual(paginated.call_count, 2)
+
     def test_hashtag_following_fetches_current_account_hashtags(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123"}

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -630,6 +630,26 @@ class UserMediasPrivateFirstRegressionTestCase(unittest.TestCase):
         private_lookup.assert_called_once_with("456", 2, end_cursor="123_456")
         public_lookup.assert_not_called()
 
+    def test_iter_user_medias_streams_paginated_pages_and_respects_amount(self):
+        client = self.build_private_client()
+        medias = [self.build_media(pk=str(i)) for i in range(1, 5)]
+
+        with mock.patch.object(
+            client,
+            "user_medias_paginated",
+            side_effect=[(medias[:2], "cursor-1"), (medias[2:], "cursor-2")],
+        ) as paginated:
+            result = list(client.iter_user_medias("456", amount=3, page_size=2))
+
+        self.assertEqual([media.pk for media in result], ["1", "2", "3"])
+        paginated.assert_has_calls(
+            [
+                mock.call("456", amount=2, end_cursor=""),
+                mock.call("456", amount=1, end_cursor="cursor-1"),
+            ]
+        )
+        self.assertEqual(paginated.call_count, 2)
+
     def test_authorized_user_medias_uses_private_before_public(self):
         client = self.build_private_client()
         medias = [self.build_media()]

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -600,6 +600,59 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         params = private_request.call_args.kwargs["params"]
         self.assertEqual(params["count"], MAX_USER_COUNT)
 
+    def test_iter_user_followers_v1_streams_chunks_and_respects_amount(self):
+        client = self.build_private_client()
+        users = [
+            UserShort(pk="1", username="one"),
+            UserShort(pk="2", username="two"),
+            UserShort(pk="3", username="three"),
+            UserShort(pk="4", username="four"),
+        ]
+
+        with mock.patch.object(
+            client,
+            "user_followers_v1_chunk",
+            side_effect=[(users[:2], "cursor-1"), (users[2:], "cursor-2")],
+        ) as chunk:
+            result = list(
+                client.iter_user_followers_v1(
+                    "123",
+                    amount=3,
+                    page_size=2,
+                    order="date_followed_latest",
+                )
+            )
+
+        self.assertEqual([user.pk for user in result], ["1", "2", "3"])
+        self.assertEqual(
+            chunk.call_args_list[0].kwargs, {"max_amount": 2, "max_id": "", "order": "date_followed_latest"}
+        )
+        self.assertEqual(
+            chunk.call_args_list[1].kwargs,
+            {"max_amount": 1, "max_id": "cursor-1", "order": "date_followed_latest"},
+        )
+        self.assertEqual(chunk.call_count, 2)
+
+    def test_iter_user_following_v1_streams_chunks_and_respects_amount(self):
+        client = self.build_private_client()
+        users = [
+            UserShort(pk="1", username="one"),
+            UserShort(pk="2", username="two"),
+            UserShort(pk="3", username="three"),
+        ]
+
+        with mock.patch.object(
+            client,
+            "user_following_v1_chunk",
+            side_effect=[(users[:2], "cursor-1"), (users[2:], "")],
+        ) as chunk:
+            result = list(client.iter_user_following_v1("123", amount=3, page_size=2))
+
+        self.assertEqual([user.pk for user in result], ["1", "2", "3"])
+        self.assertEqual(chunk.call_args_list[0].kwargs, {"max_amount": 2, "max_id": ""})
+        self.assertEqual(chunk.call_args_list[1].kwargs, {"max_amount": 1, "max_id": "cursor-1"})
+        self.assertEqual(chunk.call_count, 2)
+
     def test_authorized_user_followers_falls_back_when_private_list_is_limited(self):
         client = self.build_private_client()
         private_user = UserShort(pk="private", username="private")


### PR DESCRIPTION
## Summary
- Add a shared `iter_paginated()` helper and iterator APIs for heavy paginated lists.
- Add `iter_user_followers_v1()`, `iter_user_following_v1()`, `iter_user_medias()`, and `iter_hashtag_medias()`.
- Add regression tests, live iterator tests, and usage-guide examples.

Fixes https://github.com/subzeroid/instagrapi/issues/1141

## Verification
- `ruff check instagrapi/mixins/user.py instagrapi/mixins/media.py instagrapi/mixins/hashtag.py instagrapi/utils/iterators.py tests/regression/test_user.py tests/regression/test_media.py tests/regression/test_hashtag.py tests/live/test_user.py tests/live/test_hashtag.py docs/usage-guide/user.md docs/usage-guide/media.md docs/usage-guide/hashtag.md`
- `python -m pytest -q tests/regression/test_user.py tests/regression/test_media.py tests/regression/test_hashtag.py`
- Live iterator tests: `4 passed`
