### PR TITLE
feat: support linked reels

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -39,7 +39,6 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_delete(media_id: str) | bool | Delete media |
 | media_edit(media_id: str, caption: str, title: str = "", usertags: List[Usertag] = [], location: Location = None) | dict | Edit caption, optional IGTV title, usertags, or location |
 | media_link_reel(media_id: str, target_media_id: str, link_name: str = "Watch Next") | bool | Link one Reel to another Reel so Instagram can show a navigation button |
-| media_unlink_reel(media_id: str) | bool | Remove the linked Reel navigation button from media |
 | media_user(media_pk: str) | UserShort | Get author of media |
 | media_oembed(url: str) | dict | Return short oEmbed-style media info by URL |
 | media_like(media_id: str) | bool | Like media |
@@ -277,7 +276,7 @@ Notes:
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.
-* `media_link_reel()` and `media_unlink_reel()` use Instagram's private `media/{media_id}/edit_media/` endpoint. Pass full media IDs when you have them; plain media PKs are normalized with `media_id()` before the request.
+* `media_link_reel()` uses Instagram's private `media/{media_id}/edit_media/` endpoint. Pass full media IDs when you have them; plain media PKs are normalized with `media_id()` before the request.
 
 Extended `Media` metadata fields:
 

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -39,7 +39,6 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_delete(media_id: str) | bool | Delete media |
 | media_edit(media_id: str, caption: str, title: str = "", usertags: List[Usertag] = [], location: Location = None) | dict | Edit caption, optional IGTV title, usertags, or location |
 | media_link_reel(media_id: str, target_media_id: str, link_name: str = "Watch Next") | bool | Link one Reel to another Reel so Instagram can show a navigation button |
-| media_unlink_reel(media_id: str, target_media_id: str = None) | bool | Remove a linked Reel navigation button from a Reel |
 | media_user(media_pk: str) | UserShort | Get author of media |
 | media_oembed(url: str) | dict | Return short oEmbed-style media info by URL |
 | media_like(media_id: str) | bool | Like media |
@@ -277,7 +276,7 @@ Notes:
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.
-* `media_link_reel()` uses Instagram's private `media/{media_id}/edit_media/` endpoint. `media_unlink_reel()` uses Instagram's private `LinkedMediaDelete` GraphQL mutation. Pass full media IDs when you have them; plain media PKs are normalized with `media_id()` before the request.
+* `media_link_reel()` uses Instagram's private `media/{media_id}/edit_media/` endpoint. Pass full media IDs when you have them; plain media PKs are normalized with `media_id()` before the request.
 
 Extended `Media` metadata fields:
 

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -39,6 +39,7 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_delete(media_id: str) | bool | Delete media |
 | media_edit(media_id: str, caption: str, title: str = "", usertags: List[Usertag] = [], location: Location = None) | dict | Edit caption, optional IGTV title, usertags, or location |
 | media_link_reel(media_id: str, target_media_id: str, link_name: str = "Watch Next") | bool | Link one Reel to another Reel so Instagram can show a navigation button |
+| media_unlink_reel(media_id: str, target_media_id: str = None) | bool | Remove a linked Reel navigation button from a Reel |
 | media_user(media_pk: str) | UserShort | Get author of media |
 | media_oembed(url: str) | dict | Return short oEmbed-style media info by URL |
 | media_like(media_id: str) | bool | Like media |
@@ -276,7 +277,7 @@ Notes:
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.
-* `media_link_reel()` uses Instagram's private `media/{media_id}/edit_media/` endpoint. Pass full media IDs when you have them; plain media PKs are normalized with `media_id()` before the request.
+* `media_link_reel()` uses Instagram's private `media/{media_id}/edit_media/` endpoint. `media_unlink_reel()` uses Instagram's private `LinkedMediaDelete` GraphQL mutation. Pass full media IDs when you have them; plain media PKs are normalized with `media_id()` before the request.
 
 Extended `Media` metadata fields:
 

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -38,6 +38,8 @@ In terms of Instagram, this is called Media, usually users call it publications 
 | media_info(media_pk: str, use_cache: bool = True) | Media | Return media info |
 | media_delete(media_id: str) | bool | Delete media |
 | media_edit(media_id: str, caption: str, title: str = "", usertags: List[Usertag] = [], location: Location = None) | dict | Edit caption, optional IGTV title, usertags, or location |
+| media_link_reel(media_id: str, target_media_id: str, link_name: str = "Watch Next") | bool | Link one Reel to another Reel so Instagram can show a navigation button |
+| media_unlink_reel(media_id: str) | bool | Remove the linked Reel navigation button from media |
 | media_user(media_pk: str) | UserShort | Get author of media |
 | media_oembed(url: str) | dict | Return short oEmbed-style media info by URL |
 | media_like(media_id: str) | bool | Like media |
