### PR TITLE
types: use enum for note audience

### DIFF
--- a/docs/usage-guide/notes.md
+++ b/docs/usage-guide/notes.md
@@ -5,19 +5,20 @@
 | get_notes()                 | List[Note]        | Retrieve direct Notes           |
 | get_note_by_user(notes: List[Note], username: str) | Optional[Note] | Find a Note by username |
 | get_note_text_by_user(notes: List[Note], username: str) | Optional[str] | Get note text by username |
-| create_note(text: str, audience: Literal[0, 1] = 0) | Note | Post a new Note                 |
+| create_note(text: str, audience: NoteAudience = NoteAudience.MUTUAL_FOLLOWERS) | Note | Post a new Note                 |
 | notes_music_browser()      | Dict              | Retrieve music candidates for Notes |
-| create_music_note(track: Track \| Dict, text: str = "", audience: Literal[0, 1] = 0, start_time: Optional[int] = None, duration: int = 30000, browse_session_id: Optional[str] = None, alacorn_session_id: Optional[str] = None) | Note | Post a new Note with music |
+| create_music_note(track: Track \| Dict, text: str = "", audience: NoteAudience = NoteAudience.MUTUAL_FOLLOWERS, start_time: Optional[int] = None, duration: int = 30000, browse_session_id: Optional[str] = None, alacorn_session_id: Optional[str] = None) | Note | Post a new Note with music |
 | delete_note(note_id: int)   | bool              | Delete a posted Note            |
 | last_seen_update_note()     | bool              | Update the last seen time |
 
 Example:
 
 ``` python
->>> note = cl.create_note("Hello from Instagrapi, everyone can see it!", 0)
+>>> from instagrapi.mixins.note import NoteAudience
+>>> note = cl.create_note("Hello from Instagrapi!", audience=NoteAudience.MUTUAL_FOLLOWERS)
 >>> print(note.dict())
 {'id': '17849203563031468',
-'text': 'Hello from Instagrapi, everyone can see it!',
+'text': 'Hello from Instagrapi!',
 'user_id': 12312312312,
 'user': {
   'pk': '12312312312',
@@ -59,7 +60,7 @@ track = music["items"][0]["playlist"]["preview_items"][0]["track"]
 note = cl.create_music_note(
     track=track,
     text="",
-    audience=0,
+    audience=NoteAudience.CLOSE_FRIENDS,
     alacorn_session_id=music.get("alacorn_session_id"),
 )
 cl.delete_note(note.id)
@@ -78,7 +79,7 @@ Common arguments:
 
 * `note_id` - ID of the Note object
 * `text` - Content of the Note
-* `audience` - Who can see the note. Exposed as `NoteAudience = Literal[0, 1]` **(0 = Followers you follow back, 1 = Close Friends only)**
+* `audience` - Who can see the note. Use `NoteAudience.MUTUAL_FOLLOWERS` for followers you follow back or `NoteAudience.CLOSE_FRIENDS` for Close Friends only. Instagram still receives the numeric wire value internally.
 * `username` - Username used to search in an existing `notes` list
 * `track` - Track object or raw track dict from `notes_music_browser()`
 

--- a/instagrapi/mixins/note.py
+++ b/instagrapi/mixins/note.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Literal, Optional, Union
+from enum import IntEnum
+from typing import Dict, List, Optional, Union
 
 from instagrapi.exceptions import ClientGraphqlError
 from instagrapi.types import Note, Track, UserShort
@@ -11,10 +12,21 @@ INBOX_TRAY_ROOT_FIELD = "xdt_get_inbox_tray_items"
 CREATE_INBOX_TRAY_ITEM_CLIENT_DOC_ID = "3510400299951610199199089856"
 CREATE_INBOX_TRAY_ITEM_FRIENDLY_NAME = "CreateInboxTrayItemRequest"
 
-NoteAudience = Literal[0, 1]
+
+class NoteAudience(IntEnum):
+    MUTUAL_FOLLOWERS = 0
+    CLOSE_FRIENDS = 1
 
 
 class NoteMixin:
+    @staticmethod
+    def _note_audience_value(audience: NoteAudience) -> int:
+        assert isinstance(audience, NoteAudience), (
+            f"Invalid audience parameter={audience} (must be NoteAudience.MUTUAL_FOLLOWERS "
+            "or NoteAudience.CLOSE_FRIENDS)"
+        )
+        return int(audience)
+
     @staticmethod
     def _track_value(track: Union[Track, Dict], key: str):
         if isinstance(track, dict):
@@ -223,7 +235,7 @@ class NoteMixin:
         assert result.get("status", "") == "ok", "Failed to retrieve Notes music"
         return result
 
-    def create_note(self, text: str, audience: NoteAudience = 0) -> Note:
+    def create_note(self, text: str, audience: NoteAudience = NoteAudience.MUTUAL_FOLLOWERS) -> Note:
         """
         Create personal Note
 
@@ -231,9 +243,9 @@ class NoteMixin:
         ----------
         text: str
             Content of the Note
-        audience: Literal[0, 1], optional
-            Audience to see Note, deafult 0 (Followers you follow back).
-            Best Friends - 1
+        audience: NoteAudience, optional
+            Audience to see the Note. Use NoteAudience.MUTUAL_FOLLOWERS
+            or NoteAudience.CLOSE_FRIENDS.
 
         Returns
         -------
@@ -242,12 +254,9 @@ class NoteMixin:
 
         """
         assert self.user_id, "Login required"
-        assert audience in (
-            0,
-            1,
-        ), f"Invalid audience parameter={audience} (must be 0 or 1)"
+        audience_value = self._note_audience_value(audience)
 
-        data = {"note_style": 0, "text": text, "_uuid": self.uuid, "audience": audience}
+        data = {"note_style": 0, "text": text, "_uuid": self.uuid, "audience": audience_value}
         result = self.private_request("notes/create_note", data=data)
 
         assert result.pop("status", "") == "ok", "Failed to create new Note"
@@ -257,7 +266,7 @@ class NoteMixin:
         self,
         track: Union[Track, Dict],
         text: str = "",
-        audience: NoteAudience = 0,
+        audience: NoteAudience = NoteAudience.MUTUAL_FOLLOWERS,
         start_time: Optional[int] = None,
         duration: int = 30000,
         browse_session_id: Optional[str] = None,
@@ -272,9 +281,9 @@ class NoteMixin:
             Track from ``notes_music_browser()`` or a compatible dict.
         text: str, optional
             Content of the Note.
-        audience: Literal[0, 1], optional
-            Audience to see Note, default 0 (Followers you follow back).
-            Best Friends - 1.
+        audience: NoteAudience, optional
+            Audience to see the Note. Use NoteAudience.MUTUAL_FOLLOWERS
+            or NoteAudience.CLOSE_FRIENDS.
         start_time: int, optional
             Audio start time in milliseconds. Defaults to the first highlighted
             start time from the track, or 0.
@@ -292,10 +301,7 @@ class NoteMixin:
             Created music Note.
         """
         assert self.user_id, "Login required"
-        assert audience in (
-            0,
-            1,
-        ), f"Invalid audience parameter={audience} (must be 0 or 1)"
+        audience_value = self._note_audience_value(audience)
         audio_asset_id = self._track_value(track, "audio_asset_id") or self._track_value(track, "id")
         audio_cluster_id = self._track_value(track, "audio_cluster_id")
         assert audio_asset_id, "track.audio_asset_id or track.id is required"
@@ -312,7 +318,7 @@ class NoteMixin:
             "should_fetch_content_note_stack_video_info": False,
             "request": {
                 "inbox_tray_item_type": "note",
-                "audience": audience,
+                "audience": audience_value,
                 "additional_params": {
                     "note_create_params": {
                         "text": text,

--- a/tests/regression/test_notes.py
+++ b/tests/regression/test_notes.py
@@ -1,7 +1,29 @@
+from instagrapi.mixins.note import NoteAudience
 from tests.helpers import *
 
 
 class NoteMixinRegressionTestCase(unittest.TestCase):
+    def _note_response(self, text="hello", audience=0):
+        return {
+            "status": "ok",
+            "id": "18072502430410984",
+            "text": text,
+            "user_id": "123",
+            "user": {
+                "pk": "123",
+                "username": "example",
+                "full_name": "",
+                "profile_pic_url": None,
+                "is_private": False,
+            },
+            "audience": audience,
+            "created_at": datetime(2024, 3, 9, 16, 0, tzinfo=UTC()),
+            "expires_at": datetime(2024, 3, 10, 16, 0, tzinfo=UTC()),
+            "is_emoji_only": False,
+            "has_translation": False,
+            "note_style": 0,
+        }
+
     def test_get_note_helpers_by_user(self):
         client = Client()
         notes = [
@@ -44,6 +66,29 @@ class NoteMixinRegressionTestCase(unittest.TestCase):
             with_signature=False,
         )
         self.assertEqual(result, expected)
+
+    def test_create_note_posts_note_audience_enum_wire_value(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.private.cookies.set("ds_user_id", "123")
+
+        with mock.patch.object(client, "private_request", return_value=self._note_response(audience=1)) as request:
+            note = client.create_note("hello", audience=NoteAudience.CLOSE_FRIENDS)
+
+        request.assert_called_once_with(
+            "notes/create_note",
+            data={"note_style": 0, "text": "hello", "_uuid": "uuid-1", "audience": 1},
+        )
+        self.assertEqual(note.audience, 1)
+
+    def test_create_note_rejects_raw_int_audience(self):
+        client = Client()
+        client.uuid = "uuid-1"
+        client.private.cookies.set("ds_user_id", "123")
+
+        with mock.patch.object(client, "private_request", return_value=self._note_response(audience=1)):
+            with self.assertRaisesRegex(AssertionError, "NoteAudience"):
+                client.create_note("hello", audience=1)  # type: ignore[arg-type]
 
     def test_get_notes_uses_inbox_tray_graphql_items(self):
         client = Client()
@@ -155,7 +200,7 @@ class NoteMixinRegressionTestCase(unittest.TestCase):
             note = client.create_music_note(
                 track=track,
                 text="Now playing",
-                audience=1,
+                audience=NoteAudience.CLOSE_FRIENDS,
                 start_time=66000,
                 duration=30000,
                 browse_session_id="browse-1",

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -1,4 +1,5 @@
 import unittest
+from enum import IntEnum
 from inspect import signature
 from pathlib import Path
 from typing import Optional, get_args
@@ -10,7 +11,7 @@ from instagrapi.mixins.direct import BOX, SELECTED_FILTER, SEND_ATTRIBUTE_MEDIA,
 from instagrapi.mixins.hashtag import HashtagTab
 from instagrapi.mixins.insights import DATA_ORDERING, POST_TYPE, TIME_FRAME, InsightsMixin
 from instagrapi.mixins.location import LocationTab
-from instagrapi.mixins.note import NoteAudience
+from instagrapi.mixins.note import NoteAudience, NoteMixin
 from instagrapi.mixins.notification import MUTE_ALL, SETTING_VALUE, NotificationContentType, NotificationMixin
 from instagrapi.mixins.public import PublicTransport
 from instagrapi.mixins.track import MUSIC_PRODUCT, TrackMixin
@@ -83,7 +84,10 @@ def literal_values(alias):
 class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
     def test_public_literal_aliases_expose_supported_values(self):
         self.assertEqual(set(get_args(ProfessionalAccountType)), {2, 3})
-        self.assertEqual(set(get_args(NoteAudience)), {0, 1})
+        self.assertIsInstance(NoteAudience, type)
+        self.assertTrue(issubclass(NoteAudience, IntEnum))
+        self.assertEqual(NoteAudience.MUTUAL_FOLLOWERS.value, 0)
+        self.assertEqual(NoteAudience.CLOSE_FRIENDS.value, 1)
         self.assertEqual(set(get_args(HashtagTab)), {"top", "recent", "clips"})
         self.assertEqual(set(get_args(LocationTab)), {"ranked", "recent"})
         self.assertEqual(set(get_args(NotificationContentType)), EXPECTED_NOTIFICATION_CONTENT_TYPES)
@@ -111,6 +115,31 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         direct_threads_chunk = signature(DirectMixin.direct_threads_chunk)
         self.assertIsNone(direct_threads_chunk.parameters["selected_filter"].default)
         self.assertIsNone(direct_threads_chunk.parameters["box"].default)
+
+    def test_note_methods_use_public_audience_enum(self):
+        create_note = signature(NoteMixin.create_note)
+        create_music_note = signature(NoteMixin.create_music_note)
+
+        self.assertEqual(create_note.parameters["audience"].annotation, NoteAudience)
+        self.assertEqual(create_note.parameters["audience"].default, NoteAudience.MUTUAL_FOLLOWERS)
+        self.assertEqual(create_music_note.parameters["audience"].annotation, NoteAudience)
+        self.assertEqual(create_music_note.parameters["audience"].default, NoteAudience.MUTUAL_FOLLOWERS)
+
+    def test_note_usage_guide_documents_public_audience_enum(self):
+        docs = Path("docs/usage-guide/notes.md").read_text()
+
+        self.assertIn(
+            "create_note(text: str, audience: NoteAudience = NoteAudience.MUTUAL_FOLLOWERS)",
+            docs,
+        )
+        self.assertIn(
+            'create_music_note(track: Track \\| Dict, text: str = "", '
+            "audience: NoteAudience = NoteAudience.MUTUAL_FOLLOWERS",
+            docs,
+        )
+        self.assertIn("NoteAudience.MUTUAL_FOLLOWERS", docs)
+        self.assertIn("NoteAudience.CLOSE_FRIENDS", docs)
+        self.assertNotIn("audience: Literal[0, 1]", docs)
 
     def test_direct_media_share_uses_public_send_attribute_literal(self):
         direct_media_share = signature(DirectMixin.direct_media_share)


### PR DESCRIPTION
## Summary
- replace the public Notes `NoteAudience = Literal[0, 1]` alias with a named `IntEnum`
- require `NoteAudience.MUTUAL_FOLLOWERS` or `NoteAudience.CLOSE_FRIENDS` for `create_note()` and `create_music_note()`
- keep Instagram payloads numeric by sending `int(audience)`, and document the enum options

## Tests
- `.venv/bin/python -m pytest tests/regression/test_notes.py tests/regression/test_public_literal_types.py -q`
- `git diff --check`