### PR TITLE
Fix media extraction when video_versions is null

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -55,7 +55,7 @@ def _normalize_media_gql_typename(data):
 def extract_media_v1(data):
     """Extract media from Private API"""
     media = deepcopy(data)
-    if "video_versions" in media:
+    if media.get("video_versions"):
         # Select Best Quality by Resolutiuon
         media["video_url"] = sorted(media["video_versions"], key=lambda o: o["height"] * o["width"])[-1]["url"]
     if media["media_type"] == 2 and not media.get("product_type"):
@@ -222,7 +222,7 @@ def extract_media_inline_comment_gql(data, replied_to_comment_id=None):
 
 def extract_resource_v1(data):
     data = deepcopy(data)
-    if "video_versions" in data:
+    if data.get("video_versions"):
         data["video_url"] = sorted(data["video_versions"], key=lambda o: o["height"] * o["width"])[-1]["url"]
     candidates = data.get("image_versions2", {}).get("candidates", [])
     data["thumbnail_url"] = (
@@ -550,7 +550,7 @@ def extract_direct_message(data):
 
 def extract_direct_media(data):
     media = deepcopy(data)
-    if "video_versions" in media:
+    if media.get("video_versions"):
         # Select Best Quality by Resolutiuon
         media["video_url"] = sorted(media["video_versions"], key=lambda o: o["height"] * o["width"])[-1]["url"]
     if "image_versions2" in media:
@@ -587,7 +587,7 @@ def extract_story_v1(data):
     """Extract story from Private API"""
     story = deepcopy(data)
     story["pk"] = str(story.get("pk"))
-    if "video_versions" in story:
+    if story.get("video_versions"):
         # Select Best Quality by Resolutiuon
         story["video_url"] = sorted(story["video_versions"], key=lambda o: o["height"] * o["width"])[-1]["url"]
     if story["media_type"] == 2 and not story.get("product_type"):

--- a/tests/regression/test_public.py
+++ b/tests/regression/test_public.py
@@ -1,4 +1,9 @@
-from instagrapi.exceptions import ClientForbiddenError, ClientLoginRequired, ClientNotFoundError
+from instagrapi.exceptions import (
+    ClientForbiddenError,
+    ClientLoginRequired,
+    ClientNotFoundError,
+    ClientUnauthorizedError,
+)
 from instagrapi.mixins import public as public_mixin
 from tests.helpers import *
 
@@ -381,6 +386,75 @@ class PublicRegressionTestCase(unittest.TestCase):
         self.assertEqual(media.view_count, 200000)
         self.assertEqual(media.play_count, 210000)
         self.assertFalse(media.has_liked)
+
+    def test_media_info_handles_web_info_payload_with_null_video_versions(self):
+        client = Client()
+        user = {
+            "id": "1713591624",
+            "username": "example",
+            "profile_pic_url": "https://example.com/profile.jpg",
+            "is_private": False,
+        }
+        media_payload = {
+            "pk": "3908029358833535861",
+            "id": "3908029358833535861_1713591624",
+            "code": "DY8G_8JEgt1",
+            "taken_at": 1782608696,
+            "media_type": 8,
+            "user": user,
+            "image_versions2": {
+                "candidates": [
+                    {
+                        "url": "https://example.com/thumbnail.jpg",
+                        "width": 720,
+                        "height": 1280,
+                    }
+                ]
+            },
+            "video_versions": None,
+            "carousel_media": [
+                {
+                    "pk": "3908029358833535862",
+                    "id": "3908029358833535862_1713591624",
+                    "media_type": 1,
+                    "image_versions2": {
+                        "candidates": [
+                            {
+                                "url": "https://example.com/child.jpg",
+                                "width": 720,
+                                "height": 1280,
+                            }
+                        ]
+                    },
+                    "video_versions": None,
+                }
+            ],
+            "caption": {"text": "sidecar"},
+            "comment_count": 0,
+            "like_count": -1,
+            "has_liked": False,
+        }
+
+        with mock.patch.object(
+            client,
+            "public_graphql_request",
+            side_effect=ClientUnauthorizedError("401", response=Mock(status_code=401)),
+        ):
+            with mock.patch.object(
+                client,
+                "public_doc_id_graphql_request",
+                return_value={"xdt_api__v1__media__shortcode__web_info": {"items": [media_payload]}},
+            ):
+                with mock.patch.object(client, "media_info_v1", side_effect=AssertionError("private fallback")):
+                    media = client.media_info("3908029358833535861")
+
+        self.assertEqual(media.pk, "3908029358833535861")
+        self.assertEqual(media.code, "DY8G_8JEgt1")
+        self.assertEqual(media.media_type, 8)
+        self.assertIsNone(media.video_url)
+        self.assertEqual(len(media.resources), 1)
+        self.assertEqual(media.resources[0].media_type, 1)
+        self.assertIsNone(media.resources[0].video_url)
 
     def test_media_info_gql_normalizes_xdt_sidecar_children(self):
         client = Client()


### PR DESCRIPTION
## Summary
- handle `video_versions: null` in media, resource, direct media, and story extractors
- add a public media regression test for current `xdt_api__v1__media__shortcode__web_info` payloads with null video versions

## Notes
- Related to #2713. This fixes the crash/LoginRequired fallback path for null `video_versions`.
- I checked current web bundles/HAR/APK paths and did not find a public anonymous doc_id that restores Reels view/play counts; authenticated private `media/{pk}/info/` remains the verified source for `play_count`.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_public.py::PublicRegressionTestCase::test_media_info_handles_web_info_payload_with_null_video_versions tests/regression/test_public.py::PublicRegressionTestCase::test_media_info_gql_extracts_current_web_info_payload tests/regression/test_media.py::MediaInfoV2RegressionTestCase::test_extract_media_v1_normalizes_video_view_count`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_public.py tests/regression/test_media.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/ruff check instagrapi/extractors.py tests/regression/test_public.py`
- `git diff --check`