### PR TITLE
docs: expose followers order literal

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -6,9 +6,9 @@ View a list of a user's medias, following and followers
 
 | Method                                        | Return                | Description                                                  |
 |-----------------------------------------------|-----------------------|--------------------------------------------------------------|
-| user_followers(user_id: str, amount: int = 0, order: str = None) | Dict\[int, UserShort] | Get dict of followers users (amount=0 - fetch all followers). Use `order="date_followed_latest"` or `order="date_followed_earliest"` for mobile follower sorting |
+| user_followers(user_id: str, amount: int = 0, order: Optional[FOLLOWERS_ORDER] = None) | Dict\[int, UserShort] | Get dict of followers users (amount=0 - fetch all followers). Use `order="date_followed_latest"` or `order="date_followed_earliest"` for mobile follower sorting |
 | user_following(user_id: str, amount: int = 0) | Dict\[int, UserShort] | Get dict of following users (amount=0 - fetch all)           |
-| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: str = None) | Iterator[UserShort] | Stream followers from the private/mobile API without building a full dict |
+| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: Optional[FOLLOWERS_ORDER] = None) | Iterator[UserShort] | Stream followers from the private/mobile API without building a full dict |
 | iter_user_following_v1(user_id: str, amount: int = 0, page_size: int = 200) | Iterator[UserShort] | Stream following users from the private/mobile API without building a full dict |
 | search_followers(user_id: str, query: str)    | List[UserShort]       | Search by followers                                          |
 | search_following(user_id: str, query: str)    | List[UserShort]       | Search by following                                          |
@@ -52,10 +52,14 @@ View a list of a user's medias, following and followers
 
 ### Option types
 
+Follower sort orders are exposed as `FOLLOWERS_ORDER = Literal["date_followed_latest", "date_followed_earliest"]`.
+Pass `None` to keep Instagram's default follower order.
+
 User block surfaces are exposed as `UserBlockSurface = Literal["profile", "direct_thread_info"]`.
 
 | Type | Values | Used by |
 |------|--------|---------|
+| `FOLLOWERS_ORDER` | `"date_followed_latest"`, `"date_followed_earliest"` | `user_followers(order=...)`, `user_followers_v1(order=...)`, `iter_user_followers_v1(order=...)` |
 | `UserBlockSurface` | `"profile"`, `"direct_thread_info"` | `user_block(surface=...)`, `user_unblock(surface=...)` |
 
 Lookup helpers:
@@ -82,11 +86,11 @@ Low level methods:
 |-------------------------------------------------------------------------------------|-----------------------------|----------------------------------------------------------------------------|
 | user_followers_gql_chunk(user_id: str, max_amount: int = 0, end_cursor: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Public Graphql API and end_cursor      |
 | user_followers_gql(user_id: str, amount: int = 0)                                   | List[UserShort]             | Get user's followers information by Public Graphql API                     |
-| user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "", order: str = None) | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor). Supports `date_followed_latest` and `date_followed_earliest` |
-| user_followers_v1(user_id: str, amount: int = 0, order: str = None)                 | List[UserShort]             | Get user's followers information by Private Mobile API. Supports `date_followed_latest` and `date_followed_earliest` |
-| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: str = None) | Iterator[UserShort] | Stream followers page by page through `user_followers_v1_chunk()` |
-| user_followers_private_gql_chunk(user_id: str, max_amount: int = 0, max_id: str = None, rank_token: str = None, order: str = None) | Tuple[List[UserShort], str] | Get user's followers through the private mobile GraphQL `FollowersList` surface and max_id cursor |
-| user_followers_private_gql(user_id: str, amount: int = 0, rank_token: str = None, order: str = None) | List[UserShort] | Get user's followers through the private mobile GraphQL `FollowersList` surface |
+| user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "", order: Optional[FOLLOWERS_ORDER] = None) | Tuple[List[UserShort], str] | Get user's followers information by Private Mobile API and max_id (cursor). Supports `date_followed_latest` and `date_followed_earliest` |
+| user_followers_v1(user_id: str, amount: int = 0, order: Optional[FOLLOWERS_ORDER] = None) | List[UserShort] | Get user's followers information by Private Mobile API. Supports `date_followed_latest` and `date_followed_earliest` |
+| iter_user_followers_v1(user_id: str, amount: int = 0, page_size: int = 200, order: Optional[FOLLOWERS_ORDER] = None) | Iterator[UserShort] | Stream followers page by page through `user_followers_v1_chunk()` |
+| user_followers_private_gql_chunk(user_id: str, max_amount: int = 0, max_id: str = None, rank_token: str = None, order: Optional[FOLLOWERS_ORDER] = None) | Tuple[List[UserShort], str] | Get user's followers through the private mobile GraphQL `FollowersList` surface and max_id cursor |
+| user_followers_private_gql(user_id: str, amount: int = 0, rank_token: str = None, order: Optional[FOLLOWERS_ORDER] = None) | List[UserShort] | Get user's followers through the private mobile GraphQL `FollowersList` surface |
 | user_following_v1(user_id: str, amount: int = 0)                                    | List[UserShort]             | Get user's following users information by Private Mobile API               |
 | iter_user_following_v1(user_id: str, amount: int = 0, page_size: int = 200)         | Iterator[UserShort]          | Stream following users page by page through `user_following_v1_chunk()` |
 | user_follow_requests_chunk(max_amount: int = 0, max_id: str = "")                   | Tuple[List[UserShort], str] | Get pending incoming follow requests by Private Mobile API and max_id      |
