### PR TITLE
docs: expose insights literal aliases

### DIFF
--- a/docs/usage-guide/insight.md
+++ b/docs/usage-guide/insight.md
@@ -6,9 +6,11 @@ Get business/professional account statistics. Common arguments:
 * `time_frame` - Time frame for media publishing date: "ONE_WEEK", "ONE_MONTH", "THREE_MONTHS", "SIX_MONTHS", "ONE_YEAR", "TWO_YEARS".
 * `data_ordering` - Data ordering in instagram response: "REACH_COUNT", "LIKE_COUNT", "FOLLOW", "SHARE_COUNT", "BIO_LINK_CLICK", "COMMENT_COUNT", "IMPRESSION_COUNT", "PROFILE_VIEW", "VIDEO_VIEW_COUNT", "SAVE_COUNT".
 
+These arguments are exposed as `POST_TYPE`, `TIME_FRAME`, and `DATA_ORDERING` Literal aliases.
+
 | Method | Return | Description |
 | --- | --- | --- |
-| insights_media_feed_all(post_type: str = "ALL", time_frame: str = "TWO_YEARS", data_ordering: str = "REACH_COUNT", count: int = 0, sleep: int = 2) | List[Dict] | Return feed media edges with insight stats and pagination |
+| insights_media_feed_all(post_type: POST_TYPE = "ALL", time_frame: TIME_FRAME = "TWO_YEARS", data_ordering: DATA_ORDERING = "REACH_COUNT", count: int = 0, sleep: int = 2) | List[Dict] | Return feed media edges with insight stats and pagination |
 | insights_account() | Dict | Get account-level insights (activity, audience, content tabs) |
 | insights_media(media_pk: int) | Dict | Get insights for a single media object |
 

--- a/instagrapi/mixins/insights.py
+++ b/instagrapi/mixins/insights.py
@@ -68,11 +68,11 @@ class InsightsMixin:
 
         Parameters
         ----------
-        post_type: str, optional
+        post_type: POST_TYPE, optional
             Types of posts, default is "ALL"
-        time_frame: str, optional
+        time_frame: TIME_FRAME, optional
             Time frame to pull media insights, default is "TWO_YEARS"
-        data_ordering: str, optional
+        data_ordering: DATA_ORDERING, optional
             Ordering strategy for the data, default is "REACH_COUNT"
         count: int, optional
             Max media count for retrieving, default is 0

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -1,10 +1,12 @@
 import unittest
 from inspect import signature
+from pathlib import Path
 from typing import get_args
 
 from instagrapi.mixins.account import ProfessionalAccountType
 from instagrapi.mixins.direct import BOX, SELECTED_FILTER, SEND_ATTRIBUTE_MEDIA, DirectMixin
 from instagrapi.mixins.hashtag import HashtagTab
+from instagrapi.mixins.insights import DATA_ORDERING, POST_TYPE, TIME_FRAME, InsightsMixin
 from instagrapi.mixins.location import LocationTab
 from instagrapi.mixins.note import NoteAudience
 from instagrapi.mixins.notification import NotificationContentType
@@ -74,3 +76,23 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         direct_media_share = signature(DirectMixin.direct_media_share)
 
         self.assertEqual(direct_media_share.parameters["send_attribute"].annotation, SEND_ATTRIBUTE_MEDIA)
+
+    def test_insights_media_feed_all_uses_public_literal_aliases(self):
+        insights_media_feed_all = signature(InsightsMixin.insights_media_feed_all)
+
+        self.assertEqual(insights_media_feed_all.parameters["post_type"].annotation, POST_TYPE)
+        self.assertEqual(insights_media_feed_all.parameters["time_frame"].annotation, TIME_FRAME)
+        self.assertEqual(insights_media_feed_all.parameters["data_ordering"].annotation, DATA_ORDERING)
+
+    def test_insights_usage_guide_documents_public_literal_aliases(self):
+        docs = Path("docs/usage-guide/insight.md").read_text()
+
+        self.assertIn(
+            'insights_media_feed_all(post_type: POST_TYPE = "ALL", time_frame: TIME_FRAME = "TWO_YEARS", '
+            'data_ordering: DATA_ORDERING = "REACH_COUNT"',
+            docs,
+        )
+        self.assertNotIn(
+            'post_type: str = "ALL", time_frame: str = "TWO_YEARS", data_ordering: str = "REACH_COUNT"',
+            docs,
+        )


### PR DESCRIPTION
## Summary
- Document insights_media_feed_all with the public POST_TYPE, TIME_FRAME, and DATA_ORDERING Literal aliases instead of plain str.
- Align the method docstring with the runtime signature.
- Add regression coverage for the public signature and usage guide text.

Mirror: https://github.com/subzeroid/aiograpi/pull/386

## Tests
- .venv/bin/python -m pytest tests/regression/test_public_literal_types.py -q
- .venv/bin/python -m pytest tests/regression -q
- .venv/bin/python -m ruff check instagrapi/mixins/insights.py tests/regression/test_public_literal_types.py
- .venv/bin/python -m mkdocs build --strict