### PR TITLE
Document public type models

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
 * [Usage Guide](usage-guide/fundamentals.md)
 * [Runnable Examples](usage-guide/examples.md)
 * [Interactions](usage-guide/interactions.md)
+  * [Types](usage-guide/types.md) - Field reference for public `instagrapi.types` models
   * [`Media`](usage-guide/media.md) - Publication (also called post): Photo, Video, Album, IGTV and Reels
   * [`Resource`](usage-guide/media.md) - Part of Media (for albums)
   * [`MediaOembed`](usage-guide/media.md) - Short version of Media

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -3,6 +3,7 @@
 `instagrapi` provides various types of `Interactions` that can be used to control how the program will interact with the `Instagram`:
 
 * [`Media`](media.md) - Media (Photo, Video, Album, IGTV, Reels or Story)
+* [Types](types.md) - Field reference for public `instagrapi.types` models
 * [`Resource`](media.md) - Part of Media (for albums)
 * [`MediaOembed`](media.md) - Short version of Media
 * [`Account`](account.md) - Full private info for your account (e.g. email, phone_number)

--- a/docs/usage-guide/types.md
+++ b/docs/usage-guide/types.md
@@ -1,0 +1,207 @@
+# Types
+
+`instagrapi.types` contains the public Pydantic models returned by high-level client methods and accepted by upload/story helpers.
+
+Import models directly when you need structured input objects:
+
+```python
+from instagrapi.types import Location, Media, StoryMention, UserShort, Usertag
+```
+
+## How To Read Fields
+
+Required fields have no default value. `Optional[...]` fields may be absent from Instagram responses or returned as `null`. Fields with raw `dict` or `list` types intentionally preserve Instagram data whose shape is not stable enough for a dedicated public model yet.
+
+## Common Models
+
+| Model | Common source | Notes |
+| --- | --- | --- |
+| `Account` | `account_info()` | Private account profile for the authenticated user, including email/phone fields when Instagram returns them. |
+| `User` | `user_info(...)`, `user_info_by_username(...)` | Full public profile fields such as counts, biography, public contacts, business category, location, and messaging ids. |
+| `UserShort` | user lists, tags, comments, direct threads | Compact user profile used inside many other models. Preserves newer v2 fields such as `fbid_v2`, `profile_pic_id`, `account_badges`, and `friendship_status`. |
+| `Media` | `media_info(...)`, feeds, timelines, hashtag media | Main post/Reel/album object. Includes caption/count flags, resources, usertags, coauthors, DASH info, music attribution, and inline comment previews when returned. |
+| `Resource` | `Media.resources` | Album child media with thumbnail/video URLs and nested usertags. |
+| `Comment` | comment helpers | Public comment model with author, text, like state/count, and reply target. |
+| `DirectThread` | direct thread helpers | Direct conversation shell with participants, messages, mute/pin/group state, and activity metadata. |
+| `DirectMessage` | direct message helpers | Individual direct item with text, media shares, visual media, links, reactions, replies, and seen state. |
+| `Story` | story/reel helpers | Story media object with stickers, mentions, hashtags, links, locations, sponsor tags, and video metadata. |
+| `Location` | location helpers and upload metadata | Place metadata used by media and story publishing flows. |
+| `Hashtag` | hashtag helpers | Hashtag identity, media count, and profile picture. |
+| `Track` | music/Reels helpers | Music track metadata and audio URLs when available. |
+| `Note` | notes helpers | Direct Notes payload with author, audience, timestamps, and style flags. |
+
+## Account And User Models
+
+::: instagrapi.types.Account
+
+::: instagrapi.types.User
+
+::: instagrapi.types.UserShort
+
+::: instagrapi.types.RelationshipShort
+
+::: instagrapi.types.Relationship
+
+::: instagrapi.types.Viewer
+
+::: instagrapi.types.Usertag
+
+::: instagrapi.types.About
+
+::: instagrapi.types.BioLink
+
+::: instagrapi.types.Broadcast
+
+::: instagrapi.types.AddressBookPhone
+
+::: instagrapi.types.AddressBookEmail
+
+::: instagrapi.types.AddressBookContact
+
+## Media Models
+
+::: instagrapi.types.Media
+
+::: instagrapi.types.Resource
+
+::: instagrapi.types.MediaOembed
+
+::: instagrapi.types.MediaXma
+
+::: instagrapi.types.MediaDimensions
+
+::: instagrapi.types.MediaDashInfo
+
+::: instagrapi.types.MediaInlineComment
+
+::: instagrapi.types.MediaCommentsPreview
+
+::: instagrapi.types.SharedMediaImageCandidate
+
+::: instagrapi.types.SharedMediaImageVersions
+
+::: instagrapi.types.AdditionalCandidates
+
+::: instagrapi.types.ScrubberSpritesheetInfo
+
+::: instagrapi.types.ScrubberSpritesheetInfoCandidates
+
+::: instagrapi.types.Collection
+
+::: instagrapi.types.Comment
+
+::: instagrapi.types.Location
+
+::: instagrapi.types.Hashtag
+
+::: instagrapi.types.Guide
+
+::: instagrapi.types.Highlight
+
+::: instagrapi.types.Share
+
+## Reels And Music Models
+
+::: instagrapi.types.ClipsMetadata
+
+::: instagrapi.types.ClipsAchievementsInfo
+
+::: instagrapi.types.AudioReattributionInfo
+
+::: instagrapi.types.ClipsAdditionalAudioInfo
+
+::: instagrapi.types.ClipsAudioRankingInfo
+
+::: instagrapi.types.ClipsBrandedContentTagInfo
+
+::: instagrapi.types.ClipsContentAppreciationInfo
+
+::: instagrapi.types.ClipsMashupInfo
+
+::: instagrapi.types.ClipsConsumptionInfo
+
+::: instagrapi.types.ClipsFbDownstreamUseXpostMetadata
+
+::: instagrapi.types.ClipsIgArtist
+
+::: instagrapi.types.ClipsOriginalSoundInfo
+
+::: instagrapi.types.ClipsReusableTextColor
+
+::: instagrapi.types.ClipsReusableTextInfo
+
+::: instagrapi.types.ClipsMusicAttributionInfo
+
+::: instagrapi.types.Track
+
+## Story Models
+
+::: instagrapi.types.Story
+
+::: instagrapi.types.StoryMention
+
+::: instagrapi.types.StoryMedia
+
+::: instagrapi.types.StoryHashtag
+
+::: instagrapi.types.StoryLocation
+
+::: instagrapi.types.StoryStickerLink
+
+::: instagrapi.types.StorySticker
+
+::: instagrapi.types.StoryPoll
+
+::: instagrapi.types.StoryBuild
+
+::: instagrapi.types.StoryLink
+
+::: instagrapi.types.StoryArchiveDay
+
+## Direct Models
+
+::: instagrapi.types.DirectThread
+
+::: instagrapi.types.DirectShortThread
+
+::: instagrapi.types.DirectMessage
+
+::: instagrapi.types.DirectResponse
+
+::: instagrapi.types.DirectMedia
+
+::: instagrapi.types.ReplyMessage
+
+::: instagrapi.types.MessageReaction
+
+::: instagrapi.types.MessageReactions
+
+::: instagrapi.types.MessageLink
+
+::: instagrapi.types.LinkContext
+
+::: instagrapi.types.LastSeenInfo
+
+::: instagrapi.types.DisappearingMessagesSeenState
+
+::: instagrapi.types.FallbackUrl
+
+::: instagrapi.types.DirectMessageImageCandidate
+
+::: instagrapi.types.DirectMessageImageVersions
+
+::: instagrapi.types.VideoVersion
+
+::: instagrapi.types.FriendshipStatus
+
+::: instagrapi.types.VisualMedia
+
+::: instagrapi.types.VisualMediaContent
+
+::: instagrapi.types.VisualMediaUser
+
+::: instagrapi.types.ExpiringMediaActionSummary
+
+## Notes
+
+::: instagrapi.types.Note

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
     - Fundamentals: usage-guide/fundamentals.md
     - Interactions: usage-guide/interactions.md
     - TOTP: usage-guide/totp.md
