### PR TITLE
Type Direct media share send attribute

### DIFF
--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -26,7 +26,7 @@
 | direct_thread_add_users(thread_id: int, user_ids: List[int])              | bool                    | Add users to a group thread
 | direct_thread_hide(thread_id: int)                                        | bool                    | Delete (called "hide")
 | direct_thread_update_title(thread_id: int, title: str)                    | bool                    | Update a group thread title
-| direct_media_share(media_id: str, user_ids: List[int] = [], thread_ids: List[int] = []) | DirectMessage | Share a media to users or existing threads
+| direct_media_share(media_id: str, user_ids: List[int] = [], thread_ids: List[int] = [], send_attribute: SEND_ATTRIBUTE_MEDIA = "feed_timeline") | DirectMessage | Share a media to users or existing threads
 | direct_story_share(story_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage       | Share a story to list of users
 | direct_profile_share(user_id: str, user_ids: List[int], thread_ids: List[int]) | DirectMessage      | Share a user profile to list of users
 | direct_thread_mark_unread(thread_id: int)                                 | bool                    | Mark a thread as unread

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -1680,7 +1680,7 @@ class DirectMixin:
         media_id: str,
         user_ids: List[int] = [],
         thread_ids: List[int] = [],
-        send_attribute: SEND_ATTRIBUTES_MEDIA = "feed_timeline",
+        send_attribute: SEND_ATTRIBUTE_MEDIA = "feed_timeline",
         media_type: str = "photo",
     ) -> DirectMessage:
         """
@@ -1694,7 +1694,7 @@ class DirectMixin:
             List of unique identifier of Users id (recipients)
         thread_ids: List[int]
             List of unique identifier of Direct thread id
-        send_attribute: str, optional
+        send_attribute: SEND_ATTRIBUTE_MEDIA, optional
             Sending option. Default is "feed_timeline"
         media_type: str, optional
             Type of the shared media. Default is "photo", also can be "video"

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -3,7 +3,7 @@ from inspect import signature
 from typing import get_args
 
 from instagrapi.mixins.account import ProfessionalAccountType
-from instagrapi.mixins.direct import BOX, SELECTED_FILTER, DirectMixin
+from instagrapi.mixins.direct import BOX, SELECTED_FILTER, SEND_ATTRIBUTE_MEDIA, DirectMixin
 from instagrapi.mixins.hashtag import HashtagTab
 from instagrapi.mixins.location import LocationTab
 from instagrapi.mixins.note import NoteAudience
@@ -38,6 +38,13 @@ EXPECTED_NOTIFICATION_CONTENT_TYPES = {
     "report_updated",
     "login_notification",
 }
+EXPECTED_DIRECT_MEDIA_SEND_ATTRIBUTES = {
+    "feed_timeline",
+    "feed_contextual_chain",
+    "feed_short_url",
+    "feed_contextual_self_profile",
+    "feed_contextual_profile",
+}
 
 
 class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
@@ -48,6 +55,7 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(set(get_args(LocationTab)), {"ranked", "recent"})
         self.assertEqual(set(get_args(NotificationContentType)), EXPECTED_NOTIFICATION_CONTENT_TYPES)
         self.assertEqual(set(get_args(PublicTransport)), {"requests", "curl"})
+        self.assertEqual(set(get_args(SEND_ATTRIBUTE_MEDIA)), EXPECTED_DIRECT_MEDIA_SEND_ATTRIBUTES)
         self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
 
     def test_direct_thread_filter_literals_remain_optional(self):
@@ -61,3 +69,8 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         direct_threads_chunk = signature(DirectMixin.direct_threads_chunk)
         self.assertIsNone(direct_threads_chunk.parameters["selected_filter"].default)
         self.assertIsNone(direct_threads_chunk.parameters["box"].default)
+
+    def test_direct_media_share_uses_public_send_attribute_literal(self):
+        direct_media_share = signature(DirectMixin.direct_media_share)
+
+        self.assertEqual(direct_media_share.parameters["send_attribute"].annotation, SEND_ATTRIBUTE_MEDIA)


### PR DESCRIPTION
## Summary
- type `direct_media_share(send_attribute=...)` with the public `SEND_ATTRIBUTE_MEDIA` Literal alias
- document the Direct media share send attribute option
- add a regression guard for the public literal annotation

## Test plan
- `.venv/bin/python -m ruff check instagrapi/mixins/direct.py tests/regression/test_public_literal_types.py`
- `.venv/bin/python -m ruff format --check instagrapi/mixins/direct.py tests/regression/test_public_literal_types.py`
- `.venv/bin/python -m pytest tests/regression/test_public_literal_types.py -q`
- `.venv/bin/python -m mkdocs build --strict`
- `.venv/bin/python -m pytest tests/regression -q`
- `git diff --check`