@@ -95,8 +99,8 @@ Low level methods:
 | search_following_v1(user_id: str, query: str)                                       | List[UserShort]             | Search by following by Private Mobile API                                  |
 | user_info_v2_gql(user_id: str)                                                      | User                        | Profile lookup through current doc_id GraphQL                              |
 | user_info_by_username_v2_gql(username: str)                                         | User                        | Resolve username through doc_id search, then fetch profile                 |
-| private_graphql_followers_list(user_id: str, rank_token: str, ..., order: str = None) | dict                      | Raw private mobile GraphQL followers list. Supports `date_followed_latest` and `date_followed_earliest` |
-| private_graphql_following_list(user_id: str, rank_token: str, ..., order: str = None) | dict                      | Raw private mobile GraphQL following list. Supports mobile `order` when accepted by Instagram |
+| private_graphql_followers_list(user_id: str, rank_token: str, ..., order: Optional[FOLLOWERS_ORDER] = None) | dict | Raw private mobile GraphQL followers list. Supports `date_followed_latest` and `date_followed_earliest` |
+| private_graphql_following_list(user_id: str, rank_token: str, ..., order: Optional[FOLLOWERS_ORDER] = None) | dict | Raw private mobile GraphQL following list. Supports mobile `order` when accepted by Instagram |
 | private_graphql_clips_profile(target_user_id: str, ...)                             | dict                        | Raw private mobile GraphQL profile Reels stream                            |
 | private_graphql_inbox_tray_for_user(user_id: str, ...)                              | dict                        | Raw private mobile GraphQL inbox tray query                                |
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -2,7 +2,7 @@ import json
 import logging
 from copy import deepcopy
 from json.decoder import JSONDecodeError
-from typing import Dict, Iterator, List, Literal, Sequence, Tuple, Union
+from typing import Dict, Iterator, List, Literal, Optional, Sequence, Tuple, Union
 
 from requests.exceptions import RequestException
 
@@ -966,7 +966,7 @@ class UserMixin:
         user_id: str,
         max_amount: int = 0,
         max_id: str = "",
-        order: FOLLOWERS_ORDER = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
     ) -> Tuple[List[UserShort], str]:
         """
         Get user's followers information by Private Mobile API and max_id (cursor)
@@ -979,7 +979,7 @@ class UserMixin:
             Maximum number of media to return, default is 0 - Inf
         max_id: str, optional
             Max ID, default value is empty String
-        order: str, optional
+        order: FOLLOWERS_ORDER, optional
             Followers sort order: date_followed_latest or date_followed_earliest
 
         Returns
@@ -1023,7 +1023,7 @@ class UserMixin:
         self,
         user_id: str,
         amount: int = 0,
-        order: FOLLOWERS_ORDER = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
     ) -> List[UserShort]:
         """
         Get user's followers information by Private Mobile API
