### PR TITLE
Fix photo upload usertags readback

### DIFF
--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -307,13 +307,52 @@ class UploadPhotoMixin:
             )
             if configured:
                 self.expose()
-                return self._extract_configured_media_or_recent(
+                media = self._extract_configured_media_or_recent(
                     configured,
                     PhotoConfigureError,
                     "Photo upload",
                     previous_media_ids,
                 )
+                return self._photo_upload_apply_usertags_if_needed(
+                    media,
+                    caption,
+                    usertags,
+                    location,
+                    can_edit=extra_data.get("publish_mode") != "scheduled",
+                )
         raise PhotoConfigureError(response=self.last_response, **self.last_json)
+
+    @staticmethod
+    def _media_contains_usertags(media: Media, usertags: List[Usertag]) -> bool:
+        if not usertags:
+            return True
+        existing = {(str(tag.user.pk), tag.x, tag.y) for tag in media.usertags}
+        requested = {(str(tag.user.pk), tag.x, tag.y) for tag in usertags}
+        return requested.issubset(existing)
+
+    def _photo_upload_apply_usertags_if_needed(
+        self,
+        media: Media,
+        caption: str,
+        usertags: List[Usertag],
+        location: Location = None,
+        can_edit: bool = True,
+    ) -> Media:
+        if not can_edit or self._media_contains_usertags(media, usertags):
+            return media
+        try:
+            edited = self.media_edit(media.id, caption, usertags=usertags, location=location)
+        except Exception as e:
+            self.logger.debug("Unable to apply photo usertags with media_edit: %s", e)
+            return media
+        updated = self._extract_configured_media(edited)
+        if updated is not None:
+            return updated
+        try:
+            return self.media_info_v1(media.pk)
+        except Exception as e:
+            self.logger.debug("Unable to refresh photo after media_edit usertags: %s", e)
+            return media
 
     def photo_upload_with_music(
         self,

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -143,7 +143,7 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
         if not TEST_ACCOUNTS_URL:
             self.skipTest("TEST_ACCOUNTS_URL is required for upload live tests")
         try:
-            self.cl = self.fresh_account()
+            self.cl = _helpers.fresh_test_account(count=50, attempts=20, timeout=30)
         except RuntimeError as exc:
             self.skipTest(str(exc))
 
@@ -195,6 +195,26 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             else:
                 return info
         self.fail(f"Album resource usertags were not visible after {attempts} media_info_v1 attempts: {last_resources}")
+
+    def assertPhotoUsertagsAccessible(self, media, expected_usertags, attempts=8, delay=5):
+        last_tags = []
+        for attempt in range(attempts):
+            if attempt:
+                time.sleep(delay)
+            info = self.cl.media_info_v1(media.pk)
+            last_tags = info.usertags
+            if len(last_tags) < len(expected_usertags):
+                continue
+            for actual_tag, expected_tag in zip(last_tags, expected_usertags):
+                if (
+                    str(actual_tag.user.pk) != str(expected_tag.user.pk)
+                    or actual_tag.x != expected_tag.x
+                    or actual_tag.y != expected_tag.y
+                ):
+                    break
+            else:
+                return info
+        self.fail(f"Photo usertags were not visible after {attempts} media_info_v1 attempts: {last_tags}")
 
     def ensure_creator_account(self):
         account = self.cl.account_info()
@@ -298,6 +318,23 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             self.assertEqual(media.caption_text, caption_text)
             self.assertLocation(media.location)
             self.assertUploadedMediaAccessible(media, media_type=1, caption_text=caption_text)
+        finally:
+            if media:
+                self.assertTrue(self.cl.media_delete(media.id))
+
+    def test_photo_upload_with_usertags_visible_after_media_info(self):
+        path = self.copy_media_fixture("examples/kanada.jpg")
+        self.assertIsInstance(path, Path)
+        media = None
+        try:
+            instagram = self.user_short(self.user_info_by_username("instagram"))
+            usertag = Usertag(user=instagram, x=0.5, y=0.5)
+            caption_text = "Test caption for photo usertags"
+            media = self.cl.photo_upload(path, caption_text, usertags=[usertag])
+            self.assertIsInstance(media, Media)
+            self.assertEqual(media.caption_text, caption_text)
+            info = self.assertPhotoUsertagsAccessible(media, [usertag])
+            self.assertEqual(info.caption_text, caption_text)
         finally:
             if media:
                 self.assertTrue(self.cl.media_delete(media.id))

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -586,6 +586,48 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertIsInstance(media, Media)
         self.assertEqual(media.pk, "1")
 
+    def test_photo_upload_applies_usertags_with_media_edit_when_configure_ignores_them(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=1)
+        tagged_payload = self.build_media_payload(media_type=1)
+        tagged_payload["usertags"] = {
+            "in": [
+                {
+                    "user": {
+                        "pk": "25025320",
+                        "username": "instagram",
+                        "profile_pic_url": "https://example.com/instagram.jpg",
+                    },
+                    "position": [0.5, 0.5],
+                }
+            ]
+        }
+        usertag = Usertag(
+            user=UserShort(
+                pk="25025320",
+                username="instagram",
+                profile_pic_url="https://example.com/instagram.jpg",
+            ),
+            x=0.5,
+            y=0.5,
+        )
+
+        with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
+            with mock.patch.object(client, "photo_configure", return_value={"status": "ok", "media": media_payload}):
+                with mock.patch.object(
+                    client,
+                    "media_edit",
+                    return_value={"status": "ok", "media": tagged_payload},
+                ) as media_edit:
+                    with mock.patch("time.sleep"):
+                        media = client.photo_upload(Path("example.jpg"), "caption", usertags=[usertag])
+
+        media_edit.assert_called_once_with(media_payload["id"], "caption", usertags=[usertag], location=None)
+        self.assertEqual(len(media.usertags), 1)
+        self.assertEqual(media.usertags[0].user.pk, "25025320")
+        self.assertEqual(media.usertags[0].x, 0.5)
+        self.assertEqual(media.usertags[0].y, 0.5)
+
     def test_photo_upload_sends_scheduled_publish_metadata(self):
         client = self.build_client()
         media_payload = self.build_media_payload(media_type=1)


### PR DESCRIPTION
Fixes https://github.com/subzeroid/instagrapi/issues/937

Single-photo media/configure accepts the usertags payload but current readback can still return an untagged media object. When photo_upload receives a Media without the requested tags, it now applies the same usertags through media_edit and returns the updated Media. Scheduled photo publishing is left unchanged.

Tests:
- .venv/bin/python -m pytest -q tests/regression/test_upload.py
- .venv/bin/python -m ruff check instagrapi/mixins/photo.py tests/regression/test_upload.py tests/live/test_upload.py
- live: tests/live/test_upload.py::ClienUploadTestCase::test_photo_upload_with_usertags_visible_after_media_info