### PR TITLE
fix: accept signup age eligibility register flag

### DIFF
--- a/instagrapi/mixins/signup.py
+++ b/instagrapi/mixins/signup.py
@@ -711,7 +711,9 @@ class SignUpMixin:
             # Date of Birth (DOB) Age Eligibility Check
             if year and month and day:
                 age_check_result = self.check_age_eligibility(year, month, day)
-                if not age_check_result.get("eligible"):  # Assuming "eligible": True is success
+                # IG returns "eligible_to_register"; keep "eligible" as a fallback
+                eligible = age_check_result.get("eligible_to_register", age_check_result.get("eligible"))
+                if not eligible:
                     raise AgeEligibilityError(f"Account not eligible based on age criteria: {age_check_result}")
 
             # send code confirmation

--- a/tests/regression/test_signup.py
+++ b/tests/regression/test_signup.py
@@ -227,6 +227,41 @@ class SignupHelperRegressionTestCase(unittest.TestCase):
                         day=9,
                     )
 
+    def test_signup_accepts_age_eligibility_to_register_response(self):
+        client = Client()
+        client.wait_seconds = 0
+        client.challenge_code_handler = mock.Mock(return_value="123456")
+        client.get_signup_config = mock.Mock(return_value={"status": "ok"})
+        client.check_email = mock.Mock(return_value={"valid": True, "available": True})
+        client.send_verify_email = mock.Mock(return_value={"email_sent": True})
+        client.check_age_eligibility = mock.Mock(return_value={"eligible_to_register": True})
+        client.check_confirmation_code = mock.Mock(return_value={"signup_code": "signup-code"})
+        client.accounts_create = mock.Mock(
+            return_value={
+                "created_user": {
+                    "pk": "123",
+                    "username": "example",
+                    "full_name": "Example User",
+                    "profile_pic_url": "https://example.com/avatar.jpg",
+                }
+            }
+        )
+
+        user = client.signup(
+            username="example",
+            password="password",
+            email="addr@example.com",
+            full_name="Example User",
+            year=1995,
+            month=6,
+            day=9,
+        )
+
+        self.assertIsInstance(user, UserShort)
+        self.assertEqual(user.pk, "123")
+        client.check_age_eligibility.assert_called_once_with(1995, 6, 9)
+        client.accounts_create.assert_called_once()
+
     def test_check_username_posts_uuid_payload(self):
         client = Client()
         client.uuid = "uuid"


### PR DESCRIPTION
## Summary
- mirror the aiograpi signup age eligibility fix into instagrapi
- accept Instagram's `eligible_to_register` response key while keeping `eligible` as a fallback
- add a regression test for the legacy email signup path

## Verification
- RED: `pytest tests/regression/test_signup.py::SignupHelperRegressionTestCase::test_signup_accepts_age_eligibility_to_register_response -q` failed with `AgeEligibilityError` before the fix
- GREEN: same target passed after the fix
- `pytest tests/regression/test_signup.py -q` -> 27 passed, 3 skipped, 1 warning, 2 subtests passed
- `ruff check instagrapi/mixins/signup.py tests/regression/test_signup.py` -> passed
- `pytest tests/regression -q` -> 660 passed, 3 skipped, 33 warnings, 22 subtests passed
- live account smoke on 3 existing session accounts -> 3/3 PASS (`account_info`, `get_timeline_feed`, `login_by_sessionid`)

## Live Notes
- I did not run destructive live account signup.
- A direct DOB eligibility endpoint probe from an existing session returned `ClientForbiddenError`, so the PR relies on the captured aiograpi response shape plus regression coverage for this specific key.
- Sanitized live report: `/tmp/instagrapi_signup_age_account_live_smoke_sanitized.json`