+    - Types: usage-guide/types.md
     - Challenge Resolver: usage-guide/challenge_resolver.md
     - Handle Exceptions: usage-guide/handle_exception.md
     - Collection: usage-guide/collection.md

--- a/tests/regression/test_docs_model_reference.py
+++ b/tests/regression/test_docs_model_reference.py
@@ -1,0 +1,39 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TYPES_SOURCE = ROOT / "instagrapi" / "types.py"
+MODEL_REFERENCE = ROOT / "docs" / "usage-guide" / "types.md"
+MKDOCS_CONFIG = ROOT / "mkdocs.yml"
+
+
+def _public_type_models() -> list[str]:
+    tree = ast.parse(TYPES_SOURCE.read_text())
+    bases_by_class = {
+        node.name: [base.id if isinstance(base, ast.Name) else getattr(base, "attr", "") for base in node.bases]
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+    }
+
+    def is_type_model(class_name: str) -> bool:
+        bases = bases_by_class[class_name]
+        return "TypesBaseModel" in bases or any(base in bases_by_class and is_type_model(base) for base in bases)
+
+    return sorted(name for name in bases_by_class if name != "TypesBaseModel" and is_type_model(name))
+
+
+def test_model_reference_lists_every_public_type_model():
+    reference = MODEL_REFERENCE.read_text()
+    missing = [name for name in _public_type_models() if f"::: instagrapi.types.{name}" not in reference]
+
+    assert missing == []
+
+
+def test_model_reference_is_linked_from_docs_navigation():
+    mkdocs_config = MKDOCS_CONFIG.read_text()
+    interactions = (ROOT / "docs" / "usage-guide" / "interactions.md").read_text()
+    index = (ROOT / "docs" / "index.md").read_text()
+
+    assert "Types: usage-guide/types.md" in mkdocs_config
+    assert "[Types](types.md)" in interactions
+    assert "[Types](usage-guide/types.md)" in index


### PR DESCRIPTION
## Summary
- add `docs/usage-guide/types.md` as a model reference for every public `instagrapi.types` Pydantic model
- link the new reference from MkDocs navigation, the overview, and Interactions
- add regression coverage that fails when a public type model is missing from the reference

Closes https://github.com/subzeroid/instagrapi/issues/944

## Tests
- `.venv/bin/python -m pytest -q tests/regression/test_docs_model_reference.py`
- `.venv/bin/mkdocs build --strict`