### PR TITLE
docs: expose music product literal

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -382,8 +382,8 @@ Upload medias to your feed. Common arguments:
 | clip_share_to_fb_unified_destination(config: Dict = None) | dict | Resolve confirmed Reel Facebook destination fields from the unified cross-posting config
 | clip_share_to_fb_destination(config: Dict = None, destination_id: str = None, destination_type: Literal["USER", "PAGE"] = None) | dict | Resolve confirmed Reel Facebook destination fields without treating Account Center linking ids as publish destinations
 | clip_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: Literal["USER", "PAGE"] = None) | dict | Build modern Reel Facebook cross-post configure fields for manual `extra_data`
-| clip_music_extra_data(track: Track or dict, extra_data: Dict = {}) | dict | Build Reels music configure fields for manual `clip_upload(..., extra_data=...)`
-| clip_upload_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, extra_data: Dict = {}) | Media | Upload a Reel with music metadata without local audio muxing
+| clip_music_extra_data(track: Track or dict, product: MUSIC_PRODUCT = "story_camera_clips_v2", extra_data: Dict = {}) | dict | Build Reels music configure fields for manual `clip_upload(..., extra_data=...)`
+| clip_upload_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, product: MUSIC_PRODUCT = "story_camera_clips_v2", extra_data: Dict = {}) | Media | Upload a Reel with music metadata without local audio muxing
 | clip_upload_as_reel_with_music(path: Path, caption: str, track: Track, extra_data: Dict = {}) | Media | Upload a Reel after locally muxing the track into the video with MoviePy
 | photo_upload_with_music(path: Path, caption: str, track: Track or dict, extra_data: Dict = {}, schedule_at: int \| datetime = None) | Media | Upload feed photo with music metadata
 | album_upload_with_music(paths: List[Path], caption: str, track: Track or dict, extra_data: Dict = {}, schedule_at: int \| datetime = None) | Media | Upload feed album/carousel with music metadata

--- a/docs/usage-guide/track.md
+++ b/docs/usage-guide/track.md
@@ -10,11 +10,11 @@ Viewing and downloading tracks
 | track_download_by_url(url: str, filename: str = "", folder: Path = "") | Path | Download track by URL |
 | search_music(query: str) | List[Track] | Search music and return track objects |
 | music_in_feed_audio_browser(browse_session_id: str = None) | dict | Browse music candidates for feed photo and carousel uploads |
-| music_trending(product: str = "feed_post") | dict | Browse trending music candidates |
-| music_top_trends(product: str = "music_in_feed", page_size: int = 15) | dict | Browse top trending music candidates |
-| music_search_v2(query: str, product: str = "music_in_feed", from_typeahead: bool = False, search_session_id: str = None, browse_session_id: str = None) | dict | Search music through the current app endpoint |
-| music_keyword_search(query: str, product: str = "music_in_feed", num_keywords: int = 3, search_session_id: str = "", browse_session_id: str = None) | dict | Search music keyword suggestions |
-| music_clips_audio_browser(product: str = "story_camera_clips_v2", browse_session_id: str = None) | dict | Browse music candidates for the Reels/Clips camera |
+| music_trending(product: MUSIC_PRODUCT = "feed_post") | dict | Browse trending music candidates |
+| music_top_trends(product: MUSIC_PRODUCT = "music_in_feed", page_size: int = 15) | dict | Browse top trending music candidates |
+| music_search_v2(query: str, product: MUSIC_PRODUCT = "music_in_feed", from_typeahead: bool = False, search_session_id: str = None, browse_session_id: str = None) | dict | Search music through the current app endpoint |
+| music_keyword_search(query: str, product: MUSIC_PRODUCT = "music_in_feed", num_keywords: int = 3, search_session_id: str = "", browse_session_id: str = None) | dict | Search music keyword suggestions |
+| music_clips_audio_browser(product: MUSIC_PRODUCT = "story_camera_clips_v2", browse_session_id: str = None) | dict | Browse music candidates for the Reels/Clips camera |
 | music_verify_original_audio_title(original_audio_name: str) | bool | Validate an original audio title for Reels publishing |
 | music_bookmark(original_audio_id: str, surface_requested_from: str = "audio_aggregation_page") | bool | Bookmark an original audio track |
 | music_bookmarked(max_id: str = "") | dict | Retrieve bookmarked music tracks |

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 from instagrapi import config
 from instagrapi.exceptions import ClientError, ClipConfigureError, ClipNotUpload