@@ -275,6 +277,7 @@ Notes:
 * `media_pk_from_url()` now also resolves `share/p/...` URLs before extracting the canonical shortcode.
 * Accepted Instagram Collabs/coauthor users from private media payloads are available as `media.coauthor_producers`. This is separate from upload-time `coauthor_user_ids`, which only sends collaborator invitations.
 * `media_edit()` uses `caption` and optional `location`/`usertags`; for IGTV posts it can also derive or send a separate `title`.
+* `media_link_reel()` and `media_unlink_reel()` use Instagram's private `media/{media_id}/edit_media/` endpoint. Pass full media IDs when you have them; plain media PKs are normalized with `media_id()` before the request.
 
 Extended `Media` metadata fields:
 

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -820,34 +820,6 @@ class MediaMixin:
         )
         return result.get("status") == "ok"
 
-    def media_unlink_reel(self, media_id: str) -> bool:
-        """
-        Remove a linked Reel from media.
-
-        Parameters
-        ----------
-        media_id: str
-            Media id that should have its linked Reel cleared
-
-        Returns
-        -------
-        bool
-            A boolean value
-        """
-        assert self.user_id, "Login required"
-        media_id = self.media_id(media_id)
-        data = {
-            "_uid": str(self.user_id),
-            "_uuid": self.uuid,
-            "linked_media_info": dumps({}),
-        }
-        self._medias_cache.pop(self.media_pk(media_id), None)
-        result = self.private_request(
-            f"media/{media_id}/edit_media/",
-            self.with_action_data(data),
-        )
-        return result.get("status") == "ok"
-
     def media_user(self, media_pk: str) -> UserShort:
         """
         Get author of the media

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -787,6 +787,67 @@ class MediaMixin:
         )
         return result
 
+    def media_link_reel(self, media_id: str, target_media_id: str, link_name: str = "Watch Next") -> bool:
+        """
+        Link one Reel to another Reel.
+
+        Parameters
+        ----------
+        media_id: str
+            Origin media id that receives the linked Reel navigation button
+        target_media_id: str
+            Destination media id opened by the linked Reel navigation button
+        link_name: str, optional
+            Text shown by Instagram for the link, default value is "Watch Next"
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        assert self.user_id, "Login required"
+        media_id = self.media_id(media_id)
+        target_media_id = self.media_id(target_media_id)
+        data = {
+            "_uid": str(self.user_id),
+            "_uuid": self.uuid,
+            "linked_media_info": dumps({"media_id": target_media_id, "link_name": link_name}),
+        }
+        self._medias_cache.pop(self.media_pk(media_id), None)
+        result = self.private_request(
+            f"media/{media_id}/edit_media/",
+            self.with_action_data(data),
+        )
+        return result.get("status") == "ok"
+
+    def media_unlink_reel(self, media_id: str) -> bool:
+        """
+        Remove a linked Reel from media.
+
+        Parameters
+        ----------
+        media_id: str
+            Media id that should have its linked Reel cleared
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        assert self.user_id, "Login required"
+        media_id = self.media_id(media_id)
+        data = {
+            "_uid": str(self.user_id),
+            "_uuid": self.uuid,
+            "linked_media_info": "",
+        }
+        self._medias_cache.pop(self.media_pk(media_id), None)
+        result = self.private_request(
+            f"media/{media_id}/edit_media/",
+            self.with_action_data(data),
+        )
+        return result.get("status") == "ok"
+
     def media_user(self, media_pk: str) -> UserShort:
         """
         Get author of the media

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -35,9 +35,6 @@ from instagrapi.utils.serialization import dumps, json_value
 
 MEDIA_INFO_DOC_ID = "27128499623469141"
 IG_PROFILE_TIMELINE_DOC_ID = "56030350814417327502004290437"
-LINKED_MEDIA_DELETE_CLIENT_DOC_ID = "8731250647292294617344433924"
-LINKED_MEDIA_DELETE_FRIENDLY_NAME = "LinkedMediaDelete"
-LINKED_MEDIA_DELETE_ROOT_FIELD = "xig_linked_media_delete"
 
 
 class MediaMixin:
@@ -822,44 +819,6 @@ class MediaMixin:
             self.with_action_data(data),
         )
         return result.get("status") == "ok"
