### PR TITLE
docs: expose user report reason literal

### DIFF
--- a/docs/usage-guide/user.md
+++ b/docs/usage-guide/user.md
@@ -28,7 +28,7 @@ View a list of a user's medias, following and followers
 | user_id_from_username(username: str)          | int                   | Get user_id by username                                      |
 | username_from_user_id(user_id: str)           | str                   | Get username by user_id                                      |
 | user_remove_follower(user_id: str)            | bool                  | Remove your follower                                         |
-| user_report(user_id: str, reason: str = "spam") | bool                | Report a user account. Currently supports the live-verified spam report flow |
+| user_report(user_id: str, reason: USER_REPORT_REASON = "spam") | bool | Report a user account. Currently supports the live-verified spam report flow |
 | mute_posts_from_follow(user_id: str)          | bool                  | Mute posts from following user                               |
 | unmute_posts_from_follow(user_id: str)        | bool                  | Unmute posts from following user                             |
 | mute_stories_from_follow(user_id: str)        | bool                  | Mute stories from following user                             |
@@ -57,10 +57,13 @@ Pass `None` to keep Instagram's default follower order.
 
 User block surfaces are exposed as `UserBlockSurface = Literal["profile", "direct_thread_info"]`.
 
+User report reasons are exposed as `USER_REPORT_REASON = Literal["spam"]`.
+
 | Type | Values | Used by |
 |------|--------|---------|
 | `FOLLOWERS_ORDER` | `"date_followed_latest"`, `"date_followed_earliest"` | `user_followers(order=...)`, `user_followers_v1(order=...)`, `iter_user_followers_v1(order=...)` |
 | `UserBlockSurface` | `"profile"`, `"direct_thread_info"` | `user_block(surface=...)`, `user_unblock(surface=...)` |
+| `USER_REPORT_REASON` | `"spam"` | `user_report(reason=...)` |
 
 Lookup helpers:
 
@@ -111,7 +114,7 @@ each `user_id`; they do not implement an auto-approval policy.
 
 `UserShort` objects returned from private GraphQL follow-list payloads preserve selected v2-only fields when Instagram sends them: `friendship_status`, `profile_pic_id`, `fbid_v2`, `interop_messaging_user_fbid`, `strong_id__`, and raw `account_badges`. The legacy `latest_reel_media` property is also populated from Instagram's current `1llatest_reel_media` key.
 
-`user_report(user_id, reason="spam")` follows Instagram's current mobile FRX report flow for account spam reports and submits the report. This is a real account action; use it only for accounts you actually intend to report. Unsupported reasons raise `ValueError` until their FRX tag paths are captured and tested.
+`user_report(user_id, reason="spam")` follows Instagram's current mobile FRX report flow for account spam reports and submits the report. `reason` uses `USER_REPORT_REASON` and currently supports `"spam"`. This is a real account action; use it only for accounts you actually intend to report. Unsupported reasons raise `ValueError` until their FRX tag paths are captured and tested.
 
 Example:
 

--- a/tests/regression/test_public_literal_types.py
+++ b/tests/regression/test_public_literal_types.py
@@ -15,7 +15,7 @@ from instagrapi.mixins.note import NoteAudience, NoteMixin
 from instagrapi.mixins.notification import MUTE_ALL, SETTING_VALUE, NotificationContentType, NotificationMixin
 from instagrapi.mixins.public import PublicTransport
 from instagrapi.mixins.track import MUSIC_PRODUCT, TrackMixin
-from instagrapi.mixins.user import FOLLOWERS_ORDER, UserBlockSurface, UserMixin
+from instagrapi.mixins.user import FOLLOWERS_ORDER, USER_REPORT_REASON, UserBlockSurface, UserMixin
 from instagrapi.types import StoryResizeMode
 
 EXPECTED_NOTIFICATION_CONTENT_TYPES = {
@@ -101,6 +101,7 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
         self.assertEqual(set(get_args(DirectMediaType)), {"photo", "video"})
         self.assertEqual(set(get_args(MUSIC_PRODUCT)), EXPECTED_MUSIC_PRODUCTS)
         self.assertEqual(set(get_args(FOLLOWERS_ORDER)), {"date_followed_latest", "date_followed_earliest"})
+        self.assertEqual(set(get_args(USER_REPORT_REASON)), {"spam"})
         self.assertEqual(set(get_args(UserBlockSurface)), {"profile", "direct_thread_info"})
         self.assertEqual(set(get_args(StoryResizeMode)), {"fill", "fit"})
 
@@ -212,6 +213,12 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
                 self.assertEqual(method.parameters["order"].annotation, Optional[FOLLOWERS_ORDER])
                 self.assertIsNone(method.parameters["order"].default)
 
+    def test_user_report_uses_public_reason_literal(self):
+        user_report = signature(UserMixin.user_report)
+
+        self.assertEqual(user_report.parameters["reason"].annotation, USER_REPORT_REASON)
+        self.assertEqual(user_report.parameters["reason"].default, "spam")
+
     def test_user_usage_guide_documents_block_surface_literal(self):
         docs = Path("docs/usage-guide/user.md").read_text()
 
@@ -250,6 +257,14 @@ class PublicLiteralTypesRegressionTestCase(unittest.TestCase):
             docs,
         )
         self.assertNotIn("order: str = None", docs)
+
+    def test_user_usage_guide_documents_report_reason_literal(self):
+        docs = Path("docs/usage-guide/user.md").read_text()
+
+        self.assertIn('USER_REPORT_REASON = Literal["spam"]', docs)
+        self.assertIn('user_report(user_id: str, reason: USER_REPORT_REASON = "spam")', docs)
+        self.assertIn('| `USER_REPORT_REASON` | `"spam"` | `user_report(reason=...)` |', docs)
+        self.assertNotIn('user_report(user_id: str, reason: str = "spam")', docs)
 
     def test_insights_media_feed_all_uses_public_literal_aliases(self):
         insights_media_feed_all = signature(InsightsMixin.insights_media_feed_all)


### PR DESCRIPTION
## Summary
- document `USER_REPORT_REASON = Literal["spam"]` in the user usage guide
- show `user_report(..., reason: USER_REPORT_REASON = "spam")` instead of `str`
- add regression coverage for the signature and usage guide

## Tests
- `.venv/bin/python -m pytest tests/regression/test_public_literal_types.py -q`
- `git diff --check`