### PR TITLE
Release 2.16.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.16.24"
+version = "2.16.25"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]


### PR DESCRIPTION
## Summary
- Bump instagrapi package version to 2.16.25 for the sponsor tag normalization fix merged in #2702

## Tests
- .venv/bin/python -m pytest tests/regression -q
- git diff --check