-
-    def media_unlink_reel(self, media_id: str, target_media_id: Optional[str] = None) -> bool:
-        """
-        Remove a linked Reel navigation button from a Reel.
-
-        Parameters
-        ----------
-        media_id: str
-            Origin media id that currently has the linked Reel navigation button
-        target_media_id: str, optional
-            Destination media id to remove from the origin media. When omitted,
-            Instagram removes the linked Reel from the origin media.
-
-        Returns
-        -------
-        bool
-            A boolean value
-        """
-        assert self.user_id, "Login required"
-        media_id = self.media_id(media_id)
-        input_data = {"source_media_id": media_id}
-        if target_media_id is not None:
-            input_data["destination_media_id"] = self.media_id(target_media_id)
-        self._medias_cache.pop(self.media_pk(media_id), None)
-        result = self.private_graphql_query_request(
-            friendly_name=LINKED_MEDIA_DELETE_FRIENDLY_NAME,
-            root_field_name=LINKED_MEDIA_DELETE_ROOT_FIELD,
-            variables={"input_data": input_data},
-            client_doc_id=LINKED_MEDIA_DELETE_CLIENT_DOC_ID,
-        )
-        if result.get("status") == "ok":
-            return True
-        root = (result.get("data") or {}).get(LINKED_MEDIA_DELETE_ROOT_FIELD)
-        if isinstance(root, dict):
-            if root.get("status") is not None:
-                return root.get("status") == "ok"
-            return root.get("success") is True or root.get("is_success") is True
-        return root is True
 
     def media_user(self, media_pk: str) -> UserShort:
         """

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -839,7 +839,7 @@ class MediaMixin:
         data = {
             "_uid": str(self.user_id),
             "_uuid": self.uuid,
-            "linked_media_info": "",
+            "linked_media_info": dumps({}),
         }
         self._medias_cache.pop(self.media_pk(media_id), None)
         result = self.private_request(

--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -35,6 +35,9 @@ from instagrapi.utils.serialization import dumps, json_value
 
 MEDIA_INFO_DOC_ID = "27128499623469141"
 IG_PROFILE_TIMELINE_DOC_ID = "56030350814417327502004290437"
+LINKED_MEDIA_DELETE_CLIENT_DOC_ID = "8731250647292294617344433924"
+LINKED_MEDIA_DELETE_FRIENDLY_NAME = "LinkedMediaDelete"
+LINKED_MEDIA_DELETE_ROOT_FIELD = "xig_linked_media_delete"
 
 
 class MediaMixin:
@@ -819,6 +822,44 @@ class MediaMixin:
             self.with_action_data(data),
         )
         return result.get("status") == "ok"
+
+    def media_unlink_reel(self, media_id: str, target_media_id: Optional[str] = None) -> bool:
+        """
+        Remove a linked Reel navigation button from a Reel.
+
+        Parameters
+        ----------
+        media_id: str
+            Origin media id that currently has the linked Reel navigation button
+        target_media_id: str, optional
+            Destination media id to remove from the origin media. When omitted,
+            Instagram removes the linked Reel from the origin media.
+
+        Returns
+        -------
+        bool
+            A boolean value
+        """
+        assert self.user_id, "Login required"
+        media_id = self.media_id(media_id)
+        input_data = {"source_media_id": media_id}
+        if target_media_id is not None:
+            input_data["destination_media_id"] = self.media_id(target_media_id)
+        self._medias_cache.pop(self.media_pk(media_id), None)
+        result = self.private_graphql_query_request(
+            friendly_name=LINKED_MEDIA_DELETE_FRIENDLY_NAME,
+            root_field_name=LINKED_MEDIA_DELETE_ROOT_FIELD,
+            variables={"input_data": input_data},
+            client_doc_id=LINKED_MEDIA_DELETE_CLIENT_DOC_ID,
+        )
+        if result.get("status") == "ok":
+            return True
+        root = (result.get("data") or {}).get(LINKED_MEDIA_DELETE_ROOT_FIELD)
+        if isinstance(root, dict):
+            if root.get("status") is not None:
+                return root.get("status") == "ok"
+            return root.get("success") is True or root.get("is_success") is True
+        return root is True
 
     def media_user(self, media_pk: str) -> UserShort:
         """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -211,11 +211,16 @@ def build_test_accounts_url(count=None):
 def client_from_test_account(acc):
     settings = dict(acc["client_settings"])
     totp_seed = settings.pop("totp_seed", None)
+    authorization_data = settings.get("authorization_data") or {}
+    account_user_id = acc.get("user_id") or authorization_data.get("ds_user_id")
+    has_authorized_session = bool(authorization_data)
     cl = Client(settings=settings, proxy=os.getenv("IG_PROXY") or acc["proxy"])
+    if has_authorized_session and account_user_id:
+        cl._user_id = str(account_user_id)
     login_kwargs = {
         "username": acc["username"],
         "password": acc["password"],
-        "relogin": True,
+        "relogin": not has_authorized_session,
     }
     if totp_seed:
         totp_code = cl.totp_generate_code(totp_seed)
@@ -224,7 +229,7 @@ def client_from_test_account(acc):
         login_kwargs["verification_code"] = totp_code
     with fresh_account_login_timeout():
         cl.login(**login_kwargs)
-    cl._user_id = acc.get("user_id")
+    cl._user_id = account_user_id
     return cl
 
 

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -114,6 +114,37 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
             if media:
                 self.cl.media_delete(media.id)
 