+from instagrapi.mixins.track import MUSIC_PRODUCT
 from instagrapi.types import Location, Media, Track, Usertag
 from instagrapi.utils.timing import date_time_original
 from instagrapi.utils.video import MOVIEPY_2_INSTALL_MESSAGE, analyze_video_for_upload
@@ -1021,7 +1022,7 @@ class UploadClipMixin:
         overlap_duration: int = 30000,
         original_volume: float = 1.0,
         music_volume: float = 1.0,
-        product: str = "story_camera_clips_v2",
+        product: MUSIC_PRODUCT = "story_camera_clips_v2",
         alacorn_session_id: str = "null",
     ) -> Dict[str, object]:
         """
@@ -1082,7 +1083,7 @@ class UploadClipMixin:
         overlap_duration: int = 30000,
         original_volume: float = 1.0,
         music_volume: float = 1.0,
-        product: str = "story_camera_clips_v2",
+        product: MUSIC_PRODUCT = "story_camera_clips_v2",
         alacorn_session_id: str = "null",
         **kwargs,
     ) -> Media:

--- a/instagrapi/mixins/track.py
+++ b/instagrapi/mixins/track.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 from urllib.parse import urlparse
 
 import requests
@@ -8,6 +8,8 @@ from instagrapi.exceptions import ClientError, TrackNotFound
 from instagrapi.extractors import extract_track
 from instagrapi.types import Track
 from instagrapi.utils.serialization import json_value
+
+MUSIC_PRODUCT = Literal["feed_post", "music_in_feed", "story_camera_clips_v2"]
 
 
 class TrackMixin:
@@ -86,13 +88,13 @@ class TrackMixin:
             with_signature=False,
         )
 
-    def music_trending(self, product: str = "feed_post") -> Dict:
+    def music_trending(self, product: MUSIC_PRODUCT = "feed_post") -> Dict:
         """
         Retrieve trending music candidates.
 
         Parameters
         ----------
-        product: str, optional
+        product: MUSIC_PRODUCT, optional
             Music product surface. The Android app uses ``feed_post`` for the
             successful current feed-post path.
 
@@ -107,13 +109,13 @@ class TrackMixin:
             with_signature=False,
         )
 
-    def music_top_trends(self, product: str = "music_in_feed", page_size: int = 15) -> Dict:
+    def music_top_trends(self, product: MUSIC_PRODUCT = "music_in_feed", page_size: int = 15) -> Dict:
         """
         Retrieve top trending music candidates.
 
         Parameters
         ----------
-        product: str, optional
+        product: MUSIC_PRODUCT, optional
             Music product surface.
         page_size: int, optional
             Number of trend rows requested.
@@ -136,7 +138,7 @@ class TrackMixin:
     def music_search_v2(
         self,
         query: str,
-        product: str = "music_in_feed",
+        product: MUSIC_PRODUCT = "music_in_feed",
         from_typeahead: bool = False,
         search_session_id: Optional[str] = None,
         browse_session_id: Optional[str] = None,
@@ -148,7 +150,7 @@ class TrackMixin:
         ----------
         query: str
             Search query.
-        product: str, optional
+        product: MUSIC_PRODUCT, optional
             Music product surface.
         from_typeahead: bool, optional
             Whether the query came from a typeahead suggestion.
@@ -182,7 +184,7 @@ class TrackMixin:
     def music_keyword_search(
         self,
         query: str,
-        product: str = "music_in_feed",
+        product: MUSIC_PRODUCT = "music_in_feed",
         num_keywords: int = 3,
         search_session_id: str = "",
         browse_session_id: Optional[str] = None,
@@ -194,7 +196,7 @@ class TrackMixin:
         ----------
         query: str
             Search query.
-        product: str, optional
+        product: MUSIC_PRODUCT, optional
             Music product surface.
         num_keywords: int, optional
             Number of keyword suggestions requested.
@@ -277,7 +279,7 @@ class TrackMixin:
 
     def music_clips_audio_browser(
         self,
-        product: str = "story_camera_clips_v2",
+        product: MUSIC_PRODUCT = "story_camera_clips_v2",
         browse_session_id: Optional[str] = None,
     ) -> Dict:
         """
@@ -285,7 +287,7 @@ class TrackMixin:
 
         Parameters
         ----------
-        product: str, optional
+        product: MUSIC_PRODUCT, optional
             Music product surface.
         browse_session_id: str, optional
             Browse session id. Generated when omitted.

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import get_args
 
 from instagrapi.mixins.account import ProfessionalAccountType