@@ -1034,7 +1034,7 @@ class UserMixin:
             User id of an instagram account
         amount: int, optional
             Maximum number of media to return, default is 0 - Inf
-        order: str, optional
+        order: FOLLOWERS_ORDER, optional
             Followers sort order: date_followed_latest or date_followed_earliest
 
         Returns
@@ -1052,7 +1052,7 @@ class UserMixin:
         user_id: str,
         amount: int = 0,
         page_size: int = MAX_USER_COUNT,
-        order: FOLLOWERS_ORDER = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
     ) -> Iterator[UserShort]:
         """
         Iterate over user's followers by Private Mobile API.
@@ -1065,7 +1065,7 @@ class UserMixin:
             Maximum number of users to yield, default is 0 - Inf
         page_size: int, optional
             Maximum number of users to fetch per page, default is 200
-        order: str, optional
+        order: FOLLOWERS_ORDER, optional
             Followers sort order: date_followed_latest or date_followed_earliest
 
         Returns
@@ -1106,7 +1106,7 @@ class UserMixin:
         max_amount: int = 0,
         max_id: str = None,
         rank_token: str = None,
-        order: FOLLOWERS_ORDER = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
         priority: str = "u=3, i",
     ) -> Tuple[List[UserShort], str]:
         """
@@ -1122,7 +1122,7 @@ class UserMixin:
             The cursor from which it is worth continuing to receive the list of followers
         rank_token: str, optional
             Rank token for the follow list request. Defaults to client rank_token
-        order: str, optional
+        order: FOLLOWERS_ORDER, optional
             Followers sort order: date_followed_latest or date_followed_earliest
         priority: str, optional
             GraphQL request priority header captured from the Android app
@@ -1155,7 +1155,7 @@ class UserMixin:
         user_id: str,
         amount: int = 0,
         rank_token: str = None,
-        order: FOLLOWERS_ORDER = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
         priority: str = "u=3, i",
     ) -> List[UserShort]:
         """
@@ -1169,7 +1169,7 @@ class UserMixin:
             Maximum number of users to return, default is 0 - Inf
         rank_token: str, optional
             Rank token for the follow list request. Defaults to client rank_token
-        order: str, optional
+        order: FOLLOWERS_ORDER, optional
             Followers sort order: date_followed_latest or date_followed_earliest
         priority: str, optional
             GraphQL request priority header captured from the Android app
@@ -1205,7 +1205,7 @@ class UserMixin:
         user_id: str,
         use_cache: bool = True,
         amount: int = 0,
-        order: FOLLOWERS_ORDER = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
     ) -> Dict[str, UserShort]:
         """
         Get user's followers
@@ -1218,7 +1218,7 @@ class UserMixin:
             Whether or not to use information from cache, default value is True
         amount: int, optional
             Maximum number of media to return, default is 0 - Inf
-        order: str, optional
+        order: FOLLOWERS_ORDER, optional
             Followers sort order: date_followed_latest or date_followed_earliest.
             Sorted requests use the private mobile endpoint and bypass cache.
 
@@ -2329,7 +2329,7 @@ class UserMixin:
         client_doc_id: str = "28479704797510738576165798526",
         max_id: int = None,
         priority: str = None,
-        order: str = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
         exclude_field_is_favorite: bool = None,
         exclude_unused_fields: bool = None,
     ) -> dict:
@@ -2375,7 +2375,7 @@ class UserMixin:
         client_doc_id: str = "161046392817718486717479294775",
         max_id: int = None,
         priority: str = None,
-        order: str = None,
+        order: Optional[FOLLOWERS_ORDER] = None,
         exclude_field_is_favorite: bool = None,
         exclude_unused_fields: bool = None,
         skip_preview_hashtags: bool = True,

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -1,7 +1,7 @@
 import unittest
 from inspect import signature
 from pathlib import Path
-from typing import get_args
+from typing import Optional, get_args
 
 from instagrapi.mixins.account import ProfessionalAccountType
 from instagrapi.mixins.clip import UploadClipMixin
