### PR TITLE
docs: expose user block surface literal

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -18,6 +18,8 @@ View a list of a user's medias, following and followers
 | user_guides_v1(user_id: int)                  | List[Guide]           | Get user's guides                                            |
 | user_follow(user_id: str)                     | bool                  | Follow user, or request to follow a private user             |
 | user_unfollow(user_id: str)                   | bool                  | Unfollow user                                                |
+| user_block(user_id: str, surface: UserBlockSurface = "profile") | bool | Block a user from a profile or Direct thread surface |
+| user_unblock(user_id: str, surface: UserBlockSurface = "profile") | bool | Unblock a user from a profile or Direct thread surface |
 | user_follow_requests(amount: int = 0)         | List[UserShort]       | Get pending incoming follow requests                         |
 | user_follow_request_approve(user_id: str)     | bool                  | Approve a pending incoming follow request                    |
 | user_follow_request_decline(user_id: str)     | bool                  | Decline a pending incoming follow request                    |
@@ -47,6 +49,14 @@ View a list of a user's medias, following and followers
 | fetch_suggestion_details(user_id: str, chained_ids: str) | dict       | Expanded social-context fields for chained suggestion ids (`discover/fetch_suggestion_details/`) |
 | discover_recommended_accounts_for_category_v1(user_id: str) | dict | Business-category-similar accounts: extracts `category_id` from the target's stream payload, then calls `discover/recommended_accounts_for_category/` |
 | user_related_profiles_gql(user_id: str)       | List[UserShort]       | Related profiles via public GraphQL `edge_chaining` (legacy `query_hash`, gated by IG — prefer `chaining` for reliability) |
+
+### Option types
+
+User block surfaces are exposed as `UserBlockSurface = Literal["profile", "direct_thread_info"]`.
+
+| Type | Values | Used by |
+|------|--------|---------|
+| `UserBlockSurface` | `"profile"`, `"direct_thread_info"` | `user_block(surface=...)`, `user_unblock(surface=...)` |
 
 Lookup helpers:
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 INFO_FROM_MODULE = Literal["self_profile", "feed_timeline", "reel_feed_timeline"]
 FOLLOWERS_ORDER = Literal["date_followed_latest", "date_followed_earliest"]
 USER_REPORT_REASON = Literal["spam"]
+UserBlockSurface = Literal["profile", "direct_thread_info"]
 
 
 class UserMixin:
@@ -1452,7 +1453,7 @@ class UserMixin:
             self._users_following[self.user_id].pop(user_id, None)
         return result["friendship_status"]["following"] is False
 
-    def user_block(self, user_id: str, surface: str = "profile") -> bool:
+    def user_block(self, user_id: str, surface: UserBlockSurface = "profile") -> bool:
         """
         Block a User
 
@@ -1460,8 +1461,9 @@ class UserMixin:
         ----------
         user_id: str
             User ID of an Instagram account
-        surface: str, (optional)
-            Surface of block (deafult "profile", also can be "direct_thread_info")
+        surface: UserBlockSurface, optional
+            Surface used by Instagram for the block action, default "profile"; use
+            "direct_thread_info" from Direct thread info.
 
         Returns
         -------
@@ -1483,7 +1485,7 @@ class UserMixin:
 
         return result.get("friendship_status", {}).get("blocking") is True
 
-    def user_unblock(self, user_id: str, surface: str = "profile") -> bool:
+    def user_unblock(self, user_id: str, surface: UserBlockSurface = "profile") -> bool:
         """
         Unlock a User
 
@@ -1491,8 +1493,9 @@ class UserMixin:
         ----------
         user_id: str
             User ID of an Instagram account
-        surface: str, (optional)
-            Surface of block (deafult "profile", also can be "direct_thread_info")
+        surface: UserBlockSurface, optional
+            Surface used by Instagram for the unblock action, default "profile"; use
+            "direct_thread_info" from Direct thread info.
 
         Returns
         -------

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -13,6 +13,7 @@ from instagrapi.mixins.note import NoteAudience
 from instagrapi.mixins.notification import NotificationContentType
 from instagrapi.mixins.public import PublicTransport
 from instagrapi.mixins.track import MUSIC_PRODUCT, TrackMixin
+from instagrapi.mixins.user import UserBlockSurface, UserMixin
 from instagrapi.types import StoryResizeMode
 
 EXPECTED_NOTIFICATION_CONTENT_TYPES = {
@@ -67,6 +68,7 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(set(get_args(SEND_ATTRIBUTE_MEDIA)), EXPECTED_DIRECT_MEDIA_SEND_ATTRIBUTES)
         self.assertEqual(set(get_args(DirectMediaType)), {"photo", "video"})
         self.assertEqual(set(get_args(MUSIC_PRODUCT)), EXPECTED_MUSIC_PRODUCTS)
+        self.assertEqual(set(get_args(UserBlockSurface)), {"profile", "direct_thread_info"})
         self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
 
     def test_direct_thread_filter_literals_remain_optional(self):
@@ -102,6 +104,26 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertIn(
             '| `DirectMediaType` | `"photo"`, `"video"` | `direct_send_file(content_type=...)`, '
             "`direct_media_share(media_type=...)` |",
+            docs,
+        )
+
+    def test_user_block_methods_use_public_surface_literal(self):
+        user_block = signature(UserMixin.user_block)
+        user_unblock = signature(UserMixin.user_unblock)
+
+        self.assertEqual(user_block.parameters["surface"].annotation, UserBlockSurface)
+        self.assertEqual(user_unblock.parameters["surface"].annotation, UserBlockSurface)
+
+    def test_user_usage_guide_documents_block_surface_literal(self):
+        docs = Path("docs/usage-guide/user.md").read_text()
+
+        self.assertIn('user_block(user_id: str, surface: UserBlockSurface = "profile")', docs)
+        self.assertIn('user_unblock(user_id: str, surface: UserBlockSurface = "profile")', docs)
+        self.assertIn("### Option types", docs)
+        self.assertIn('UserBlockSurface = Literal["profile", "direct_thread_info"]', docs)
+        self.assertIn(
+            '| `UserBlockSurface` | `"profile"`, `"direct_thread_info"` | `user_block(surface=...)`, '
+            "`user_unblock(surface=...)` |",
             docs,
         )
 


### PR DESCRIPTION
## Summary
- Add `UserBlockSurface = Literal["profile", "direct_thread_info"]`.
- Annotate `user_block(surface=...)` and `user_unblock(surface=...)`.
- Document supported values in the User usage guide and cover signatures/docs with regression tests.

## Test plan
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/mkdocs build --strict`
- [x] `.venv/bin/python -m pytest tests/regression -q`