### PR TITLE
Add live-verified user report flow

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -26,6 +26,7 @@ View a list of a user's medias, following and followers
 | user_id_from_username(username: str)          | int                   | Get user_id by username                                      |
 | username_from_user_id(user_id: str)           | str                   | Get username by user_id                                      |
 | user_remove_follower(user_id: str)            | bool                  | Remove your follower                                         |
+| user_report(user_id: str, reason: str = "spam") | bool                | Report a user account. Currently supports the live-verified spam report flow |
 | mute_posts_from_follow(user_id: str)          | bool                  | Mute posts from following user                               |
 | unmute_posts_from_follow(user_id: str)        | bool                  | Unmute posts from following user                             |
 | mute_stories_from_follow(user_id: str)        | bool                  | Mute stories from following user                             |
@@ -95,6 +96,8 @@ each `user_id`; they do not implement an auto-approval policy.
 `user_follow()` returns `True` only when it sends a new follow action and Instagram reports either an immediate follow or a new outgoing follow request for a private account. It returns `False` when the current account already follows the target or already has a pending outgoing follow request. Use `user_friendship_v1()` when you need to distinguish `following` from `outgoing_request`.
 
 `UserShort` objects returned from private GraphQL follow-list payloads preserve selected v2-only fields when Instagram sends them: `friendship_status`, `profile_pic_id`, `fbid_v2`, `interop_messaging_user_fbid`, `strong_id__`, and raw `account_badges`. The legacy `latest_reel_media` property is also populated from Instagram's current `1llatest_reel_media` key.
+
+`user_report(user_id, reason="spam")` follows Instagram's current mobile FRX report flow for account spam reports and submits the report. This is a real account action; use it only for accounts you actually intend to report. Unsupported reasons raise `ValueError` until their FRX tag paths are captured and tested.
 
 Example:
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -35,11 +35,13 @@ USER_WEB_PROFILE_DOC_ID = "26762473490008061"
 USER_INFO_V2_DOC_ID = "25980296051578533"
 USER_INFO_BY_USERNAME_V2_DOC_ID = "26347858941511777"
 ADDRESS_BOOK_DEFAULT_INCLUDE = ("extra_display_name", "thumbnails")
+USER_REPORT_REASONS = {"spam": ("ig_report_account", "ig_its_inappropriate", "ig_spam_v3")}
 
 logger = logging.getLogger(__name__)
 
 INFO_FROM_MODULE = Literal["self_profile", "feed_timeline", "reel_feed_timeline"]
 FOLLOWERS_ORDER = Literal["date_followed_latest", "date_followed_earliest"]
+USER_REPORT_REASON = Literal["spam"]
 
 
 class UserMixin:
@@ -1510,6 +1512,68 @@ class UserMixin:
         assert result.get("status", "") == "ok"
 
         return result.get("friendship_status", {}).get("blocking") is False
