### PR TITLE
fix: wrap unavailable CAA Bloks login endpoint

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -546,6 +546,13 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             return "sms"
         return "totp"
 
+    def _is_unavailable_caa_bloks_login_error(self, exc: ClientError) -> bool:
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None) or getattr(exc, "code", None)
+        error_type = str(getattr(exc, "error_type", "") or "").casefold()
+        message = str(getattr(exc, "message", "") or exc).casefold()
+        return status_code == 404 or (error_type == "field_exception" and "payload returned is null" in message)
+
     def _login_with_bloks_two_factor(self, verification_code: str, login_json: Dict, exc: Exception) -> bool:
         context = self._extract_two_step_verification_context(login_json)
         if not context:
@@ -584,7 +591,23 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         ) from exc
 
     def _login_with_caa_bloks_two_factor(self, verification_code: str, password: str, exc: Exception) -> bool:
-        caa_result = self.bloks_caa_login_send_request(password, login_attempt_count=1)
+        try:
+            caa_result = self.bloks_caa_login_send_request(password, login_attempt_count=1)
+        except ClientError as caa_exc:
+            if not self._is_unavailable_caa_bloks_login_error(caa_exc):
+                raise
+            login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
+            raise TwoFactorRequired(
+                "Instagram rejected the legacy login endpoint and the current "
+                "CAA/Bloks login endpoint is unavailable for this account/session. "
+                "Complete verification in the official Instagram app or web flow "
+                "on a trusted device, then retry with the same saved client "
+                "settings, device identifiers, and proxy/IP. If this persists, "
+                "capture a fresh CAA login flow because Instagram may require "
+                "additional Bloks preflight steps before send_login_request.",
+                response=getattr(caa_exc, "response", getattr(exc, "response", None)),
+                **self._exception_context(login_json),
+            ) from caa_exc
         context = self.bloks_extract_two_step_verification_context(caa_result)
         login_json = deepcopy(self.last_json) if isinstance(self.last_json, dict) else {}
         if not context:

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -457,7 +457,9 @@ class BloksMixin:
         contact_point = username or self.username
         encrypted_password = password if password.startswith("#PWD_") else self.password_encrypt(password)
         flow_id = waterfall_id or str(uuid4())
