### PR TITLE
Keep FBNS connected on read timeout

### DIFF
--- a/instagrapi/realtime/fbns.py
+++ b/instagrapi/realtime/fbns.py
@@ -312,6 +312,8 @@ class FbnsClient:
     def _recv_packet(self) -> bytes:
         try:
             return self.transport.recv_packet()
+        except TimeoutError:
+            raise
         except Exception:
             self.connected = False
             raise

--- a/tests/regression/test_fbns.py
+++ b/tests/regression/test_fbns.py
@@ -257,6 +257,23 @@ def test_fbns_read_once_marks_client_disconnected_when_socket_closes():
     assert not fbns.connected
 
 
+def test_fbns_read_once_keeps_client_connected_on_socket_timeout():
+    client = _build_logged_in_client()
+    transport = mock.Mock()
+    transport.recv_packet.side_effect = TimeoutError("timed out")
+    fbns = FbnsClient(client, transport=transport)
+    fbns.connected = True
+
+    try:
+        fbns.read_once()
+    except TimeoutError:
+        pass
+    else:
+        raise AssertionError("read_once should raise when the transport read times out")
+
+    assert fbns.connected
+
+
 def test_fbns_disconnect_clears_client_state_after_broken_socket():
     client = _build_logged_in_client()
     transport = mock.Mock()


### PR DESCRIPTION
## What

- Keep `FbnsClient.connected` true when a read attempt raises `TimeoutError`.
- Preserve the existing behavior where closed sockets / transport failures mark FBNS disconnected.
- Add regression coverage for the timeout path.

## Why

A read timeout means no MQTT packet arrived before the socket timeout; it does not prove the socket is closed. The previous cleanup fix treated every `_recv_packet()` exception as fatal.

## Verification

- RED: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_fbns.py::test_fbns_read_once_keeps_client_connected_on_socket_timeout` failed before the fix with `fbns.connected` false.
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/ruff check instagrapi/realtime/fbns.py tests/regression/test_fbns.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression/test_fbns.py`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -q tests/regression`

Mirror of subzeroid/aiograpi#403 / subzeroid/aiograpi#402.