+
+    def user_report(self, user_id: str, reason: USER_REPORT_REASON = "spam") -> bool:
+        """
+        Report a User
+
+        Parameters
+        ----------
+        user_id: str
+            User ID of an Instagram account
+        reason: str, optional
+            Report reason. Currently supports ``"spam"``.
+
+        Returns
+        -------
+        bool
+            True if Instagram returns the report confirmation state
+        """
+        user_id = str(user_id)
+        if reason not in USER_REPORT_REASONS:
+            raise ValueError(
+                f'Unsupported user report reason "{reason}". Supported reasons: {tuple(USER_REPORT_REASONS)}'
+            )
+
+        result = self.private_request(
+            "reports/get_frx_prompt/",
+            data={
+                "_uuid": self.uuid,
+                "container_module": "profile",
+                "entry_point": "1",
+                "frx_prompt_request_type": "1",
+                "is_dark_mode": "false",
+                "location": "2",
+                "nua_action": "",
+                "object_id": user_id,
+                "object_type": "5",
+            },
+            with_signature=False,
+        )
+        response = result.get("response", result)
+        context = response.get("context")
+        if not context:
+            raise ClientError("Instagram report flow did not return an initial context", **result)
+
+        for tag in USER_REPORT_REASONS[reason]:
+            result = self.private_request(
+                "reports/get_frx_prompt/",
+                data={
+                    "_uuid": self.uuid,
+                    "context": context,
+                    "frx_prompt_request_type": "2",
+                    "is_dark_mode": "false",
+                    "nua_action": "",
+                    "selected_tag_types": dumps([tag]),
+                },
+                with_signature=False,
+            )
+            response = result.get("response", result)
+            context = response.get("context")
+            if not context:
+                raise ClientError(f'Instagram report flow did not return context after tag "{tag}"', **result)
+
+        return bool(response.get("follow_up_actions"))
 
     def user_remove_follower(self, user_id: str) -> bool:
         """

--- a/tests/live/test_user.py
+++ b/tests/live/test_user.py
@@ -57,6 +57,20 @@ class ClientUserTestCase(_helpers.ClientPrivateTestCase):
         self.assertIsInstance(followers[0], UserShort)
 
 
+class ClientUserReportLiveTestCase(unittest.TestCase):
+    def test_user_report_spam_live(self):
+        if os.getenv("IG_USER_REPORT_LIVE") != "1":
+            self.skipTest("Set IG_USER_REPORT_LIVE=1 to run the destructive user report live test")
+        target_user_id = os.getenv("IG_USER_REPORT_TARGET_ID")
+        if not target_user_id:
+            self.skipTest("IG_USER_REPORT_TARGET_ID is required for the user report live test")
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for user report live tests")
+        cl = fresh_test_account(count=5, attempts=5, timeout=30)
+
+        self.assertTrue(cl.user_report(target_user_id))
+
+
 class ClientPrivateGraphQLV2UserFieldsLiveTestCase(unittest.TestCase):
     def test_user_followers_private_gql_preserves_v2_user_fields(self):
         if not TEST_ACCOUNTS_URL:

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1199,6 +1199,64 @@ class UserMixinRegressionTestCase(unittest.TestCase):
             data={"_uuid": "uuid"},
         )
 
+    def test_user_report_spam_replays_live_frx_prompt_sequence(self):
+        client = Client()
+        client.uuid = "uuid"
+        responses = [
+            {"response": {"context": "context-0", "report_tags": [{"tag_type": "ig_report_account"}]}},
+            {"response": {"context": "context-1", "report_tags": [{"tag_type": "ig_its_inappropriate"}]}},
+            {"response": {"context": "context-2", "report_tags": [{"tag_type": "ig_spam_v3"}]}},
+            {
+                "response": {
+                    "context": "context-3",
+                    "follow_up_actions": [{"action_type": 2}],
+                    "subtitle": {"text": "Thanks for your feedback"},
+                }
+            },
+        ]
+
+        with mock.patch.object(client, "private_request", side_effect=responses) as private_request:
+            result = client.user_report("16147964785")
+
+        self.assertTrue(result)
+        self.assertEqual(private_request.call_count, 4)
+        first_call = private_request.call_args_list[0]
+        self.assertEqual(first_call.args[0], "reports/get_frx_prompt/")
+        self.assertFalse(first_call.kwargs["with_signature"])
+        self.assertEqual(
+            first_call.kwargs["data"],
+            {
+                "_uuid": "uuid",
+                "container_module": "profile",
+                "entry_point": "1",
+                "frx_prompt_request_type": "1",
+                "is_dark_mode": "false",
+                "location": "2",
+                "nua_action": "",
+                "object_id": "16147964785",
+                "object_type": "5",
+            },
+        )
+
+        expected_contexts = ["context-0", "context-1", "context-2"]
+        expected_tags = ["ig_report_account", "ig_its_inappropriate", "ig_spam_v3"]
+        for call, context, tag in zip(private_request.call_args_list[1:], expected_contexts, expected_tags):
+            self.assertEqual(call.args[0], "reports/get_frx_prompt/")
+            self.assertFalse(call.kwargs["with_signature"])
+            self.assertEqual(call.kwargs["data"]["context"], context)
+            self.assertEqual(call.kwargs["data"]["frx_prompt_request_type"], "2")
+            self.assertEqual(json.loads(call.kwargs["data"]["selected_tag_types"]), [tag])
+            self.assertEqual(call.kwargs["data"]["is_dark_mode"], "false")
+
+    def test_user_report_rejects_unknown_reason_before_request(self):
+        client = Client()
+
+        with mock.patch.object(client, "private_request") as private_request:
+            with self.assertRaisesRegex(ValueError, 'Unsupported user report reason "copyright"'):
+                client.user_report("123", reason="copyright")
+
+        private_request.assert_not_called()
+
     def test_user_stream_by_id_v1_sends_expected_endpoint_and_data(self):
         client = Client()
         with mock.patch.object(client, "private_request", return_value={"stream_rows": []}) as private_request:


### PR DESCRIPTION
## Summary
- add `Client.user_report(user_id, reason="spam")` using Instagram's current FRX report prompt flow
- keep unsupported reasons rejected before any request until their FRX tag paths are captured and tested
- add regression coverage, opt-in destructive live coverage, and user guide docs

Fixes https://github.com/subzeroid/instagrapi/issues/742

## Tests
- `.venv/bin/python -m ruff check instagrapi/mixins/user.py tests/regression/test_user.py tests/live/test_user.py`
- `.venv/bin/python -m pytest -q tests/regression`
- `.venv/bin/python -m pytest -q tests/regression/test_docs_model_reference.py`
- `.venv/bin/python -m pytest -q -rs tests/live/test_user.py::ClientUserReportLiveTestCase::test_user_report_spam_live` (default skip)
- `IG_USER_REPORT_LIVE=1 IG_USER_REPORT_TARGET_ID=16147964785 .venv/bin/python -m pytest -q -rs tests/live/test_user.py::ClientUserReportLiveTestCase::test_user_report_spam_live` (opt-in live: passed)