### PR TITLE
Type public option literals

### DIFF
--- a/docs/usage-guide/account.md
+++ b/docs/usage-guide/account.md
@@ -12,7 +12,7 @@ Viewing and managing your profile
 | account_set_public() | bool | Switch account to public mode |
 | account_convert_to_business(category_id: str \| int = "2347428775505624", should_show_category: bool = True, should_show_public_contacts: bool = False) | Account | Convert the current account to a business professional account |
 | account_convert_to_creator(category_id: str \| int = "2347428775505624", should_show_category: bool = True, should_show_public_contacts: bool = False) | Account | Convert the current account to a creator professional account |
-| account_convert_to_professional(to_account_type: int = 3, category_id: str \| int = "2347428775505624", should_show_category: bool = True, should_show_public_contacts: bool = False) | Account | Generic professional account conversion helper; `2` is business and `3` is creator |
+| account_convert_to_professional(to_account_type: Literal[2, 3] = 3, category_id: str \| int = "2347428775505624", should_show_category: bool = True, should_show_public_contacts: bool = False) | Account | Generic professional account conversion helper; `2` is business and `3` is creator |
 | account_security_info() | dict | Return account security settings, backup codes, trusted devices, and 2FA state |
 | set_external_url(external_url: str) | dict | Replace bio links with a single external URL |
 | remove_bio_links(link_ids: List[int]) | dict | Remove one or more bio links by link ID |
@@ -94,7 +94,7 @@ Notes:
 * `account_edit(**data)` only applies supported fields and preserves missing required profile fields from `account_info()`.
 * Use `account_set_biography()` when you want Instagram to re-process biography entities/markup explicitly.
 * Professional conversion uses Instagram's mobile conversion flow and may still be blocked by account-specific eligibility, category, contact, or Account Center requirements.
-* `account_convert_to_business()` sends `to_account_type=2`; `account_convert_to_creator()` sends `to_account_type=3`.
+* `account_convert_to_business()` sends `to_account_type=2`; `account_convert_to_creator()` sends `to_account_type=3`. The generic helper exposes this as `ProfessionalAccountType = Literal[2, 3]`.
 * `send_password_reset()` starts Instagram's recovery flow by requesting a reset link or code. It does not set a new password by itself; continue with the link/code flow that Instagram sends to the account email or phone.
 * `account_security_info()` and `insights_*` style methods require an authenticated session and may depend on the account type or enabled security features.
 

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -2,7 +2,7 @@
 
 | Method                                                                    | Return                  | Description
 | ------------------------------------------------------------------------- | ----------------------- | ----------------------------------
-| `direct_threads(amount: int = 20, selected_filter: str = "", box: str = "", thread_message_limit: Optional[int] = None)` <br> Note: `selected_filter` = `""`, `"flagged"` or `"unread"`; `box` = `""`, `"primary"` or `"general"` | List[DirectThread] | Get all threads from inbox
+| `direct_threads(amount: int = 20, selected_filter: Optional[Literal["flagged", "unread"]] = None, box: Optional[Literal["primary", "general"]] = None, thread_message_limit: Optional[int] = None)` <br> Note: omit `selected_filter` / `box` or pass `None` for the default inbox | List[DirectThread] | Get all threads from inbox
 | direct_pending_inbox(amount: int = 20)                                    | List[DirectThread]      | Get all threads from pending inbox
 | direct_requests(amount: int = 20)                                         | List[DirectThread]      | Get message request threads (pending inbox / invitations)
 | direct_pending_requests_preview(pending_inbox_filters: Optional[List[str]] = None) | Dict             | Get lightweight pending request counters

--- a/docs/usage-guide/hashtag.md
+++ b/docs/usage-guide/hashtag.md
@@ -132,10 +132,10 @@ Low level methods:
 | hashtag_info_gql(name: str, amount: int = 12, end_cursor: str = None) | Hashtag | Get information about a hashtag by Public Graphql API
 | hashtag_info_v1(name: str) | Hashtag | Get information about a hashtag by Private Mobile API
 | hashtag_medias_paginated_gql(name: str, amount: int = 27, end_cursor: str = None) | Tuple[List[Media], str] | Get one recent hashtag media page by Public GraphQL API