+    def test_media_link_and_unlink_reel(self):
+        origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
+        target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
+        self.assertIsInstance(origin_path, Path)
+        self.assertIsInstance(target_path, Path)
+        origin = None
+        target = None
+        try:
+            timestamp = int(time.time())
+            target = self.cl.clip_upload(target_path, f"Linked Reel target {timestamp}")
+            self.assertUploadedMediaAccessible(
+                target,
+                media_type=2,
+                product_type="clips",
+                caption_text=f"Linked Reel target {timestamp}",
+            )
+            origin = self.cl.clip_upload(origin_path, f"Linked Reel origin {timestamp}")
+            self.assertUploadedMediaAccessible(
+                origin,
+                media_type=2,
+                product_type="clips",
+                caption_text=f"Linked Reel origin {timestamp}",
+            )
+
+            self.assertTrue(self.cl.media_link_reel(origin.id, target.id, link_name="Watch Next"))
+            self.assertTrue(self.cl.media_unlink_reel(origin.id))
+        finally:
+            for media in (origin, target):
+                if media:
+                    self.cl.media_delete(media.id)
+
     def test_media_edit_igtv(self):
         path = self.make_video_fixture(label="IGTV edit fixture", duration=61)
         self.assertIsInstance(path, Path)

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -230,17 +230,7 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
         except Exception as exc:
             print(f"Linked Reel cleanup media_delete failed: {exc.__class__.__name__} {exc}")
 
-    def assert_linked_media_data_removed(self, media, attempts=6, delay=2):
-        last_payload = None
-        for attempt in range(attempts):
-            if attempt:
-                time.sleep(delay)
-            last_payload = self.uploaded_media_payload(media)
-            if not last_payload.get("linked_media_data"):
-                return
-        self.fail(f"linked_media_data was still present after unlink: {last_payload.get('linked_media_data')}")
-
-    def run_media_link_and_unlink_reel(self, client, origin_path, target_path, origin_cover, target_cover):
+    def run_media_link_reel(self, client, origin_path, target_path, origin_cover, target_cover):
         self.cl = client
         origin = None
         target = None
@@ -262,15 +252,11 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
             )
 
             self.assertTrue(self.cl.media_link_reel(origin.id, target.id, link_name="Watch Next"))
-            linked_payload = self.uploaded_media_payload(origin)
-            self.assertTrue(linked_payload.get("linked_media_data"))
-            self.assertTrue(self.cl.media_unlink_reel(origin.id, target_media_id=target.id))
-            self.assert_linked_media_data_removed(origin)
         finally:
             for media in (origin, target):
                 self.cleanup_uploaded_media(media)
 
-    def test_media_link_and_unlink_reel(self):
+    def test_media_link_reel(self):
         origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
         target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
         origin_cover = self.make_cover_fixture("blue")
@@ -283,7 +269,7 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
         upload_failures = {}
         for client in self.clients:
             try:
-                self.run_media_link_and_unlink_reel(client, origin_path, target_path, origin_cover, target_cover)
+                self.run_media_link_reel(client, origin_path, target_path, origin_cover, target_cover)
                 return
             except (
                 ClipNotUpload,

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -1,4 +1,11 @@
-from instagrapi.exceptions import ClientForbiddenError
+from instagrapi.exceptions import (
+    ClientForbiddenError,
+    ClientThrottledError,
+    ClipNotUpload,
+    LoginRequired,
+    PhotoNotUpload,
+    PleaseWaitFewMinutes,
+)
 from tests import helpers as _helpers
 from tests.helpers import *
 
@@ -189,6 +196,7 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
 class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
     def __init__(self, *args, **kwargs):
         self.cl = None
+        self.clients = []
         return unittest.TestCase.__init__(self, *args, **kwargs)
 
     def setup_method(self, *args, **kwargs):
@@ -198,27 +206,44 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
         if not TEST_ACCOUNTS_URL:
             self.skipTest("TEST_ACCOUNTS_URL is required for linked Reel live tests")
         try:
-            self.cl = _helpers.fresh_test_account(count=50, attempts=20, timeout=30)
+            self.clients = self.fresh_accounts(10)
         except RuntimeError as exc:
             self.skipTest(str(exc))
 
-    def test_media_link_and_unlink_reel(self):
-        origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
-        target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
-        self.assertIsInstance(origin_path, Path)
-        self.assertIsInstance(target_path, Path)
+    def make_cover_fixture(self, color):
+        try:
+            from PIL import Image
+        except ImportError:
+            self.skipTest("Pillow is required to generate a linked Reel cover fixture")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jpg") as tmp:
+            path = Path(tmp.name)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        Image.new("RGB", (720, 1280), color).save(path, quality=95)
+        return path
+
+    def cleanup_uploaded_media(self, media):
+        if not media:
+            return
+        try:
+            self.assertTrue(self.cl.media_delete(media.id))
+        except Exception as exc:
+            print(f"Linked Reel cleanup media_delete failed: {exc.__class__.__name__} {exc}")
+
+    def run_media_link_and_unlink_reel(self, client, origin_path, target_path, origin_cover, target_cover):
+        self.cl = client
         origin = None
         target = None
         try:
             timestamp = int(time.time())
-            target = self.cl.clip_upload(target_path, f"Linked Reel target {timestamp}")
+            target = self.cl.clip_upload(target_path, f"Linked Reel target {timestamp}", thumbnail=target_cover)
             self.assertUploadedMediaAccessible(
                 target,
                 media_type=2,
                 product_type="clips",
                 caption_text=f"Linked Reel target {timestamp}",
             )
-            origin = self.cl.clip_upload(origin_path, f"Linked Reel origin {timestamp}")
+            origin = self.cl.clip_upload(origin_path, f"Linked Reel origin {timestamp}", thumbnail=origin_cover)
             self.assertUploadedMediaAccessible(
                 origin,
                 media_type=2,
@@ -230,8 +255,35 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(self.cl.media_unlink_reel(origin.id))
         finally:
             for media in (origin, target):
-                if media:
-                    self.cl.media_delete(media.id)
+                self.cleanup_uploaded_media(media)
+
+    def test_media_link_and_unlink_reel(self):
+        origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
+        target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
+        origin_cover = self.make_cover_fixture("blue")
+        target_cover = self.make_cover_fixture("red")
+        self.assertIsInstance(origin_path, Path)
+        self.assertIsInstance(target_path, Path)
+        self.assertIsInstance(origin_cover, Path)
+        self.assertIsInstance(target_cover, Path)
+
+        upload_failures = {}
+        for client in self.clients:
+            try:
+                self.run_media_link_and_unlink_reel(client, origin_path, target_path, origin_cover, target_cover)
+                return
+            except (
+                ClipNotUpload,
+                PhotoNotUpload,
+                LoginRequired,
+                PleaseWaitFewMinutes,
+                ClientThrottledError,
+                RetryError,
+            ) as exc:
+                upload_failures[exc.__class__.__name__] = upload_failures.get(exc.__class__.__name__, 0) + 1
+                continue
+
+        self.skipTest(f"No linked Reel upload-capable test account was available (upload_failures={upload_failures})")
 
 
 class ClientCompareExtractTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -114,37 +114,6 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
             if media:
                 self.cl.media_delete(media.id)
 
-    def test_media_link_and_unlink_reel(self):
-        origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
-        target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
-        self.assertIsInstance(origin_path, Path)
-        self.assertIsInstance(target_path, Path)
-        origin = None
-        target = None
-        try:
-            timestamp = int(time.time())
-            target = self.cl.clip_upload(target_path, f"Linked Reel target {timestamp}")
-            self.assertUploadedMediaAccessible(
-                target,
-                media_type=2,
-                product_type="clips",
-                caption_text=f"Linked Reel target {timestamp}",
-            )
-            origin = self.cl.clip_upload(origin_path, f"Linked Reel origin {timestamp}")
-            self.assertUploadedMediaAccessible(
-                origin,
-                media_type=2,
-                product_type="clips",
-                caption_text=f"Linked Reel origin {timestamp}",
-            )
-
-            self.assertTrue(self.cl.media_link_reel(origin.id, target.id, link_name="Watch Next"))
-            self.assertTrue(self.cl.media_unlink_reel(origin.id))
-        finally:
-            for media in (origin, target):
-                if media:
-                    self.cl.media_delete(media.id)
-
     def test_media_edit_igtv(self):
         path = self.make_video_fixture(label="IGTV edit fixture", duration=61)
         self.assertIsInstance(path, Path)
@@ -215,6 +184,54 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
         finally:
             if note and note.get("id"):
                 self.assertTrue(self.cl.media_note_delete(note["id"]))
+
+
+class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for linked Reel live tests")
+        try:
+            self.cl = _helpers.fresh_test_account(count=50, attempts=20, timeout=30)
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def test_media_link_and_unlink_reel(self):
+        origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
+        target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
+        self.assertIsInstance(origin_path, Path)
+        self.assertIsInstance(target_path, Path)
+        origin = None
+        target = None
+        try:
+            timestamp = int(time.time())
+            target = self.cl.clip_upload(target_path, f"Linked Reel target {timestamp}")
+            self.assertUploadedMediaAccessible(
+                target,
+                media_type=2,
+                product_type="clips",
+                caption_text=f"Linked Reel target {timestamp}",
+            )
+            origin = self.cl.clip_upload(origin_path, f"Linked Reel origin {timestamp}")
+            self.assertUploadedMediaAccessible(
+                origin,
+                media_type=2,
+                product_type="clips",
+                caption_text=f"Linked Reel origin {timestamp}",
+            )
+
+            self.assertTrue(self.cl.media_link_reel(origin.id, target.id, link_name="Watch Next"))
+            self.assertTrue(self.cl.media_unlink_reel(origin.id))
+        finally:
+            for media in (origin, target):
+                if media:
+                    self.cl.media_delete(media.id)
 
 
 class ClientCompareExtractTestCase(_helpers.ClientPrivateTestCase):

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -230,7 +230,7 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
         except Exception as exc:
             print(f"Linked Reel cleanup media_delete failed: {exc.__class__.__name__} {exc}")
 
-    def run_media_link_and_unlink_reel(self, client, origin_path, target_path, origin_cover, target_cover):
+    def run_media_link_reel(self, client, origin_path, target_path, origin_cover, target_cover):
         self.cl = client
         origin = None
         target = None
@@ -252,12 +252,11 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
             )
 
             self.assertTrue(self.cl.media_link_reel(origin.id, target.id, link_name="Watch Next"))
-            self.assertTrue(self.cl.media_unlink_reel(origin.id))
         finally:
             for media in (origin, target):
                 self.cleanup_uploaded_media(media)
 
-    def test_media_link_and_unlink_reel(self):
+    def test_media_link_reel(self):
         origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
         target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
         origin_cover = self.make_cover_fixture("blue")
@@ -270,7 +269,7 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
         upload_failures = {}
         for client in self.clients:
             try:
-                self.run_media_link_and_unlink_reel(client, origin_path, target_path, origin_cover, target_cover)
+                self.run_media_link_reel(client, origin_path, target_path, origin_cover, target_cover)
                 return
             except (
                 ClipNotUpload,

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -230,7 +230,17 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
         except Exception as exc:
             print(f"Linked Reel cleanup media_delete failed: {exc.__class__.__name__} {exc}")
 
-    def run_media_link_reel(self, client, origin_path, target_path, origin_cover, target_cover):
+    def assert_linked_media_data_removed(self, media, attempts=6, delay=2):
+        last_payload = None
+        for attempt in range(attempts):
+            if attempt:
+                time.sleep(delay)
+            last_payload = self.uploaded_media_payload(media)
+            if not last_payload.get("linked_media_data"):
+                return
+        self.fail(f"linked_media_data was still present after unlink: {last_payload.get('linked_media_data')}")
+
+    def run_media_link_and_unlink_reel(self, client, origin_path, target_path, origin_cover, target_cover):
         self.cl = client
         origin = None
         target = None
@@ -252,11 +262,15 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
             )
 
             self.assertTrue(self.cl.media_link_reel(origin.id, target.id, link_name="Watch Next"))
+            linked_payload = self.uploaded_media_payload(origin)
+            self.assertTrue(linked_payload.get("linked_media_data"))
+            self.assertTrue(self.cl.media_unlink_reel(origin.id, target_media_id=target.id))
+            self.assert_linked_media_data_removed(origin)
         finally:
             for media in (origin, target):
                 self.cleanup_uploaded_media(media)
 
-    def test_media_link_reel(self):
+    def test_media_link_and_unlink_reel(self):
         origin_path = self.make_video_fixture(label="linked Reel origin fixture", color="blue")
         target_path = self.make_video_fixture(label="linked Reel target fixture", color="red")
         origin_cover = self.make_cover_fixture("blue")
@@ -269,7 +283,7 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
         upload_failures = {}
         for client in self.clients:
             try:
-                self.run_media_link_reel(client, origin_path, target_path, origin_cover, target_cover)
+                self.run_media_link_and_unlink_reel(client, origin_path, target_path, origin_cover, target_cover)
                 return
             except (
                 ClipNotUpload,

--- a/tests/regression/test_helpers.py
+++ b/tests/regression/test_helpers.py
@@ -65,6 +65,40 @@ class LiveAccountHelperRegressionTestCase(unittest.TestCase):
                 with self.assertRaises(helper_module.FreshAccountLoginTimeout):
                     helper_module.client_from_test_account(self._account_payload())
 
+    def test_client_from_test_account_reuses_authorized_session_settings(self):
+        account = self._account_payload()
+        account["client_settings"] = {
+            "authorization_data": {
+                "ds_user_id": "123",
+                "sessionid": "sessionid",
+                "should_use_header_over_cookies": True,
+            },
+        }
+        client = Mock()
+
+        def assert_user_id_set_before_login(**kwargs):
+            self.assertEqual(client._user_id, "123")
+            return True
+
+        client.login.side_effect = assert_user_id_set_before_login
+
+        with mock.patch.dict(helper_module.os.environ, {"IG_PROXY": ""}):
+            with mock.patch.object(helper_module, "Client", return_value=client):
+                result = helper_module.client_from_test_account(account)
+
+        self.assertIs(result, client)
+        client.login.assert_called_once_with(username="fresh.account", password="password", relogin=False)
+
+    def test_client_from_test_account_relogs_without_authorized_session_settings(self):
+        client = Mock()
+
+        with mock.patch.dict(helper_module.os.environ, {"IG_PROXY": ""}):
+            with mock.patch.object(helper_module, "Client", return_value=client):
+                result = helper_module.client_from_test_account(self._account_payload())
+
+        self.assertIs(result, client)
+        client.login.assert_called_once_with(username="fresh.account", password="password", relogin=True)
+
     def test_fresh_test_account_tries_next_account_after_login_timeout(self):
         accounts = [self._account_payload("first.account"), self._account_payload("second.account")]
         client = object()

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -950,23 +950,6 @@ class MediaActionPayloadRegressionTestCase(unittest.TestCase):
         self.assertEqual(endpoint, "media/111_222/edit_media/")
         self.assertEqual(json.loads(data["linked_media_info"])["media_id"], "333_444")
 
-    def test_media_unlink_reel_posts_empty_linked_media_info_object(self):
-        client = self._build_logged_in_client()
-        client._medias_cache = {"111": object()}
-
-        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
-            result = client.media_unlink_reel("111_222")
-
-        self.assertTrue(result)
-        endpoint, data = private_request.call_args.args
-        self.assertEqual(endpoint, "media/111_222/edit_media/")
-        self.assertEqual(data["_uid"], "1")
-        self.assertEqual(data["_uuid"], "uuid")
-        self.assertEqual(data["device_id"], "android-device")
-        self.assertEqual(data["radio_type"], "wifi-none")
-        self.assertEqual(json.loads(data["linked_media_info"]), {})
-        self.assertNotIn("111", client._medias_cache)
-
 
 class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
     def _media_v1_payload(self, pk="1"):

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -950,52 +950,6 @@ class MediaActionPayloadRegressionTestCase(unittest.TestCase):
         self.assertEqual(endpoint, "media/111_222/edit_media/")
         self.assertEqual(json.loads(data["linked_media_info"])["media_id"], "333_444")
 
-    def test_media_unlink_reel_posts_linked_media_delete_graphql_mutation(self):
-        client = self._build_logged_in_client()
-        client._medias_cache = {"111": object()}
-
-        with mock.patch.object(
-            client,
-            "private_graphql_query_request",
-            return_value={"data": {"xig_linked_media_delete": {"status": "ok"}}},
-        ) as graphql_query:
-            result = client.media_unlink_reel("111_222")
-
-        self.assertTrue(result)
-        graphql_query.assert_called_once_with(
-            friendly_name="LinkedMediaDelete",
-            root_field_name="xig_linked_media_delete",
-            variables={"input_data": {"source_media_id": "111_222"}},
-            client_doc_id="8731250647292294617344433924",
-        )
-        self.assertNotIn("111", client._medias_cache)
-
-    def test_media_unlink_reel_normalizes_optional_target_media_id(self):
-        client = self._build_logged_in_client()
-
-        with (
-            mock.patch.object(
-                client,
-                "media_user",
-                side_effect=[
-                    UserShort(pk="222", username="origin", profile_pic_url="https://example.com/origin.jpg"),
-                    UserShort(pk="444", username="target", profile_pic_url="https://example.com/target.jpg"),
-                ],
-            ),
-            mock.patch.object(
-                client,
-                "private_graphql_query_request",
-                return_value={"data": {"xig_linked_media_delete": {"status": "ok"}}},
-            ) as graphql_query,
-        ):
-            self.assertTrue(client.media_unlink_reel("111", target_media_id="333"))
-
-        variables = graphql_query.call_args.kwargs["variables"]
-        self.assertEqual(
-            variables,
-            {"input_data": {"source_media_id": "111_222", "destination_media_id": "333_444"}},
-        )
-
 
 class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
     def _media_v1_payload(self, pk="1"):

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -910,6 +910,63 @@ class MediaActionPayloadRegressionTestCase(unittest.TestCase):
             with_signature=False,
         )
 
+    def test_media_link_reel_posts_linked_media_info(self):
+        client = self._build_logged_in_client()
+        client._medias_cache = {"111": object()}
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.media_link_reel("111_222", "333_444", link_name="Watch Part 1")
+
+        self.assertTrue(result)
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/111_222/edit_media/")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["_uuid"], "uuid")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(
+            json.loads(data["linked_media_info"]),
+            {"media_id": "333_444", "link_name": "Watch Part 1"},
+        )
+        self.assertNotIn("111", client._medias_cache)
+
+    def test_media_link_reel_normalizes_origin_and_target_media_ids(self):
+        client = self._build_logged_in_client()
+
+        with (
+            mock.patch.object(
+                client,
+                "media_user",
+                side_effect=[
+                    UserShort(pk="222", username="origin", profile_pic_url="https://example.com/origin.jpg"),
+                    UserShort(pk="444", username="target", profile_pic_url="https://example.com/target.jpg"),
+                ],
+            ),
+            mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request,
+        ):
+            self.assertTrue(client.media_link_reel("111", "333"))
+
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/111_222/edit_media/")
+        self.assertEqual(json.loads(data["linked_media_info"])["media_id"], "333_444")
+
+    def test_media_unlink_reel_posts_empty_linked_media_info(self):
+        client = self._build_logged_in_client()
+        client._medias_cache = {"111": object()}
+
+        with mock.patch.object(client, "private_request", return_value={"status": "ok"}) as private_request:
+            result = client.media_unlink_reel("111_222")
+
+        self.assertTrue(result)
+        endpoint, data = private_request.call_args.args
+        self.assertEqual(endpoint, "media/111_222/edit_media/")
+        self.assertEqual(data["_uid"], "1")
+        self.assertEqual(data["_uuid"], "uuid")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["radio_type"], "wifi-none")
+        self.assertEqual(data["linked_media_info"], "")
+        self.assertNotIn("111", client._medias_cache)
+
 
 class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
     def _media_v1_payload(self, pk="1"):

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -950,6 +950,52 @@ class MediaActionPayloadRegressionTestCase(unittest.TestCase):
         self.assertEqual(endpoint, "media/111_222/edit_media/")
         self.assertEqual(json.loads(data["linked_media_info"])["media_id"], "333_444")
 