@@ -13,7 +13,7 @@ from instagrapi.mixins.note import NoteAudience
 from instagrapi.mixins.notification import NotificationContentType
 from instagrapi.mixins.public import PublicTransport
 from instagrapi.mixins.track import MUSIC_PRODUCT, TrackMixin
-from instagrapi.mixins.user import UserBlockSurface, UserMixin
+from instagrapi.mixins.user import FOLLOWERS_ORDER, UserBlockSurface, UserMixin
 from instagrapi.types import StoryResizeMode
 
 EXPECTED_NOTIFICATION_CONTENT_TYPES = {
@@ -68,6 +68,7 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(set(get_args(SEND_ATTRIBUTE_MEDIA)), EXPECTED_DIRECT_MEDIA_SEND_ATTRIBUTES)
         self.assertEqual(set(get_args(DirectMediaType)), {"photo", "video"})
         self.assertEqual(set(get_args(MUSIC_PRODUCT)), EXPECTED_MUSIC_PRODUCTS)
+        self.assertEqual(set(get_args(FOLLOWERS_ORDER)), {"date_followed_latest", "date_followed_earliest"})
         self.assertEqual(set(get_args(UserBlockSurface)), {"profile", "direct_thread_info"})
         self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
 
@@ -114,6 +115,23 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(user_block.parameters["surface"].annotation, UserBlockSurface)
         self.assertEqual(user_unblock.parameters["surface"].annotation, UserBlockSurface)
 
+    def test_user_followers_order_methods_use_optional_public_literal(self):
+        for method_name in (
+            "user_followers",
+            "user_followers_v1",
+            "iter_user_followers_v1",
+            "user_followers_v1_chunk",
+            "user_followers_private_gql",
+            "user_followers_private_gql_chunk",
+            "private_graphql_followers_list",
+            "private_graphql_following_list",
+        ):
+            with self.subTest(method_name=method_name):
+                method = signature(getattr(UserMixin, method_name))
+
+                self.assertEqual(method.parameters["order"].annotation, Optional[FOLLOWERS_ORDER])
+                self.assertIsNone(method.parameters["order"].default)
+
     def test_user_usage_guide_documents_block_surface_literal(self):
         docs = Path("docs/usage-guide/user.md").read_text()
 
@@ -126,6 +144,32 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
             "`user_unblock(surface=...)` |",
             docs,
         )
+
+    def test_user_usage_guide_documents_followers_order_literal(self):
+        docs = Path("docs/usage-guide/user.md").read_text()
+
+        self.assertIn('FOLLOWERS_ORDER = Literal["date_followed_latest", "date_followed_earliest"]', docs)
+        self.assertIn(
+            "user_followers(user_id: str, amount: int = 0, order: Optional[FOLLOWERS_ORDER] = None)",
+            docs,
+        )
+        self.assertIn(
+            'user_followers_v1_chunk(user_id: str, max_amount: int = 0, max_id: str = "", '
+            "order: Optional[FOLLOWERS_ORDER] = None)",
+            docs,
+        )
+        self.assertIn(
+            "private_graphql_followers_list(user_id: str, rank_token: str, ..., "
+            "order: Optional[FOLLOWERS_ORDER] = None)",
+            docs,
+        )
+        self.assertIn(
+            '| `FOLLOWERS_ORDER` | `"date_followed_latest"`, `"date_followed_earliest"` | '
+            "`user_followers(order=...)`, `user_followers_v1(order=...)`, "
+            "`iter_user_followers_v1(order=...)` |",
+            docs,
+        )
+        self.assertNotIn("order: str = None", docs)
 
     def test_insights_media_feed_all_uses_public_literal_aliases(self):
         insights_media_feed_all = signature(InsightsMixin.insights_media_feed_all)


### PR DESCRIPTION
## Summary
- Annotate follower ordering helpers with Optional[FOLLOWERS_ORDER].
- Document FOLLOWERS_ORDER = Literal["date_followed_latest", "date_followed_earliest"] in the User usage guide.
- Cover signatures and docs with public literal regression tests.

## Test plan
- [x] .venv/bin/ruff check .
- [x] .venv/bin/mkdocs build --strict
- [x] .venv/bin/python -m pytest tests/regression -q