### PR TITLE
Fix sponsor tag friendship status normalization

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -83,7 +83,7 @@ def extract_media_v1(data):
     )
     media["like_count"] = media.get("like_count", 0)
     media["has_liked"] = media.get("has_liked", False)
-    media["sponsor_tags"] = [tag["sponsor"] for tag in media.get("sponsor_tags") or []]
+    media["sponsor_tags"] = [extract_user_short(tag["sponsor"]) for tag in media.get("sponsor_tags") or []]
     media["view_count"] = media.get("view_count", media.get("video_view_count", 0))
     media["play_count"] = media.get("play_count", media.get("video_play_count", 0))
     media["coauthor_producers"] = [extract_user_short(user) for user in media.get("coauthor_producers", [])]
@@ -646,7 +646,7 @@ def extract_story_v1(data):
         for link in cta.get("links", []):
             story["links"].append(StoryLink(**link))
     story["user"] = extract_user_short(story.get("user"))
-    story["sponsor_tags"] = [tag["sponsor"] for tag in story.get("sponsor_tags", [])]
+    story["sponsor_tags"] = [extract_user_short(tag["sponsor"]) for tag in story.get("sponsor_tags", [])]
     story["is_paid_partnership"] = story.get("is_paid_partnership")
     if not story.get("code"):
         story["code"] = InstagramIdCodec.encode(story["pk"])

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -58,6 +58,26 @@ class MediaInfoV2RegressionTestCase(unittest.TestCase):
         self.assertEqual(media.view_count, 1234)
         self.assertEqual(media.play_count, 5678)
 
+    def test_extract_media_v1_normalizes_sponsor_tag_friendship_status(self):
+        payload = self._media_or_ad_payload()
+        payload["sponsor_tags"] = [
+            {
+                "sponsor": {
+                    "pk": "3",
+                    "username": "sponsor",
+                    "profile_pic_url": "https://example.com/sponsor.jpg",
+                    "friendship_status": {"following": False},
+                }
+            }
+        ]
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(media.sponsor_tags[0].pk, "3")
+        self.assertEqual(media.sponsor_tags[0].friendship_status.user_id, "3")
+        self.assertFalse(media.sponsor_tags[0].friendship_status.following)
+        self.assertFalse(media.sponsor_tags[0].friendship_status.incoming_request)
+
     def test_media_info_v2_strips_userid_suffix(self):
         client = Client()
         with mock.patch.object(

--- a/tests/regression/test_story.py
+++ b/tests/regression/test_story.py
@@ -147,6 +147,46 @@ class StoryMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(story.polls[0].options, ["Yes", "No"])
         self.assertTrue(story.polls[0].viewer_can_vote)
 
+    def test_extract_story_v1_normalizes_sponsor_tag_friendship_status(self):
+        story = extract_story_v1(
+            {
+                "pk": "1",
+                "id": "1_2",
+                "code": "abc",
+                "taken_at": 1710000000,
+                "media_type": 1,
+                "image_versions2": {
+                    "candidates": [
+                        {
+                            "url": "https://example.com/thumbnail.jpg",
+                            "width": 720,
+                            "height": 1280,
+                        }
+                    ]
+                },
+                "user": {
+                    "pk": "2",
+                    "username": "example",
+                    "profile_pic_url": "https://example.com/profile.jpg",
+                },
+                "sponsor_tags": [
+                    {
+                        "sponsor": {
+                            "pk": "3",
+                            "username": "sponsor",
+                            "profile_pic_url": "https://example.com/sponsor.jpg",
+                            "friendship_status": {"following": False},
+                        }
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(story.sponsor_tags[0].pk, "3")
+        self.assertEqual(story.sponsor_tags[0].friendship_status.user_id, "3")
+        self.assertFalse(story.sponsor_tags[0].friendship_status.following)
+        self.assertFalse(story.sponsor_tags[0].friendship_status.incoming_request)
+
     def test_story_poll_vote_posts_vote_to_poll_endpoint(self):
         client = self.build_private_client()
         client._user_id = "1"


### PR DESCRIPTION
## Summary
- Normalize private API media sponsor tag users through extract_user_short
- Apply the same normalization to private story sponsor tags
- Add regression coverage for incomplete sponsor friendship_status payloads

Fixes #2701

## Tests
- .venv/bin/python -m pytest tests/regression -q
- .venv/bin/python -m ruff check instagrapi/extractors.py tests/regression/test_media.py tests/regression/test_story.py
- git diff --check origin/master

## Review
- Manual pre-landing review: no structural issues found in this scoped extractor/test diff
- Note: gstack review checklist file was not present in this local checkout, so automated checklist review could not run