### PR TITLE
fix: preserve recovery bad password during login

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -517,6 +517,20 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             return value.strip().lower() in {"1", "true", "yes"}
         return False
 
+    def _login_response_requires_recovery(self, data: Dict) -> bool:
+        values = [self._find_login_response_value(data, key) for key in ("message", "error_title", "error_body")]
+        text = " ".join(value.lower() for value in values if isinstance(value, str))
+        return any(
+            marker in text
+            for marker in (
+                "linked facebook account",
+                "forgotten password",
+                "forgot password",
+                "send you an email",
+                "get back into your account",
+            )
+        )
+
     def _normalize_backup_code(self, code: str) -> str:
         return re.sub(r"[\s-]+", "", str(code).strip())
 
@@ -777,6 +791,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                     response=getattr(exc, "response", None),
                     **self._exception_context(login_json),
                 ) from exc
+            if not context and self._login_response_requires_recovery(login_json):
+                raise
             if context:
                 logged = self._login_with_bloks_two_factor(verification_code, login_json, exc)
             else:

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -347,6 +347,28 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
         client.login_flow.assert_called_once_with()
 
+    def test_login_bad_password_recovery_response_does_not_try_caa_bloks(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {
+            "message": "You can log in with your linked Facebook account.",
+            "error_title": "Forgotten password for example?",
+            "error_type": "bad_password",
+        }
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        client.bloks_caa_login_send_request = Mock(
+            side_effect=AssertionError("recovery bad_password responses are not CAA two-factor challenges")
+        )
+
+        with self.assertRaises(BadPassword):
+            client.login(verification_code="654321")
+
+        client.bloks_caa_login_send_request.assert_not_called()
+
     def test_login_with_eight_digit_backup_code_selects_backup_code_bloks_challenge(self):
         client = Client()
         client.username = "example"


### PR DESCRIPTION
## Summary
- Preserve account-recovery `BadPassword` responses during username/password login instead of treating them as CAA/Bloks two-factor challenges.
- Avoid masking recovery or linked-Facebook login responses with a secondary `ClientNotFoundError` from `bloks_caa_login_send_request`.
- Add regression coverage for the linked-Facebook recovery response while keeping the existing CAA/Bloks two-factor fallback path covered.

Refs #2723.

## Test Coverage
All new code paths have regression coverage:
- recovery-style `BadPassword` response keeps the original `BadPassword` and does not call CAA/Bloks
- existing non-recovery `BadPassword` path still exercises the CAA/Bloks context fallback

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed, design review skipped.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN

Intent: fix the misleading login fallback reported in #2723.
Delivered: preserves recovery `BadPassword` responses and adds focused regression coverage.

## Plan Completion
No plan file detected.

## Test plan
- [x] `.venv/bin/python -m pytest tests/regression/test_auth_story.py tests/regression/test_bloks.py -q` — 53 passed
- [x] `.venv/bin/python -m ruff check instagrapi/mixins/auth.py tests/regression/test_auth_story.py` — passed
- [x] `git diff --check` — passed
- [x] `.venv/bin/python -m pytest tests/regression -q` — 659 passed, 3 skipped