+    def test_media_unlink_reel_posts_linked_media_delete_graphql_mutation(self):
+        client = self._build_logged_in_client()
+        client._medias_cache = {"111": object()}
+
+        with mock.patch.object(
+            client,
+            "private_graphql_query_request",
+            return_value={"data": {"xig_linked_media_delete": {"status": "ok"}}},
+        ) as graphql_query:
+            result = client.media_unlink_reel("111_222")
+
+        self.assertTrue(result)
+        graphql_query.assert_called_once_with(
+            friendly_name="LinkedMediaDelete",
+            root_field_name="xig_linked_media_delete",
+            variables={"input_data": {"source_media_id": "111_222"}},
+            client_doc_id="8731250647292294617344433924",
+        )
+        self.assertNotIn("111", client._medias_cache)
+
+    def test_media_unlink_reel_normalizes_optional_target_media_id(self):
+        client = self._build_logged_in_client()
+
+        with (
+            mock.patch.object(
+                client,
+                "media_user",
+                side_effect=[
+                    UserShort(pk="222", username="origin", profile_pic_url="https://example.com/origin.jpg"),
+                    UserShort(pk="444", username="target", profile_pic_url="https://example.com/target.jpg"),
+                ],
+            ),
+            mock.patch.object(
+                client,
+                "private_graphql_query_request",
+                return_value={"data": {"xig_linked_media_delete": {"status": "ok"}}},
+            ) as graphql_query,
+        ):
+            self.assertTrue(client.media_unlink_reel("111", target_media_id="333"))
+
+        variables = graphql_query.call_args.kwargs["variables"]
+        self.assertEqual(
+            variables,
+            {"input_data": {"source_media_id": "111_222", "destination_media_id": "333_444"}},
+        )
+
 
 class UsertagMediasPaginationRegressionTestCase(unittest.TestCase):
     def _media_v1_payload(self, pk="1"):

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -950,7 +950,7 @@ class MediaActionPayloadRegressionTestCase(unittest.TestCase):
         self.assertEqual(endpoint, "media/111_222/edit_media/")
         self.assertEqual(json.loads(data["linked_media_info"])["media_id"], "333_444")
 