-        text_input_id = flow_id[:8]
+        # Recent CAA login screens emit short base36-like input ids. Hex-only
+        # UUID prefixes are accepted by the VM but can return a null-payload 404.
+        text_input_id = f"{uuid4().hex[:4]}ig"
         params = {
             "client_input_params": {
                 "blocked_uids": [],
@@ -525,12 +527,12 @@ class BloksMixin:
                 "offline_experiment_group": offline_experiment_group,
                 "is_from_landing_page": 0,
                 "left_nav_button_action": "NONE",
-                "password_text_input_id": f"{text_input_id}:105",
+                "password_text_input_id": f"{text_input_id}:82",
                 "is_from_empty_password": 0,  # nosec B105
                 "is_from_msplit_fallback": 0,
                 "ar_event_source": "login_home_page",
                 "qe_device_id": self.uuid,
-                "username_text_input_id": f"{text_input_id}:104",
+                "username_text_input_id": f"{text_input_id}:81",
                 "layered_homepage_experiment_group": "Deploy: Not in Experiment",
                 "device_id": self.android_device_id,
                 "login_surface": "login_home",

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -1,4 +1,4 @@
-from instagrapi.exceptions import BadPassword
+from instagrapi.exceptions import BadPassword, ClientNotFoundError
 from tests.helpers import *
 
 
@@ -422,6 +422,36 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
             client.login(verification_code="654321")
 
         self.assertIn("CAA response did not include two_step_verification_context", str(cm.exception))
+        client.bloks_caa_login_send_request.assert_called_once_with("password", login_attempt_count=1)
+        client.bloks_two_step_verification_verify_code.assert_not_called()
+
+    def test_login_bad_password_without_context_wraps_unavailable_caa_bloks_endpoint(self):
+        client = Client()
+        client.username = "example"
+        client.password = "password"
+        client.authorization_data = {}
+        client.last_json = {
+            "message": "Payload returned is null. A server error field_exception occured.",
+            "error_type": "field_exception",
+            "status": "fail",
+        }
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
+        caa_error = ClientNotFoundError(
+            "Payload returned is null. A server error field_exception occured.",
+            response=Mock(status_code=404),
+            error_type="field_exception",
+            status="fail",
+        )
+        client.bloks_caa_login_send_request = Mock(side_effect=caa_error)
+        client.bloks_two_step_verification_verify_code = Mock()
+
+        with self.assertRaises(TwoFactorRequired) as cm:
+            client.login(verification_code="654321")
+
+        self.assertIn("CAA/Bloks login endpoint", str(cm.exception))
+        self.assertIs(cm.exception.__cause__, caa_error)
         client.bloks_caa_login_send_request.assert_called_once_with("password", login_attempt_count=1)
         client.bloks_two_step_verification_verify_code.assert_not_called()
 

--- a/tests/regression/test_bloks.py
+++ b/tests/regression/test_bloks.py
@@ -394,6 +394,10 @@ class BloksRegressionTestCase(unittest.TestCase):
         self.assertEqual(params["server_params"]["credential_type"], "password")
         self.assertEqual(params["server_params"]["family_device_id"], "family-device-1")
         self.assertEqual(params["server_params"]["device_id"], "android-1")
+        username_text_input_id = params["server_params"]["username_text_input_id"]
+        password_text_input_id = params["server_params"]["password_text_input_id"]
+        self.assertRegex(username_text_input_id, r"^[a-z0-9]{6}:81$")
+        self.assertEqual(password_text_input_id, f"{username_text_input_id.rsplit(':', 1)[0]}:82")
         self.assertIn("waterfall_id", params["server_params"])
 
     def test_bloks_extract_two_step_verification_context_from_caa_action(self):


### PR DESCRIPTION
## Summary
- Align CAA/Bloks login text input IDs with the current app flow (`<6 chars>:81` / `<6 chars>:82`) so `send_login_request` no longer returns the null-payload 404 for the helper payload.
- Wrap unavailable CAA/Bloks login endpoint failures during the BadPassword fallback as `TwoFactorRequired` instead of leaking low-level `ClientNotFoundError`.
- Preserve the original exception chain and stop before Bloks 2FA verification when the CAA context cannot be obtained.
- Add regression coverage for both the updated CAA payload shape and the `404 + field_exception + Payload returned is null` fallback path reported in #2725.

## Context
Refs #2725.

Fresh v434 login HAR metadata shows successful CAA login flows use `username_text_input_id=<6 chars>:81` and `password_text_input_id=<6 chars>:82`. Live probes on this branch confirm the old helper payload returned `ClientNotFoundError`/404, while the updated payload returns `status=ok` for `com.bloks.www.bloks.caa.login.async.send_login_request`.

The PR still keeps the defensive wrapper because Instagram can return the same null-payload 404 for unsupported account/session states. Full automatic completion of every flagged-account CAA flow still depends on getting a real account state that returns `two_step_verification_context`.

## Live Account Smoke
- Parsed the freshest local account file (`09-06-26_02-29-01-f516aec435b10cb570b50db0ce002097.txt`) without printing credentials: 500 full rows with parseable session/auth and UUIDs.
- Checked 10 fresh candidates; 2 saved-session accounts were usable.
- On usable saved sessions, `account_info()` and `user_info_by_username_v1("instagram")` passed.
- PR-specific live probe with synthetic username/fake password:
  - old helper payload reproduced the CAA null-payload 404;
  - updated helper payload returned `status=ok` on both default client settings and saved account settings;
  - the fallback path wraps a live CAA `ClientNotFoundError` as `TwoFactorRequired`.

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed; design review skipped.

## Eval Results
No prompt-related files changed; evals skipped.

## Plan Completion
No plan file detected.

## Test plan
- [x] Live saved-session smoke on local test accounts
- [x] Live CAA helper route probe with synthetic username/fake password
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m ruff format --check .`
- [x] `.venv/bin/python -m pytest tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase::test_login_bad_password_without_context_wraps_unavailable_caa_bloks_endpoint -q`
- [x] `.venv/bin/python -m pytest tests/regression/test_bloks.py::BloksRegressionTestCase::test_bloks_caa_login_send_request_uses_current_payload -q`
- [x] `.venv/bin/python -m pytest tests/regression/test_auth_story.py tests/regression/test_bloks.py -q`
- [x] `.venv/bin/python -m pytest tests/regression -q` (`661 passed, 3 skipped`)
