### PR TITLE
Type notification content settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ finally:
 * Includes email/SMS-based [challenge resolver](https://subzeroid.github.io/instagrapi/usage-guide/challenge_resolver.html) hooks
 * Uploads and downloads photos, videos, albums, IGTV, reels, and stories
 * Works with users, media, comments, locations, hashtags, collections, notes, direct messages, and insights
+* Exposes account notification setting helpers with typed notification categories
 * Supports story building with mentions, hashtags, link stickers, and media stickers
 * Includes helpers for current location search and Direct message workflows
 * Supports mobile follower sorting with `date_followed_latest` and `date_followed_earliest`

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,7 @@ To learn more about the various ways `instagrapi` can be used, read the [Usage G
   * [`Media`](usage-guide/media.md) - Publication (also called post): Photo, Video, Album, IGTV and Reels
   * [`Resource`](usage-guide/media.md) - Part of Media (for albums)
   * [`MediaOembed`](usage-guide/media.md) - Short version of Media
+  * [`Notification`](usage-guide/notification.md) - Account notification settings
   * [`Account`](usage-guide/account.md) - Full private info for your account (e.g. email, phone_number)
   * [`TOTP`](usage-guide/totp.md) - 2FA TOTP helpers, code generation, and Bloks verification fallback/helpers
   * [`User`](usage-guide/user.md) - Full public user data

--- a/docs/usage-guide/notification.md
+++ b/docs/usage-guide/notification.md
@@ -1,0 +1,67 @@
+# Notification
+
+Manage notification settings for the authenticated account.
+
+| Method | Return | Description |
+| --- | --- | --- |
+| notification_settings(content_type: NotificationContentType, setting_value: str) | bool | Low-level notification setting helper |
+| notification_disable() | bool | Disable all supported account notifications |
+| notification_mute_all(setting_value: MUTE_ALL = "8_hour") | bool | Mute all notifications for a fixed period |
+| notification_likes(setting_value: SETTING_VALUE = "off") | bool | Manage likes notifications |
+| notification_comments(setting_value: SETTING_VALUE = "off") | bool | Manage comment notifications |
+| notification_direct_share_activity(setting_value: SETTING_VALUE = "off") | bool | Manage Direct share activity notifications |
+| notification_login(setting_value: SETTING_VALUE = "off") | bool | Manage login notifications |
+
+`NotificationContentType` is a `Literal` covering the known helper-backed
+notification categories:
+
+```python
+from instagrapi.mixins.notification import NotificationContentType
+```
+
+Available values are:
+
+```python
+"mute_all"
+"likes"
+"like_and_comment_on_photo_user_tagged"
+"user_tagged"
+"comments"
+"comment_likes"
+"first_post"
+"new_follower"
+"follow_request_accepted"
+"connection_notification"
+"tagged_in_bio"
+"pending_direct_share"
+"direct_share_activity"
+"direct_group_requests"
+"video_call"
+"rooms"
+"live_broadcast"
+"felix_upload_result"
+"view_count"
+"fundraiser_creator"
+"fundraiser_supporter"
+"notification_reminders"
+"announcements"
+"report_updated"
+"login_notification"
+```
+
+`SETTING_VALUE = Literal["off", "following_only", "everyone"]` is used by
+the per-category helpers. `MUTE_ALL = Literal["cancel", "15_minutes",
+"1_hour", "2_hour", "4_hour", "8_hour"]` is used by `notification_mute_all()`.
+
+Example:
+
+```python
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+
+cl.notification_comments("following_only")
+cl.notification_settings("likes", "off")
+cl.notification_mute_all("1_hour")
+```

--- a/instagrapi/mixins/notification.py
+++ b/instagrapi/mixins/notification.py
@@ -5,6 +5,33 @@ SETTING_VALUE_ITEMS = ("off", "following_only", "everyone")
 
 MUTE_ALL = Literal["cancel", "15_minutes", "1_hour", "2_hour", "4_hour", "8_hour"]
 SETTING_VALUE = Literal["off", "following_only", "everyone"]
+NotificationContentType = Literal[
+    "mute_all",
+    "likes",
+    "like_and_comment_on_photo_user_tagged",
+    "user_tagged",
+    "comments",
+    "comment_likes",
+    "first_post",
+    "new_follower",
+    "follow_request_accepted",
+    "connection_notification",
+    "tagged_in_bio",
+    "pending_direct_share",
+    "direct_share_activity",
+    "direct_group_requests",
+    "video_call",
+    "rooms",
+    "live_broadcast",
+    "felix_upload_result",
+    "view_count",
+    "fundraiser_creator",
+    "fundraiser_supporter",
+    "notification_reminders",
+    "announcements",
+    "report_updated",
+    "login_notification",
+]
 
 
 class NotificationMixin:
@@ -12,7 +39,7 @@ class NotificationMixin:
     Helpers for notification settings
     """
 
-    def notification_settings(self, content_type: str, setting_value: str) -> bool:
+    def notification_settings(self, content_type: NotificationContentType, setting_value: str) -> bool:
         data = {
             "content_type": content_type,
             "setting_value": setting_value,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Insight: usage-guide/insight.md
     - Location: usage-guide/location.md
     - Media: usage-guide/media.md
+    - Notification: usage-guide/notification.md
     - Notes: usage-guide/notes.md
     - Pydroid and ffmpeg: usage-guide/pydroid.md
     - Public Transport: usage-guide/public-transport.md

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -7,8 +7,37 @@ from instagrapi.mixins.direct import BOX, SELECTED_FILTER, DirectMixin
 from instagrapi.mixins.hashtag import HashtagTab
 from instagrapi.mixins.location import LocationTab
 from instagrapi.mixins.note import NoteAudience
+from instagrapi.mixins.notification import NotificationContentType
 from instagrapi.mixins.public import PublicTransport
 from instagrapi.types import StoryResizeMode
+
+EXPECTED_NOTIFICATION_CONTENT_TYPES = {
+    "mute_all",
+    "likes",
+    "like_and_comment_on_photo_user_tagged",
+    "user_tagged",
+    "comments",
+    "comment_likes",
+    "first_post",
+    "new_follower",
+    "follow_request_accepted",
+    "connection_notification",
+    "tagged_in_bio",
+    "pending_direct_share",
+    "direct_share_activity",
+    "direct_group_requests",
+    "video_call",
+    "rooms",
+    "live_broadcast",
+    "felix_upload_result",
+    "view_count",
+    "fundraiser_creator",
+    "fundraiser_supporter",
+    "notification_reminders",
+    "announcements",
+    "report_updated",
+    "login_notification",
+}
 
 
 class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
@@ -17,6 +46,7 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(set(get_args(NoteAudience)), {0, 1})
         self.assertEqual(set(get_args(HashtagTab)), {"top", "recent", "clips"})
         self.assertEqual(set(get_args(LocationTab)), {"ranked", "recent"})
+        self.assertEqual(set(get_args(NotificationContentType)), EXPECTED_NOTIFICATION_CONTENT_TYPES)
         self.assertEqual(set(get_args(PublicTransport)), {"requests", "curl"})
         self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
 


### PR DESCRIPTION
## Summary
- add `NotificationContentType` for `notification_settings(content_type=...)`
- document notification setting helpers and supported content type values
- cover the public literal values in regression tests

## Test plan
- `.venv/bin/python -m ruff check instagrapi/mixins/notification.py tests/regression/test_public_literal_types.py`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/notification.py tests/regression/test_public_literal_types.py`
- `.venv/bin/python -m pytest tests/regression/test_public_literal_types.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
- `.venv/bin/python -m mkdocs build --strict`
- `git diff --check`