-| hashtag_medias_paginated_v1(name: str, amount: int = 27, tab_key: str = "top\|recent\|clips", end_cursor: str = None) | Tuple[List[Media], str] | Get one hashtag media page by Private Mobile API
+| hashtag_medias_paginated_v1(name: str, amount: int = 27, tab_key: Literal["top", "recent", "clips"] = "recent", end_cursor: str = None) | Tuple[List[Media], str] | Get one hashtag media page by Private Mobile API
 | iter_hashtag_medias(name: str, amount: int = 0, page_size: int = 27, tab_key: str = "recent") | Iterator[Media] | Stream hashtag medias page by page through `hashtag_medias_paginated()`
-| hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: str = "top\|recent", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
-| hashtag_medias_v1(name: str, amount: int = 27, tab_key: str = "top\|recent") | List[Media] | Get medias for a hashtag by Private Mobile API
+| hashtag_medias_v1_chunk(name: str, max_amount: int = 27, tab_key: Literal["top", "recent", "clips"] = "top", max_id: str = None) | Tuple[List[Media], str] | Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
+| hashtag_medias_v1(name: str, amount: int = 27, tab_key: Literal["top", "recent", "clips"] = "top") | List[Media] | Get medias for a hashtag by Private Mobile API
 | hashtag_medias_top_v1(name: str, amount: int = 9) | List[Media] | Get top medias for a hashtag by Private Mobile API
 | hashtag_medias_recent_v1(name: str, amount: int = 27) | List[Media] | Get recent medias for a hashtag by Private Mobile API
 | hashtag_medias_reels_v1(name: str, amount: int = 27) | List[Media] | Get recent clips (reels) for a hashtag by Private Mobile API

--- a/docs/usage-guide/location.md
+++ b/docs/usage-guide/location.md
@@ -215,7 +215,7 @@ Low level methods:
 | Method                                         | Return  | Description
 | ---------------------------------------------- | ------- | --------------------------------------------
 | location_info_v1(location_pk: int) | Location | Get a location using location pk (Private Mobile API)
-| location_medias_v1_chunk(location_pk: int, max_amount: int = 63, tab_key: str = "ranked\|recent", max_id: str = None) | Tuple[List[Media], str] Get chunk of medias for a location and max_id (cursor) by Private Mobile API
-| location_medias_v1(location_pk: int, amount: int = 63, tab_key: str = "ranked\|recent") | List[Media] | Get medias for a location (Private Mobile API), paginating with the server cursor until `amount` is reached or the cursor is exhausted
+| location_medias_v1_chunk(location_pk: int, max_amount: int = 63, tab_key: Literal["ranked", "recent"] = "ranked", max_id: str = None) | Tuple[List[Media], str] Get chunk of medias for a location and max_id (cursor) by Private Mobile API
+| location_medias_v1(location_pk: int, amount: int = 63, tab_key: Literal["ranked", "recent"] = "ranked") | List[Media] | Get medias for a location (Private Mobile API), paginating with the server cursor until `amount` is reached or the cursor is exhausted
 | location_medias_top_v1(location_pk: int, amount: int = 21) | List[Media] | Get top medias for a location (Private Mobile API)
 | location_medias_recent_v1(location_pk: int, amount: int = 63) | List[Media] | Get recent medias for a location (Private Mobile API), paginating past the first chunk when the endpoint returns `next_max_id`

--- a/docs/usage-guide/notes.md
+++ b/docs/usage-guide/notes.md
@@ -5,9 +5,9 @@
 | get_notes()                 | List[Note]        | Retrieve direct Notes           |
 | get_note_by_user(notes: List[Note], username: str) | Optional[Note] | Find a Note by username |
 | get_note_text_by_user(notes: List[Note], username: str) | Optional[str] | Get note text by username |
-| create_note(text: str, audience: int = 0) | Note | Post a new Note                 |
+| create_note(text: str, audience: Literal[0, 1] = 0) | Note | Post a new Note                 |
 | notes_music_browser()      | Dict              | Retrieve music candidates for Notes |
-| create_music_note(track: Track \| Dict, text: str = "", audience: int = 0, start_time: Optional[int] = None, duration: int = 30000, browse_session_id: Optional[str] = None, alacorn_session_id: Optional[str] = None) | Note | Post a new Note with music |
+| create_music_note(track: Track \| Dict, text: str = "", audience: Literal[0, 1] = 0, start_time: Optional[int] = None, duration: int = 30000, browse_session_id: Optional[str] = None, alacorn_session_id: Optional[str] = None) | Note | Post a new Note with music |
 | delete_note(note_id: int)   | bool              | Delete a posted Note            |
 | last_seen_update_note()     | bool              | Update the last seen time |
 
