### PR TITLE
fix: restore public media GraphQL lookup

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -33,7 +33,7 @@ from instagrapi.utils.ids import InstagramIdCodec
 from instagrapi.utils.iterators import iter_paginated
 from instagrapi.utils.serialization import dumps, json_value
 
-MEDIA_INFO_DOC_ID = "8845758582119845"
+MEDIA_INFO_DOC_ID = "27128499623469141"
 IG_PROFILE_TIMELINE_DOC_ID = "56030350814417327502004290437"
 
 
@@ -83,6 +83,46 @@ class MediaMixin:
             media["id"] = f"{media_id}_{user['pk']}"
         if "taken_at" not in media and "1ltaken_at" in media:
             media["taken_at"] = media["1ltaken_at"]
+        return media
+
+    @staticmethod
+    def _normalize_xdt_media_info(media: Dict) -> Dict:
+        media = deepcopy(media)
+        user = media.get("user") or {}
+        if "pk" not in user and user.get("id"):
+            user["pk"] = user["id"]
+        media["user"] = user
+        media_pk = str(media.get("pk") or "")
+        media_id = str(media.get("id") or "")
+        if not media_pk and media_id:
+            media_pk = media_id.split("_", 1)[0]
+            media["pk"] = media_pk
+        elif "_" in media_pk:
+            media_pk = media_pk.split("_", 1)[0]
+            media["pk"] = media_pk
+        if media_id and "_" not in media_id and user.get("pk"):
+            media["id"] = f"{media_id}_{user['pk']}"
+        elif not media_id and media_pk and user.get("pk"):
+            media["id"] = f"{media_pk}_{user['pk']}"
+        if "code" not in media and media.get("shortcode"):
+            media["code"] = media["shortcode"]
+        if "taken_at" not in media and "taken_at_timestamp" in media:
+            media["taken_at"] = media["taken_at_timestamp"]
+        if not media.get("media_type"):
+            if media.get("carousel_media"):
+                media["media_type"] = 8
+            elif media.get("video_versions"):
+                media["media_type"] = 2
+            else:
+                media["media_type"] = 1
+        if isinstance(media.get("caption"), str):
+            media["caption"] = {"text": media["caption"]}
+        elif "caption_text" in media and "caption" not in media:
+            media["caption"] = {"text": media.pop("caption_text") or ""}
+        elif "caption_text" in media:
+            media.pop("caption_text", None)
+        if media.get("carousel_media"):
+            media["carousel_media"] = [MediaMixin._normalize_xdt_media_info(item) for item in media["carousel_media"]]
         return media
 
     def _user_medias_paginated_app_gql(self, user_id: str, amount: int = 0, end_cursor=None) -> Tuple[List[Media], str]:
@@ -542,13 +582,22 @@ class MediaMixin:
         ):
             data = self.public_doc_id_graphql_request(
                 MEDIA_INFO_DOC_ID,
-                {"shortcode": shortcode},
+                {
+                    "shortcode": shortcode,
+                    "__relay_internal__pv__PolarisAIGMMediaWebLabelEnabledrelayprovider": False,
+                },
                 referer=f"https://www.instagram.com/p/{shortcode}/",
+                url=self.GRAPHQL_PUBLIC_WEB_API_URL,
+                include_lsd=True,
+                headers={"X-FB-Friendly-Name": "PolarisPostRootQuery"},
             )
             media = data.get("xdt_shortcode_media") or data.get("shortcode_media")
-            if not media:
+            if media:
+                return extract_media_gql(media)
+            media_items = json_value(data, "xdt_api__v1__media__shortcode__web_info", "items", default=[])
+            if not media_items:
                 raise MediaNotFound(media_pk=media_pk, **data)
-            return extract_media_gql(media)
+            return extract_media_v1(self._normalize_xdt_media_info(media_items[0]))
         if not data.get("shortcode_media"):
             raise MediaNotFound(media_pk=media_pk, **data)
         if data["shortcode_media"]["location"] and self.authorization:

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -32,6 +32,8 @@ from instagrapi.utils.logging import truncate_log_text
 from instagrapi.utils.timing import random_delay
 
 PublicTransport = Literal["requests", "curl"]
+PUBLIC_WEB_APP_ID = "936619743392459"
+PUBLIC_WEB_ASBD_ID = "129477"
 
 
 class PublicRequestMixin:
@@ -509,8 +511,8 @@ class PublicRequestMixin:
                     "Content-Type": "application/x-www-form-urlencoded",
                     "Origin": "https://www.instagram.com",
                     "User-Agent": self.public_user_agent,
-                    "X-ASBD-ID": "129477",
-                    "X-IG-App-ID": "936619743392459",
+                    "X-ASBD-ID": PUBLIC_WEB_ASBD_ID,
+                    "X-IG-App-ID": PUBLIC_WEB_APP_ID,
                 }
             )
             if lsd:

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import shutil
 import time
 from pathlib import Path
@@ -37,6 +38,7 @@ class PublicRequestMixin:
     public_requests_count = 0
     PUBLIC_API_URL = "https://www.instagram.com/"
     GRAPHQL_PUBLIC_API_URL = "https://www.instagram.com/graphql/query/"
+    GRAPHQL_PUBLIC_WEB_API_URL = "https://www.instagram.com/api/graphql"
     last_public_response = None
     last_public_json = {}
     public_request_logger = logging.getLogger("public_request")
@@ -450,15 +452,27 @@ class PublicRequestMixin:
                 pass
             raise ClientGraphqlError("Error: '{}'. Message: '{}'".format(e, message), response=e.response)
 
+    @staticmethod
+    def _extract_public_lsd_token(html: str) -> Optional[str]:
+        if not html:
+            return None
+        match = re.search(r'\["LSD",\[\],\{"token":"([^"]+)"\}', html)
+        if match:
+            return match.group(1)
+        match = re.search(r'"LSD",\[\],\{"token":"([^"]+)"', html)
+        return match.group(1) if match else None
+
     def public_doc_id_graphql_request(
         self,
         doc_id: str,
         variables: Dict[str, Any],
         referer: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        url: Optional[str] = None,
+        include_lsd: bool = False,
     ) -> Dict[str, Any]:
         """
-        POST a doc_id-based GraphQL query to www.instagram.com/graphql/query/.
+        POST a doc_id-based GraphQL query to Instagram's public web endpoints.
 
         Newer Instagram web GraphQL endpoints use ``doc_id`` instead of the
         legacy ``query_hash`` / ``query_id`` scheme. Returns the parsed
@@ -472,28 +486,48 @@ class PublicRequestMixin:
         inject_sessionid = getattr(self, "inject_sessionid_to_public", None)
         if inject_sessionid:
             inject_sessionid()
+        query_url = url or self.GRAPHQL_PUBLIC_API_URL
+        referer_url = referer or "https://www.instagram.com/"
+        lsd = None
+        if include_lsd:
+            html = self.public_request(referer_url, return_json=False)
+            lsd = self._extract_public_lsd_token(html)
+            if lsd:
+                data["lsd"] = lsd
         merged_headers = {
             "Accept": "*/*",
             "Accept-Encoding": "gzip, deflate",
             "Accept-Language": "en-US,en;q=0.8",
-            "Referer": referer or "https://www.instagram.com/",
+            "Referer": referer_url,
             "User-Agent": (
                 "Instagram 273.0.0.16.70 (iPhone15,2; iOS 17_5_1; en_US; en-US; scale=3.00; 1290x2796; 470085518)"
             ),
         }
+        if include_lsd:
+            merged_headers.update(
+                {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Origin": "https://www.instagram.com",
+                    "User-Agent": self.public_user_agent,
+                    "X-ASBD-ID": "129477",
+                    "X-IG-App-ID": "936619743392459",
+                }
+            )
+            if lsd:
+                merged_headers["X-FB-LSD"] = lsd
         csrftoken = self.public.cookies.get("csrftoken")
         if csrftoken:
             merged_headers["X-CSRFToken"] = csrftoken
         if headers:
             merged_headers.update(headers)
         body_json = self.public_request(
-            self.GRAPHQL_PUBLIC_API_URL,
+            query_url,
             data=data,
             headers=merged_headers,
             update_headers=False,
             return_json=True,
         )
-        if "data" not in body_json:
+        if body_json.get("data") is None:
             errors = body_json.get("errors") or []
             summary = errors[0].get("summary") if errors else None
             description = errors[0].get("description") if errors else None

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -24,6 +24,7 @@ from instagrapi.extractors import (
     extract_user_short,
     extract_user_v1,
 )
+from instagrapi.mixins.public import PUBLIC_WEB_APP_ID, PUBLIC_WEB_ASBD_ID
 from instagrapi.types import About, AddressBookContact, Guide, Relationship, RelationshipShort, User, UserShort
 from instagrapi.utils.iterators import iter_paginated
 from instagrapi.utils.serialization import dumps, json_value
@@ -241,7 +242,7 @@ class UserMixin:
             "X-Requested-With": "XMLHttpRequest",
             "Sec-Ch-Prefers-Color-Scheme": "dark",
             "Sec-Ch-Ua-Platform": '"Linux"',
-            "X-Ig-App-Id": "936619743392459",
+            "X-Ig-App-Id": PUBLIC_WEB_APP_ID,
             "Sec-Ch-Ua-Model": '""',
             "Sec-Ch-Ua-Mobile": "?0",
             "User-Agent": (
@@ -250,7 +251,7 @@ class UserMixin:
                 "Chrome/122.0.6261.112 Safari/537.36"
             ),
             "Accept": "*/*",
-            "X-Asbd-Id": "129477",
+            "X-Asbd-Id": PUBLIC_WEB_ASBD_ID,
             "Sec-Fetch-Site": "same-origin",
             "Sec-Fetch-Mode": "cors",
             "Sec-Fetch-Dest": "empty",

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -1,5 +1,5 @@
 from instagrapi.exceptions import ClientForbiddenError, ClientLoginRequired, ClientNotFoundError
-from instagrapi.mixins.public import JSONDecodeError as PublicJSONDecodeError
+from instagrapi.mixins import public as public_mixin
 from tests.helpers import *
 
 
@@ -101,7 +101,8 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertEqual(kwargs["headers"]["X-FB-LSD"], "lsd-token")
         self.assertEqual(kwargs["headers"]["X-CSRFToken"], "csrf-token")
         self.assertEqual(kwargs["headers"]["X-FB-Friendly-Name"], "PolarisPostRootQuery")
-        self.assertEqual(kwargs["headers"]["X-IG-App-ID"], "936619743392459")
+        self.assertEqual(kwargs["headers"]["X-ASBD-ID"], public_mixin.PUBLIC_WEB_ASBD_ID)
+        self.assertEqual(kwargs["headers"]["X-IG-App-ID"], public_mixin.PUBLIC_WEB_APP_ID)
         self.assertFalse(kwargs["update_headers"])
         self.assertTrue(kwargs["return_json"])
 
@@ -116,7 +117,7 @@ class PublicRegressionTestCase(unittest.TestCase):
         response.url = "https://www.instagram.com/challenge/?next=/graphql/query/"
         response.text = '<!DOCTYPE html><html lang="en" class="no-js logged-in client-root"></html>'
         response.raise_for_status.return_value = None
-        response.json.side_effect = PublicJSONDecodeError("bad", response.text, 0)
+        response.json.side_effect = public_mixin.JSONDecodeError("bad", response.text, 0)
 
         with mock.patch.object(client.public, "get", return_value=response):
             with self.assertRaises(ClientLoginRequired):

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -70,6 +70,41 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertFalse(kwargs["update_headers"])
         self.assertTrue(kwargs["return_json"])
 
+    def test_public_doc_id_graphql_request_posts_web_api_with_lsd(self):
+        client = Client()
+        client.public.cookies.set("csrftoken", "csrf-token")
+        html = '<html><script>["LSD",[],{"token":"lsd-token"}]</script></html>'
+
+        with mock.patch.object(
+            client,
+            "public_request",
+            side_effect=[html, {"data": {"ok": True}}],
+        ) as public_request:
+            data = client.public_doc_id_graphql_request(
+                "27128499623469141",
+                {"shortcode": "DaHEdwgogl4"},
+                referer="https://www.instagram.com/p/DaHEdwgogl4/",
+                url=client.GRAPHQL_PUBLIC_WEB_API_URL,
+                include_lsd=True,
+                headers={"X-FB-Friendly-Name": "PolarisPostRootQuery"},
+            )
+
+        self.assertEqual(data, {"ok": True})
+        bootstrap_call, query_call = public_request.call_args_list
+        self.assertEqual(bootstrap_call.args[0], "https://www.instagram.com/p/DaHEdwgogl4/")
+        self.assertFalse(bootstrap_call.kwargs["return_json"])
+        self.assertEqual(query_call.args[0], client.GRAPHQL_PUBLIC_WEB_API_URL)
+        kwargs = query_call.kwargs
+        self.assertEqual(kwargs["data"]["doc_id"], "27128499623469141")
+        self.assertEqual(kwargs["data"]["variables"], '{"shortcode":"DaHEdwgogl4"}')
+        self.assertEqual(kwargs["data"]["lsd"], "lsd-token")
+        self.assertEqual(kwargs["headers"]["X-FB-LSD"], "lsd-token")
+        self.assertEqual(kwargs["headers"]["X-CSRFToken"], "csrf-token")
+        self.assertEqual(kwargs["headers"]["X-FB-Friendly-Name"], "PolarisPostRootQuery")
+        self.assertEqual(kwargs["headers"]["X-IG-App-ID"], "936619743392459")
+        self.assertFalse(kwargs["update_headers"])
+        self.assertTrue(kwargs["return_json"])
+
     def test_public_request_maps_challenge_redirect_html_to_login_required(self):
         client = Client()
         client.request_timeout = 0
@@ -109,6 +144,29 @@ class PublicRegressionTestCase(unittest.TestCase):
 
         self.assertIn("Missing 'data' in GraphQL response", str(cm.exception))
         self.assertIn("Incorrect Query", str(cm.exception))
+
+    def test_public_doc_id_graphql_request_raises_when_data_is_null(self):
+        client = Client()
+        body = {
+            "data": None,
+            "errors": [
+                {
+                    "summary": "Login required",
+                    "description": "Anonymous GraphQL access is blocked.",
+                }
+            ],
+            "status": "ok",
+        }
+
+        with mock.patch.object(client, "public_request", return_value=body):
+            with self.assertRaises(ClientGraphqlError) as cm:
+                client.public_doc_id_graphql_request(
+                    "8845758582119845",
+                    {"shortcode": "DaHEdwgogl4"},
+                )
+
+        self.assertIn("Missing 'data' in doc_id GraphQL response", str(cm.exception))
+        self.assertIn("Login required", str(cm.exception))
 
     def test_user_stories_anonymous_does_not_fallback_to_private(self):
         client = Client()
@@ -214,9 +272,15 @@ class PublicRegressionTestCase(unittest.TestCase):
                 media = client.media_info_gql("2110901750722920960")
 
         doc_id_request.assert_called_once_with(
-            "8845758582119845",
-            {"shortcode": "B1LbfVPlwIA"},
+            "27128499623469141",
+            {
+                "shortcode": "B1LbfVPlwIA",
+                "__relay_internal__pv__PolarisAIGMMediaWebLabelEnabledrelayprovider": False,
+            },
             referer="https://www.instagram.com/p/B1LbfVPlwIA/",
+            url=client.GRAPHQL_PUBLIC_WEB_API_URL,
+            include_lsd=True,
+            headers={"X-FB-Friendly-Name": "PolarisPostRootQuery"},
         )
         self.assertEqual(media.media_type, 2)
         self.assertEqual(media.comment_count, 3)
@@ -237,6 +301,85 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertEqual(media.dash_info.number_of_qualities, 0)
         self.assertEqual(media.clips_music_attribution_info.artist_name, "example")
         self.assertTrue(media.clips_music_attribution_info.uses_original_audio)
+
+    def test_media_info_gql_extracts_current_web_info_payload(self):
+        client = Client()
+        media_payload = {
+            "pk": "3929128837042014584",
+            "id": "3929128837042014584_1713591624",
+            "code": "DaHEdwgogl4",
+            "taken_at": 1782608696,
+            "media_type": 2,
+            "product_type": "clips",
+            "user": {
+                "id": "1713591624",
+                "username": "example",
+                "profile_pic_url": "https://example.com/profile.jpg",
+                "is_private": False,
+            },
+            "image_versions2": {
+                "candidates": [
+                    {
+                        "url": "https://example.com/thumbnail.jpg",
+                        "width": 720,
+                        "height": 1280,
+                    }
+                ]
+            },
+            "video_versions": [
+                {
+                    "url": "https://example.com/video.mp4",
+                    "width": 720,
+                    "height": 1280,
+                    "type": 101,
+                }
+            ],
+            "caption": {"text": "#suomi"},
+            "comment_count": 1114,
+            "like_count": 113000,
+            "view_count": 200000,
+            "play_count": 210000,
+            "has_liked": False,
+            "has_viewer_saved": True,
+        }
+
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            side_effect=ClientUnauthorizedError("401", response=Mock(status_code=401)),
+        ):
+            with mock.patch.object(
+                client,
+                "public_doc_id_graphql_request",
+                return_value={"xdt_api__v1__media__shortcode__web_info": {"items": [media_payload]}},
+            ) as doc_id_request:
+                media = client.media_info_gql("3929128837042014584")
+
+        doc_id_request.assert_called_once_with(
+            "27128499623469141",
+            {
+                "shortcode": "DaHEdwgogl4",
+                "__relay_internal__pv__PolarisAIGMMediaWebLabelEnabledrelayprovider": False,
+            },
+            referer="https://www.instagram.com/p/DaHEdwgogl4/",
+            url=client.GRAPHQL_PUBLIC_WEB_API_URL,
+            include_lsd=True,
+            headers={"X-FB-Friendly-Name": "PolarisPostRootQuery"},
+        )
+        self.assertEqual(media.pk, "3929128837042014584")
+        self.assertEqual(media.id, "3929128837042014584_1713591624")
+        self.assertEqual(media.code, "DaHEdwgogl4")
+        self.assertEqual(media.media_type, 2)
+        self.assertEqual(media.product_type, "clips")
+        self.assertEqual(media.user.pk, "1713591624")
+        self.assertEqual(str(media.thumbnail_url), "https://example.com/thumbnail.jpg")
+        self.assertEqual(str(media.video_url), "https://example.com/video.mp4")
+        self.assertEqual(media.caption_text, "#suomi")
+        self.assertEqual(media.comment_count, 1114)
+        self.assertEqual(media.like_count, 113000)
+        self.assertEqual(media.view_count, 200000)
+        self.assertEqual(media.play_count, 210000)
+        self.assertFalse(media.has_liked)
 
     def test_media_info_gql_normalizes_xdt_sidecar_children(self):
         client = Client()

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1,5 +1,6 @@
 from instagrapi import types as ig_types
 from instagrapi.extractors import extract_user_short, extract_user_v1
+from instagrapi.mixins.public import PUBLIC_WEB_APP_ID, PUBLIC_WEB_ASBD_ID
 from instagrapi.mixins.user import (
     MAX_USER_COUNT,
     USER_INFO_BY_USERNAME_V2_DOC_ID,
@@ -237,6 +238,8 @@ class UserMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(len(client.public_request_calls), 1)
         self.assertEqual(client.public_request_calls[0]["kwargs"], {})
         self.assertIn("web_profile_info/?username=example", client.public_request_calls[0]["url"])
+        self.assertEqual(client.public_request_calls[0]["headers"]["X-Asbd-Id"], PUBLIC_WEB_ASBD_ID)
+        self.assertEqual(client.public_request_calls[0]["headers"]["X-Ig-App-Id"], PUBLIC_WEB_APP_ID)
 
     def test_user_info_by_username_gql_normalizes_username(self):
         class DummyClient(UserMixin):


### PR DESCRIPTION
## Summary
- Restores anonymous public `media_info_gql` fallback for Instagram's current web GraphQL response.
- Adds `/api/graphql` doc_id support with LSD bootstrap for public web requests.
- Normalizes `xdt_api__v1__media__shortcode__web_info.items[0]` media payloads through the existing v1 extractor.
- Raises a `ClientGraphqlError` instead of leaking `AttributeError` when doc_id GraphQL returns `data: null`.

Closes #2710

## Pre-Landing Review
No issues found after checklist review. One stale docstring was corrected before commit.

## Test plan
- [x] `uv run --extra test pytest -q tests/regression/test_public.py::PublicRegressionTestCase tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase` (`19 passed`)
- [x] `uv run --extra test ruff check --output-format=github instagrapi/mixins/public.py instagrapi/mixins/media.py tests/regression/test_public.py`
- [x] `uv run --extra test ruff format --check instagrapi/mixins/public.py instagrapi/mixins/media.py tests/regression/test_public.py` (`3 files already formatted`)
- [x] Live repro: `Client().media_info_gql(Client().media_pk_from_url("https://www.instagram.com/reels/DaHEdwgogl4/"))` returned `Media` with `video_url=True` and `thumbnail_url=True`.
