### PR TITLE
Expose Threads badge user fields

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -71,6 +71,8 @@ class User(TypesBaseModel):
     biography: Optional[str] = ""
     bio_links: List[BioLink] = []
     external_url: Optional[str] = None
+    show_text_post_app_badge: Optional[bool] = None
+    text_post_app_badge_label: Optional[str] = None
     account_type: Optional[int] = None
     is_business: bool
 

--- a/tests/regression/test_user.py
+++ b/tests/regression/test_user.py
@@ -1,5 +1,5 @@
 from instagrapi import types as ig_types
-from instagrapi.extractors import extract_user_short, extract_user_v1
+from instagrapi.extractors import extract_user_gql, extract_user_short, extract_user_v1
 from instagrapi.mixins.public import PUBLIC_WEB_APP_ID, PUBLIC_WEB_ASBD_ID
 from instagrapi.mixins.user import (
     MAX_USER_COUNT,
@@ -103,6 +103,40 @@ class UserMixinRegressionTestCase(unittest.TestCase):
 
         self.assertEqual(user.public_email, "public@example.com")
         self.assertEqual(user.contact_phone_number, "+15551234567")
+
+    def test_extract_user_v1_preserves_threads_badge_fields(self):
+        payload = {
+            "pk": "123",
+            "username": "creator",
+            "full_name": "Creator",
+            "is_private": False,
+            "profile_pic_url": "https://example.com/pic.jpg",
+            "is_verified": False,
+            "media_count": 0,
+            "follower_count": 0,
+            "following_count": 0,
+            "is_business": False,
+            "show_text_post_app_badge": True,
+            "text_post_app_badge_label": "creator_threads",
+        }
+
+        user = extract_user_v1(payload)
+
+        self.assertTrue(user.show_text_post_app_badge)
+        self.assertEqual(user.text_post_app_badge_label, "creator_threads")
+
+    def test_extract_user_gql_preserves_threads_badge_fields(self):
+        payload = self.build_web_profile_user(
+            username="creator",
+            full_name="Creator",
+            show_text_post_app_badge=True,
+            text_post_app_badge_label="creator_threads",
+        )["data"]["user"]
+
+        user = extract_user_gql(payload)
+
+        self.assertTrue(user.show_text_post_app_badge)
+        self.assertEqual(user.text_post_app_badge_label, "creator_threads")
 
     def test_extract_user_short_preserves_follower_payload_fields(self):
         payload = {


### PR DESCRIPTION
## Summary
- mirror aiograpi#401 by exposing Instagram profile Threads badge fields on `User`
- preserve `show_text_post_app_badge` and `text_post_app_badge_label` from private v1 and public GraphQL user payloads
- add regression coverage for both extractor paths

## Verification
- RED: new tests failed before the model fields were added with `AttributeError: User object has no attribute show_text_post_app_badge`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_user.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/ruff check instagrapi/types.py tests/regression/test_user.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression`
- private live smoke verified `user_info_by_username_v1` returns `show_text_post_app_badge=True` and `text_post_app_badge_label` for a public profile with a Threads badge

Mirror for subzeroid/aiograpi#397.