@@ -78,7 +78,7 @@ Common arguments:
 
 * `note_id` - ID of the Note object
 * `text` - Content of the Note
-* `audience` - Who can see the note **(0 = Followers you follow back, 1 = Close Friends only)**
+* `audience` - Who can see the note. Exposed as `NoteAudience = Literal[0, 1]` **(0 = Followers you follow back, 1 = Close Friends only)**
 * `username` - Username used to search in an existing `notes` list
 * `track` - Track object or raw track dict from `notes_music_browser()`
 

--- a/docs/usage-guide/public-transport.md
+++ b/docs/usage-guide/public-transport.md
@@ -8,6 +8,8 @@
 The default public web transport is `requests`. It has the smallest dependency footprint and keeps the existing
 transport-level retry behavior.
 
+The public transport option is exposed as `PublicTransport = Literal["requests", "curl"]`.
+
 For public web endpoints that are sensitive to browser TLS fingerprints, you can install the optional curl transport:
 
 ```bash

--- a/docs/usage-guide/story.md
+++ b/docs/usage-guide/story.md
@@ -75,12 +75,12 @@ Common arguments:
 * `stickers` - Add stickers to story
 * `medias` - Reshared feed media stickers
 * `polls` - Add polls to story
-* `resize_mode` - Story media sizing mode: `"fill"` keeps the current crop/fill behavior, `"fit"` renders the full source media on a Story canvas without cropping
+* `resize_mode` - Story media sizing mode. Exposed as `StoryResizeMode = Literal["fill", "fit"]`; `"fill"` keeps the current crop/fill behavior, `"fit"` renders the full source media on a Story canvas without cropping
 
 | Method                               | Return   | Description
 | ------------------------------------ | -------- | -------------
-| photo_upload_to_story(path: Path, caption: str = "", upload_id: str = "", mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: str = "fill")  | Story  | Upload photo to story
-| video_upload_to_story(path: Path, caption: str = "", thumbnail: Path = None, mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: str = "fill") | Story  | Upload video to story
+| photo_upload_to_story(path: Path, caption: str = "", upload_id: str = "", mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: StoryResizeMode = "fill")  | Story  | Upload photo to story
+| video_upload_to_story(path: Path, caption: str = "", thumbnail: Path = None, mentions: List[StoryMention] = [], locations: List[StoryLocation] = [], links: List[StoryLink] = [], hashtags: List[StoryHashtag] = [], stickers: List[StorySticker] = [], medias: List[StoryMedia] = [], polls: List[StoryPoll] = [], extra_data: Dict[str, str] = {}, resize_mode: StoryResizeMode = "fill") | Story  | Upload video to story
 | media_share_to_story(media_id: str, background: Path = None, caption: str = "") | Story | Share an existing post to your story with a generated or provided background
 | photo_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, duration: float = 15.0, extra_data: Dict = {}) | Story | Upload photo to story as a short video with the selected music track muxed into it
 | video_upload_to_story_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Story | Upload video to story with the selected music track muxed into it

--- a/instagrapi/mixins/account.py
+++ b/instagrapi/mixins/account.py
@@ -1,11 +1,13 @@
 import json
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Literal, Optional, Union
 
 from instagrapi.extractors import extract_account, extract_user_short
 from instagrapi.types import Account, UserShort
 from instagrapi.utils.auth import gen_token, generate_signature
 from instagrapi.utils.serialization import dumps
+
+ProfessionalAccountType = Literal[2, 3]
 
 
 class AccountMixin:
@@ -64,7 +66,7 @@ class AccountMixin:
 
     def account_convert_to_professional(
         self,
-        to_account_type: int = 3,
+        to_account_type: ProfessionalAccountType = 3,
         category_id: Union[str, int] = "2347428775505624",
         should_show_category: bool = True,
         should_show_public_contacts: bool = False,
@@ -77,7 +79,7 @@ class AccountMixin:
 
         Parameters
         ----------
-        to_account_type: int, default 3
+        to_account_type: Literal[2, 3], default 3
             Instagram professional account type. ``2`` is business and ``3`` is creator.
         category_id: str or int, default "2347428775505624"
             Professional category id selected during conversion.

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Literal, Union
+from typing import Any, Dict, Iterable, List, Literal, Optional, Union
 from uuid import uuid4
 
 import requests
@@ -1020,7 +1020,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         session_retry_total: int = None,
         session_retry_backoff_factor: Union[int, float] = None,
         session_retry_statuses: list = None,
-        public_transport: str = None,
+        public_transport: Optional[Literal["requests", "curl"]] = None,
         public_transport_impersonate: str = None,
     ) -> bool:
         if request_timeout is not None:

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -77,8 +77,8 @@ class DirectMixin:
     def direct_threads(
         self,
         amount: int = 20,
-        selected_filter: SELECTED_FILTER = "",
-        box: BOX = "",
+        selected_filter: Optional[SELECTED_FILTER] = None,
+        box: Optional[BOX] = None,
         thread_message_limit: Optional[int] = None,
     ) -> List[DirectThread]:
         """
@@ -89,9 +89,9 @@ class DirectMixin:
         amount: int, optional
             Maximum number of media to return, default is 20
         selected_filter: str, optional
-            Filter to apply to threads (flagged or unread)
+            Filter to apply to threads ("flagged" or "unread")
         box: str, optional
-            Box to gather threads from (primary or general) (business accounts only)
+            Box to gather threads from ("primary" or "general") (business accounts only)
         thread_message_limit: int, optional
             Thread message limit, deafult is 10
 
@@ -117,8 +117,8 @@ class DirectMixin:
 
     def direct_threads_chunk(
         self,
-        selected_filter: SELECTED_FILTER = "",
-        box: BOX = "",
+        selected_filter: Optional[SELECTED_FILTER] = None,
+        box: Optional[BOX] = None,
         thread_message_limit: Optional[int] = None,
         cursor: str = None,
     ) -> Tuple[List[DirectThread], str]:
@@ -128,11 +128,11 @@ class DirectMixin:
         Parameters
         ----------
         selected_filter: str, optional
-            Filter to apply to threads (flagged or unread)
+            Filter to apply to threads ("flagged" or "unread")
         thread_message_limit: int, optional
             Thread message limit, deafult is 10
         box: str, optional
-            Box to gather threads from (primary or general) (business accounts only)
+            Box to gather threads from ("primary" or "general") (business accounts only)
         cursor: str, optional
             Cursor from the previous chunk request
 

--- a/instagrapi/mixins/hashtag.py
+++ b/instagrapi/mixins/hashtag.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import warnings
-from typing import Iterator, List, Tuple
+from typing import Iterator, List, Literal, Tuple
 
 from instagrapi.exceptions import ClientError, ClientLoginRequired, HashtagNotFound, PrivateError, WrongCursorError
 from instagrapi.extractors import (
@@ -13,6 +13,8 @@ from instagrapi.extractors import (
 from instagrapi.types import Hashtag, Media
 from instagrapi.utils.iterators import iter_paginated
 from instagrapi.utils.serialization import dumps
+
+HashtagTab = Literal["top", "recent", "clips"]
 
 
 class HashtagMixin:
@@ -112,7 +114,7 @@ class HashtagMixin:
         return self.hashtag_info_v1(name)
 
     def hashtag_medias_v1_chunk(
-        self, name: str, max_amount: int = 27, tab_key: str = "", max_id: str = None
+        self, name: str, max_amount: int = 27, tab_key: HashtagTab = "top", max_id: str = None
     ) -> Tuple[List[Media], str]:
         """
         Get chunk of medias for a hashtag and max_id (cursor) by Private Mobile API
@@ -124,7 +126,7 @@ class HashtagMixin:
         max_amount: int, optional
             Maximum number of media to return, default is 27
         tab_key: str, optional
-            Tab Key, default value is ""
+            Tab key: "top", "recent" or "clips", default is "top"
         max_id: str
             Max ID, default value is None
 
@@ -239,7 +241,7 @@ class HashtagMixin:
         return medias, next_cursor
 
     def hashtag_medias_paginated_v1(
-        self, name: str, amount: int = 27, tab_key: str = "recent", end_cursor: str = None
+        self, name: str, amount: int = 27, tab_key: HashtagTab = "recent", end_cursor: str = None
     ) -> Tuple[List[Media], str]:
         """
         Get a page of medias for a hashtag by Private Mobile API
@@ -265,7 +267,7 @@ class HashtagMixin:
         return self.hashtag_medias_v1_chunk(name, max_amount=amount, tab_key=tab_key, max_id=end_cursor)
 
     def hashtag_medias_paginated(
-        self, name: str, amount: int = 27, tab_key: str = "recent", end_cursor: str = None
+        self, name: str, amount: int = 27, tab_key: HashtagTab = "recent", end_cursor: str = None
     ) -> Tuple[List[Media], str]:
         """
         Get a page of medias for a hashtag
@@ -327,7 +329,7 @@ class HashtagMixin:
         name: str,
         amount: int = 0,
         page_size: int = 27,
-        tab_key: str = "recent",
+        tab_key: HashtagTab = "recent",
     ) -> Iterator[Media]:
         """
         Iterate over medias for a hashtag.
@@ -355,7 +357,7 @@ class HashtagMixin:
 
         return iter_paginated(fetch_page, amount=amount, page_size=page_size, initial_cursor=None)
 
-    def hashtag_medias_v1(self, name: str, amount: int = 27, tab_key: str = "") -> List[Media]:
+    def hashtag_medias_v1(self, name: str, amount: int = 27, tab_key: HashtagTab = "top") -> List[Media]:
         """
         Get medias for a hashtag by Private Mobile API
 
@@ -366,7 +368,7 @@ class HashtagMixin:
         amount: int, optional
             Maximum number of media to return, default is 27
         tab_key: str, optional
-            Tab Key, default value is ""
+            Tab key: "top", "recent" or "clips", default is "top"
 
         Returns
         -------

--- a/instagrapi/mixins/location.py
+++ b/instagrapi/mixins/location.py
@@ -1,12 +1,13 @@
 import base64
 import json
-from typing import List, Tuple
+from typing import List, Literal, Tuple
 
 from instagrapi.exceptions import LocationNotFound, WrongCursorError
 from instagrapi.extractors import extract_guide_v1, extract_location, extract_media_v1
 from instagrapi.types import Guide, Location, Media
 
 tab_keys_v1 = ("ranked", "recent")
+LocationTab = Literal["ranked", "recent"]
 
 
 class LocationMixin:
@@ -215,7 +216,7 @@ class LocationMixin:
         self,
         location_pk: int,
         max_amount: int = 63,
-        tab_key: str = "",
+        tab_key: LocationTab = "ranked",
         max_id: str = None,
     ) -> Tuple[List[Media], str]:
         """
@@ -228,7 +229,7 @@ class LocationMixin:
         max_amount: int, optional
             Maximum number of media to return, default is 27
         tab_key: str, optional
-            Tab Key, default value is ""
+            Tab key: "ranked" or "recent", default is "ranked"
         max_id: str
             Max ID, default value is None
 
@@ -270,7 +271,7 @@ class LocationMixin:
                 medias.append(media)
         return medias, next_max_id
 
-    def location_medias_v1(self, location_pk: int, amount: int = 63, tab_key: str = "") -> List[Media]:
+    def location_medias_v1(self, location_pk: int, amount: int = 63, tab_key: LocationTab = "ranked") -> List[Media]:
         """
         Get medias for a location by Private Mobile API
 
@@ -281,7 +282,7 @@ class LocationMixin:
         amount: int, optional
             Maximum number of media to return, default is 63
         tab_key: str, optional
-            Tab Key, default value is ""
+            Tab key: "ranked" or "recent", default is "ranked"
 
         Returns
         -------

--- a/instagrapi/mixins/note.py
+++ b/instagrapi/mixins/note.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from instagrapi.exceptions import ClientGraphqlError
 from instagrapi.types import Note, Track, UserShort
@@ -10,6 +10,8 @@ INBOX_TRAY_FRIENDLY_NAME = "InboxTrayRequest"
 INBOX_TRAY_ROOT_FIELD = "xdt_get_inbox_tray_items"
 CREATE_INBOX_TRAY_ITEM_CLIENT_DOC_ID = "3510400299951610199199089856"
 CREATE_INBOX_TRAY_ITEM_FRIENDLY_NAME = "CreateInboxTrayItemRequest"
+
+NoteAudience = Literal[0, 1]
 
 
 class NoteMixin:
@@ -221,7 +223,7 @@ class NoteMixin:
         assert result.get("status", "") == "ok", "Failed to retrieve Notes music"
         return result
 
-    def create_note(self, text: str, audience: int = 0) -> Note:
+    def create_note(self, text: str, audience: NoteAudience = 0) -> Note:
         """
         Create personal Note
 
@@ -229,7 +231,7 @@ class NoteMixin:
         ----------
         text: str
             Content of the Note
-        audience: optional
+        audience: Literal[0, 1], optional
             Audience to see Note, deafult 0 (Followers you follow back).
             Best Friends - 1
 
@@ -255,7 +257,7 @@ class NoteMixin:
         self,
         track: Union[Track, Dict],
         text: str = "",
-        audience: int = 0,
+        audience: NoteAudience = 0,
         start_time: Optional[int] = None,
         duration: int = 30000,
         browse_session_id: Optional[str] = None,
@@ -270,7 +272,7 @@ class NoteMixin:
             Track from ``notes_music_browser()`` or a compatible dict.
         text: str, optional
             Content of the Note.
-        audience: int, optional
+        audience: Literal[0, 1], optional
             Audience to see Note, default 0 (Followers you follow back).
             Best Friends - 1.
         start_time: int, optional

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -3,7 +3,7 @@ import logging
 import shutil
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 try:
     from simplejson.errors import JSONDecodeError
@@ -29,6 +29,8 @@ from instagrapi.exceptions import (
 )
 from instagrapi.utils.logging import truncate_log_text
 from instagrapi.utils.timing import random_delay
+
+PublicTransport = Literal["requests", "curl"]
 
 
 class PublicRequestMixin:
@@ -123,14 +125,14 @@ class PublicRequestMixin:
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def _normalize_public_transport(cls, public_transport: str) -> str:
+    def _normalize_public_transport(cls, public_transport: Optional[PublicTransport]) -> PublicTransport:
         public_transport = public_transport or "requests"
         if public_transport not in {"requests", "curl"}:
             raise ValueError("public_transport must be 'requests' or 'curl'")
         return public_transport
 
     @classmethod
-    def _default_public_user_agent(cls, public_transport: str, impersonate: str) -> str:
+    def _default_public_user_agent(cls, public_transport: PublicTransport, impersonate: str) -> str:
         if public_transport == "curl":
             return cls.public_curl_user_agents.get(impersonate, cls.public_curl_user_agents["chrome136"])
         return cls.public_user_agent

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -1,0 +1,33 @@
+import unittest
+from inspect import signature
+from typing import get_args
+
+from instagrapi.mixins.account import ProfessionalAccountType
+from instagrapi.mixins.direct import BOX, SELECTED_FILTER, DirectMixin
+from instagrapi.mixins.hashtag import HashtagTab
+from instagrapi.mixins.location import LocationTab
+from instagrapi.mixins.note import NoteAudience
+from instagrapi.mixins.public import PublicTransport
+from instagrapi.types import StoryResizeMode
+
+
+class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
+    def test_public_literal_aliases_expose_supported_values(self):
+        self.assertEqual(set(get_args(ProfessionalAccountType)), {2, 3})
+        self.assertEqual(set(get_args(NoteAudience)), {0, 1})
+        self.assertEqual(set(get_args(HashtagTab)), {"top", "recent", "clips"})
+        self.assertEqual(set(get_args(LocationTab)), {"ranked", "recent"})
+        self.assertEqual(set(get_args(PublicTransport)), {"requests", "curl"})
+        self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
+
+    def test_direct_thread_filter_literals_remain_optional(self):
+        self.assertEqual(set(get_args(SELECTED_FILTER)), {"flagged", "unread"})
+        self.assertEqual(set(get_args(BOX)), {"general", "primary"})
+
+        direct_threads = signature(DirectMixin.direct_threads)
+        self.assertIsNone(direct_threads.parameters["selected_filter"].default)
+        self.assertIsNone(direct_threads.parameters["box"].default)
+
+        direct_threads_chunk = signature(DirectMixin.direct_threads_chunk)
+        self.assertIsNone(direct_threads_chunk.parameters["selected_filter"].default)
+        self.assertIsNone(direct_threads_chunk.parameters["box"].default)


### PR DESCRIPTION
## Summary
- Add public Literal aliases for professional account type, note audience, hashtag/location tabs, public transport, and Direct thread filters.
- Change Direct thread filter/box defaults from empty strings to `None` while keeping the same request payload behavior.
- Give low-level hashtag/location tab helpers valid defaults (`"top"` / `"ranked"`) instead of the previous empty string that failed validation.
- Update usage docs and add regression coverage for the exported literal aliases.

## Test plan
- [x] RED: `python -m pytest tests/regression/test_public_literal_types.py -q` failed before aliases existed.
- [x] `.venv/bin/python -m pytest tests/regression/test_public_literal_types.py -q`
- [x] `.venv/bin/python -m pytest tests/regression -q` (`619 passed, 3 skipped`)
- [x] `.venv/bin/ruff check ...`
- [x] `.venv/bin/ruff format --check ...`