+from instagrapi.mixins.clip import UploadClipMixin
 from instagrapi.mixins.direct import BOX, SELECTED_FILTER, SEND_ATTRIBUTE_MEDIA, DirectMixin
 from instagrapi.mixins.hashtag import HashtagTab
 from instagrapi.mixins.insights import DATA_ORDERING, POST_TYPE, TIME_FRAME, InsightsMixin
@@ -11,6 +12,7 @@ from instagrapi.mixins.location import LocationTab
 from instagrapi.mixins.note import NoteAudience
 from instagrapi.mixins.notification import NotificationContentType
 from instagrapi.mixins.public import PublicTransport
+from instagrapi.mixins.track import MUSIC_PRODUCT, TrackMixin
 from instagrapi.types import StoryResizeMode
 
 EXPECTED_NOTIFICATION_CONTENT_TYPES = {
@@ -47,6 +49,11 @@ EXPECTED_DIRECT_MEDIA_SEND_ATTRIBUTES = {
     "feed_contextual_self_profile",
     "feed_contextual_profile",
 }
+EXPECTED_MUSIC_PRODUCTS = {
+    "feed_post",
+    "music_in_feed",
+    "story_camera_clips_v2",
+}
 
 
 class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
@@ -58,6 +65,7 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(set(get_args(NotificationContentType)), EXPECTED_NOTIFICATION_CONTENT_TYPES)
         self.assertEqual(set(get_args(PublicTransport)), {"requests", "curl"})
         self.assertEqual(set(get_args(SEND_ATTRIBUTE_MEDIA)), EXPECTED_DIRECT_MEDIA_SEND_ATTRIBUTES)
+        self.assertEqual(set(get_args(MUSIC_PRODUCT)), EXPECTED_MUSIC_PRODUCTS)
         self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
 
     def test_direct_thread_filter_literals_remain_optional(self):
@@ -94,5 +102,48 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         )
         self.assertNotIn(
             'post_type: str = "ALL", time_frame: str = "TWO_YEARS", data_ordering: str = "REACH_COUNT"',
+            docs,
+        )
+
+    def test_track_music_methods_use_public_product_literal_alias(self):
+        for method_name in (
+            "music_trending",
+            "music_top_trends",
+            "music_search_v2",
+            "music_keyword_search",
+            "music_clips_audio_browser",
+        ):
+            with self.subTest(method_name=method_name):
+                method = signature(getattr(TrackMixin, method_name))
+
+                self.assertEqual(method.parameters["product"].annotation, MUSIC_PRODUCT)
+
+    def test_clip_music_methods_use_public_product_literal_alias(self):
+        for method_name in ("clip_music_extra_data", "clip_upload_with_music"):
+            with self.subTest(method_name=method_name):
+                method = signature(getattr(UploadClipMixin, method_name))
+
+                self.assertEqual(method.parameters["product"].annotation, MUSIC_PRODUCT)
+
+    def test_track_usage_guide_documents_public_product_literal_alias(self):
+        docs = Path("docs/usage-guide/track.md").read_text()
+
+        self.assertIn('music_trending(product: MUSIC_PRODUCT = "feed_post")', docs)
+        self.assertIn('music_top_trends(product: MUSIC_PRODUCT = "music_in_feed", page_size: int = 15)', docs)
+        self.assertIn('music_clips_audio_browser(product: MUSIC_PRODUCT = "story_camera_clips_v2"', docs)
+        self.assertNotIn('product: str = "feed_post"', docs)
+        self.assertNotIn('product: str = "music_in_feed"', docs)
+        self.assertNotIn('product: str = "story_camera_clips_v2"', docs)
+
+    def test_media_usage_guide_documents_public_music_product_literal_alias(self):
+        docs = Path("docs/usage-guide/media.md").read_text()
+
+        self.assertIn(
+            'clip_music_extra_data(track: Track or dict, product: MUSIC_PRODUCT = "story_camera_clips_v2"',
+            docs,
+        )
+        self.assertIn(
+            "clip_upload_with_music(path: Path, caption: str, track: Track or dict, thumbnail: Path = None, "
+            'product: MUSIC_PRODUCT = "story_camera_clips_v2"',
             docs,
         )


### PR DESCRIPTION
## Summary
- add a public MUSIC_PRODUCT Literal for documented Instagram music product surfaces
- annotate track music product parameters and Reels music upload helpers
- update track/media usage guides and regression coverage

## Tests
- .venv/bin/ruff check .
- .venv/bin/mkdocs build --strict
- .venv/bin/python -m pytest tests/regression -q