-    def test_media_unlink_reel_posts_empty_linked_media_info(self):
+    def test_media_unlink_reel_posts_empty_linked_media_info_object(self):
         client = self._build_logged_in_client()
         client._medias_cache = {"111": object()}
 
@@ -964,7 +964,7 @@ class MediaActionPayloadRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["_uuid"], "uuid")
         self.assertEqual(data["device_id"], "android-device")
         self.assertEqual(data["radio_type"], "wifi-none")
-        self.assertEqual(data["linked_media_info"], "")
+        self.assertEqual(json.loads(data["linked_media_info"]), {})
         self.assertNotIn("111", client._medias_cache)
 
 


### PR DESCRIPTION
## Summary
- add `media_link_reel(media_id, target_media_id, link_name="Watch Next")`
- send `linked_media_info` through `media/{media_id}/edit_media/` using action data
- document the verified linked Reel helper
- reuse authorized `TEST_ACCOUNTS_URL` sessions in live-test helpers so `sk.test` does not force password+2FA relogin

Closes #2708

## Tests
- `uv run --extra test pytest -q tests/regression/test_media.py`
- `uv run --extra test pytest -q tests/regression/test_helpers.py tests/regression/test_media.py::MediaActionPayloadRegressionTestCase`
- `uv run --extra test ruff check --output-format=github instagrapi/mixins/media.py tests/regression/test_media.py tests/live/test_media.py tests/helpers.py tests/regression/test_helpers.py docs/usage-guide/media.md`
- `uv run --extra test ruff format --check instagrapi/mixins/media.py tests/regression/test_media.py tests/live/test_media.py tests/helpers.py tests/regression/test_helpers.py`
- `uv run --extra test pytest --collect-only -q tests/live/test_media.py::ClientLinkedReelLiveTestCase::test_media_link_reel`
- `ssh sk.test ... pytest -q tests/live/test_media.py::ClientLinkedReelLiveTestCase::test_media_link_reel -s` -> 1 passed in 58.49s
- GitHub checks: pass on `34d630c`

## Notes
- `media_unlink_reel()` is intentionally not included. The proposed clear payload from the issue (`linked_media_info=""`) and a JSON empty object both returned HTTP 400 in live testing, while the link payload passed.
- Android 434 contains a separate `LinkedMediaDelete` GraphQL mutation (`xig_linked_media_delete`, client doc id `8731250647292294617344433924`), but a `sk.test` live probe returned `status: ok` with null mutation data (`1$xig_linked_media_delete(input_data:$input_data): null`) and did not remove `linked_media_data` after polling. The PR only ships the verified link flow.