### PR TITLE
Fix Direct XMA deep link parsing

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -554,7 +554,7 @@ class Media(TypesBaseModel):
 
 class MediaXma(TypesBaseModel):
     # media_type: int
-    video_url: HttpUrl  # for Video and IGTV
+    video_url: str  # XMA target_url; can be http(s) or an Instagram deep link
     title: Optional[str] = ""
     preview_url: Optional[str] = None
     preview_url_mime_type: Optional[str] = None

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -554,7 +554,7 @@ class Media(TypesBaseModel):
 
 class MediaXma(TypesBaseModel):
     # media_type: int
-    video_url: str  # XMA target_url; can be http(s) or an Instagram deep link
+    video_url: str  # XMA target_url; can be http(s) or an Instagram deep link (instagram://)
     title: Optional[str] = ""
     preview_url: Optional[str] = None
     preview_url_mime_type: Optional[str] = None

--- a/tests/regression/test_extractors.py
+++ b/tests/regression/test_extractors.py
@@ -79,6 +79,29 @@ class DirectExtractorRegressionTestCase(unittest.TestCase):
         self.assertEqual(str(message.generic_xma[0].video_url), "https://example.com/first")
         self.assertEqual(str(message.generic_xma[1].video_url), "https://example.com/second")
 
+    def test_generic_xma_accepts_instagram_deep_link_target_url(self):
+        message = extract_direct_message(
+            {
+                "item_id": "1",
+                "user_id": "2",
+                "timestamp": 1761953663000000,
+                "item_type": "generic_xma",
+                "text": "",
+                "generic_xma": [
+                    {
+                        "target_url": "instagram://direct-notes?user_id=123456789&is_self_note=0",
+                        "title_text": "Direct note",
+                    },
+                ],
+            }
+        )
+
+        self.assertIsNotNone(message.generic_xma)
+        self.assertEqual(
+            message.generic_xma[0].video_url,
+            "instagram://direct-notes?user_id=123456789&is_self_note=0",
+        )
+
     def test_xma_clip_without_target_url_keeps_raw_payload(self):
         message = extract_direct_message(
             {


### PR DESCRIPTION
Fixes https://github.com/subzeroid/instagrapi/issues/2686

Direct XMA payloads can use Instagram deep links such as instagram://direct-notes in target_url. The extractor normalizes that value into MediaXma.video_url, so the field cannot be restricted to http(s) URLs.

Changes:
- relax MediaXma.video_url to a string target URL
- add a regression test for generic_xma with an instagram:// Direct Notes deep link

Checks:
- .venv/bin/python -m pytest -q tests/regression/test_extractors.py tests/regression/test_direct.py
- .venv/bin/ruff check instagrapi/types.py tests/regression/test_extractors.py
- git diff --check