### PR TITLE
feat: add QuickSnap support

### DIFF
--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -36,6 +36,7 @@ from instagrapi.mixins.public import (
     PublicRequestMixin,
     TopSearchesPublicMixin,
 )
+from instagrapi.mixins.quicksnap import QuickSnapMixin
 from instagrapi.mixins.realtime import RealtimeMixin
 from instagrapi.mixins.share import ShareMixin
 from instagrapi.mixins.signup import SignUpMixin
@@ -94,6 +95,7 @@ class Client(
     TOTPMixin,
     MultipleAccountsMixin,
     NoteMixin,
+    QuickSnapMixin,
     FundraiserMixin,
     RealtimeMixin,
 ):

--- a/instagrapi/mixins/quicksnap.py
+++ b/instagrapi/mixins/quicksnap.py
@@ -1,0 +1,129 @@
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+from instagrapi.exceptions import ClientGraphqlError
+
+QUICKSNAP_HISTORY_CLIENT_DOC_ID = "202528380816979569862257718136"
+QUICKSNAP_HISTORY_FRIENDLY_NAME = "IGQuickSnapGetHistoryPaginatedQuery"
+QUICKSNAP_CLIENT_ENDPOINT = "InsightsHostImpl:quick_snap_audience_picker"
+
+
+class QuickSnapMixin:
+    @staticmethod
+    def _quick_snap_history_from_graphql_result(result: Dict) -> Dict:
+        viewer = (result.get("data") or {}).get("viewer") or {}
+        for key, value in viewer.items():
+            if "quick_snap_paginated_history" in key and isinstance(value, dict):
+                return value
+        raise ClientGraphqlError("Failed to retrieve QuickSnap history")
+
+    @staticmethod
+    def _quick_snap_nav_chain() -> str:
+        timestamp = time.time()
+        return (
+            f"DirectInboxFragment:direct_inbox:2:main_direct:{timestamp - 55:.3f}:::{timestamp - 55:.3f},"
+            f"QuickSnapUnifiedFragment:quicksnap_unified_fragment:3:button:{timestamp - 20:.3f}:::{timestamp - 20:.3f},"
+            f"ConstAnalyticsModule:quick_snap_camera:4:button:{timestamp - 19:.3f}:::{timestamp - 19:.3f},"
+            f"{QUICKSNAP_CLIENT_ENDPOINT}:6:button:{timestamp - 5:.3f}:::{timestamp - 5:.3f}"
+        )
+
+    def quicksnap_history(self, amount: int = 20, end_cursor: Optional[str] = None) -> Dict:
+        """
+        Retrieve paginated QuickSnap history.
+
+        Parameters
+        ----------
+        amount: int, optional
+            Number of QuickSnap history items to fetch.
+        end_cursor: str, optional
+            Cursor from the previous response ``page_info.end_cursor``.
+
+        Returns
+        -------
+        Dict
+            Raw ``quick_snap_paginated_history`` payload with ``edges`` and ``page_info``.
+        """
+        assert self.user_id, "Login required"
+        variables = {"first": amount}
+        if end_cursor:
+            variables["after"] = end_cursor
+        result = self.private_graphql_www_request(
+            friendly_name=QUICKSNAP_HISTORY_FRIENDLY_NAME,
+            variables=variables,
+            client_doc_id=QUICKSNAP_HISTORY_CLIENT_DOC_ID,
+        )
+        return self._quick_snap_history_from_graphql_result(result)
+
+    def quicksnap_send(self, photo_path: Path, audience: str = "mutual_followers", upload_id: str = "") -> Dict:
+        """
+        Upload and publish a photo as a QuickSnap.
+
+        Parameters
+        ----------
+        photo_path: Path
+            Path to a photo file.
+        audience: str, optional
+            QuickSnap audience value, default ``mutual_followers``.
+        upload_id: str, optional
+            Upload id to reuse. Generated when omitted.
+
+        Returns
+        -------
+        Dict
+            Raw ``media/configure_to_quick_snap/`` response.
+        """
+        assert self.user_id, "Login required"
+        photo_path = Path(photo_path)
+        upload_id, _, _ = self.photo_rupload(photo_path, upload_id) if upload_id else self.photo_rupload(photo_path)
+        nav_chain = self._quick_snap_nav_chain()
+        data = {
+            "original_height": "0",
+            "original_width": "0",
+            "include_e2ee_mentioned_user_list": "1",
+            "hide_from_profile_grid": "false",
+            "timezone_offset": str(self.timezone_offset),
+            "source_type": "3",
+            "_uid": str(self.user_id),
+            "async_publish": "1",
+            "device_id": self.android_device_id,
+            "_uuid": self.uuid,
+            "nav_chain": nav_chain,
+            "audience": audience,
+            "upload_id": upload_id,
+            "bottom_camera_dial_selected": "11",
+            "publish_id": "1",
+            "product_type": "quick_snap",
+            "device": self.device,
+            "quick_snap_data": {},
+        }
+        return self.private_request(
+            "media/configure_to_quick_snap/",
+            self.with_default_data(data),
+            headers={
+                "X-IG-Client-Endpoint": QUICKSNAP_CLIENT_ENDPOINT,
+                "X-IG-Nav-Chain": nav_chain,
+            },
+        )
+
+    def quicksnap_delete(self, media_id: str) -> bool:
+        """
+        Soft-delete an active QuickSnap.
+
+        Parameters
+        ----------
+        media_id: str
+            QuickSnap media id.
+
+        Returns
+        -------
+        bool
+            ``True`` when Instagram confirms deletion.
+        """
+        assert self.user_id, "Login required"
+        media_id = str(media_id)
+        result = self.private_request(
+            f"media/{media_id}/soft_delete/",
+            {"media_id": media_id, "_uuid": self.uuid},
+        )
+        return result.get("did_delete") is True

--- a/tests/live/test_quicksnap.py
+++ b/tests/live/test_quicksnap.py
@@ -1,0 +1,63 @@
+from tests import helpers as _helpers
+from tests.helpers import *
+
+
+class ClientQuickSnapLiveTestCase(_helpers.ClientPrivateTestCase):
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for QuickSnap live tests")
+        try:
+            self.cl = _helpers.fresh_test_account(count=50, attempts=20, timeout=30)
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    @staticmethod
+    def quicksnap_media_id(result):
+        for post in result.get("posts") or []:
+            media_ids = post.get("media_ids") or []
+            if media_ids:
+                return str(media_ids[0])
+            if post.get("id"):
+                return str(post["id"])
+        for item in result.get("medias") or []:
+            media = item.get("media_dict") or {}
+            if media.get("id"):
+                return str(media["id"])
+            if media.get("pk"):
+                return str(media["pk"])
+        return None
+
+    @staticmethod
+    def quicksnap_media_dict(result):
+        for item in result.get("medias") or []:
+            media = item.get("media_dict") or {}
+            if media:
+                return media
+        return {}
+
+    def test_quicksnap_history_send_and_delete(self):
+        history = self.cl.quicksnap_history(amount=20)
+        self.assertIsInstance(history.get("edges"), list)
+        self.assertIsInstance(history.get("page_info"), dict)
+
+        media_id = None
+        try:
+            result = self.cl.quicksnap_send(Path("examples/kanada.jpg"))
+            self.assertEqual(result.get("status"), "ok")
+            media_id = self.quicksnap_media_id(result)
+            self.assertTrue(media_id, "QuickSnap configure response did not include a media id")
+
+            media = self.quicksnap_media_dict(result)
+            self.assertEqual(media.get("product_type"), "quick_snap")
+            self.assertEqual(media.get("audience"), "mutual_followers")
+            self.assertTrue(media.get("expiring_at"))
+        finally:
+            if media_id:
+                self.assertTrue(self.cl.quicksnap_delete(media_id))

--- a/tests/regression/test_quicksnap.py
+++ b/tests/regression/test_quicksnap.py
@@ -1,0 +1,96 @@
+from tests.helpers import *
+
+
+class QuickSnapRegressionTestCase(unittest.TestCase):
+    def build_client(self):
+        client = Client()
+        client.private.cookies.set("ds_user_id", "123")
+        client.uuid = "uuid-1"
+        client.android_device_id = "android-device"
+        client.timezone_offset = 19800
+        client.set_device(
+            {
+                "manufacturer": "vivo",
+                "model": "vivo 1819",
+                "android_version": 30,
+                "android_release": "11",
+            }
+        )
+        client.with_default_data = lambda data: data
+        return client
+
+    def test_quicksnap_history_returns_paginated_history_payload(self):
+        client = self.build_client()
+        history = {"edges": [{"node": {"id": "media-1"}}], "page_info": {"has_next_page": False}}
+        graphql_response = {
+            "data": {
+                "viewer": {
+                    "__typename": "XDTUser",
+                    "1$quick_snap_paginated_history(after:$after,first:$first)": history,
+                }
+            }
+        }
+
+        with mock.patch.object(client, "private_graphql_www_request", return_value=graphql_response) as graphql:
+            result = client.quicksnap_history(amount=20, end_cursor="cursor-1")
+
+        graphql.assert_called_once_with(
+            friendly_name="IGQuickSnapGetHistoryPaginatedQuery",
+            variables={"first": 20, "after": "cursor-1"},
+            client_doc_id="202528380816979569862257718136",
+        )
+        self.assertEqual(result, history)
+
+    def test_quicksnap_send_uploads_photo_and_configures_quick_snap(self):
+        client = self.build_client()
+        configure_response = {
+            "status": "ok",
+            "posts": [{"media_ids": ["3931708346854699261"]}],
+            "medias": [
+                {
+                    "media_dict": {
+                        "product_type": "quick_snap",
+                        "audience": "mutual_followers",
+                    }
+                }
+            ],
+        }
+
+        with (
+            mock.patch.object(client, "photo_rupload", return_value=("upload-1", 984, 984)) as rupload,
+            mock.patch.object(client, "private_request", return_value=configure_response) as private_request,
+        ):
+            result = client.quicksnap_send(Path("snap.jpg"))
+
+        rupload.assert_called_once_with(Path("snap.jpg"))
+        private_request.assert_called_once()
+        self.assertEqual(private_request.call_args.args[0], "media/configure_to_quick_snap/")
+        data = private_request.call_args.args[1]
+        self.assertEqual(data["upload_id"], "upload-1")
+        self.assertEqual(data["audience"], "mutual_followers")
+        self.assertEqual(data["source_type"], "3")
+        self.assertEqual(data["bottom_camera_dial_selected"], "11")
+        self.assertEqual(data["publish_id"], "1")
+        self.assertEqual(data["product_type"], "quick_snap")
+        self.assertEqual(data["_uid"], "123")
+        self.assertEqual(data["_uuid"], "uuid-1")
+        self.assertEqual(data["device_id"], "android-device")
+        self.assertEqual(data["timezone_offset"], "19800")
+        self.assertEqual(data["device"]["manufacturer"], "vivo")
+        self.assertEqual(data["device"]["model"], "vivo 1819")
+        self.assertEqual(data["quick_snap_data"], {})
+        self.assertIn("QuickSnapUnifiedFragment:quicksnap_unified_fragment", data["nav_chain"])
+        self.assertIn("InsightsHostImpl:quick_snap_audience_picker", data["nav_chain"])
+        self.assertEqual(result, configure_response)
+
+    def test_quicksnap_delete_soft_deletes_media(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "private_request", return_value={"did_delete": True, "status": "ok"}) as request:
+            result = client.quicksnap_delete("3931708346854699261_123")
+
+        request.assert_called_once_with(
+            "media/3931708346854699261_123/soft_delete/",
+            {"media_id": "3931708346854699261_123", "_uuid": "uuid-1"},
+        )
+        self.assertTrue(result)


### PR DESCRIPTION
## Summary
- add a `QuickSnapMixin` with `quicksnap_history()`, `quicksnap_send()`, and `quicksnap_delete()`
- use the mobile `graphql_www` QuickSnap history query and `media/configure_to_quick_snap/` upload configure endpoint
- add regression coverage for history extraction, configure payload, and soft-delete
- add a committed live lifecycle test for history -> send -> delete

Closes #2709

## Live verification
- authenticated QuickSnap history query returned the expected paginated `edges` / `page_info` structure
- `quicksnap_send()` uploaded a photo and returned `product_type=quick_snap`, `audience=mutual_followers`, and an expiration timestamp
- `quicksnap_delete()` soft-deleted the uploaded QuickSnap successfully

## Tests
- `python -m pytest -q tests/live/test_quicksnap.py` -> 1 passed
- `python -m pytest -q tests/regression/test_quicksnap.py` -> 3 passed
- `python -m pytest -q tests/regression` -> 664 passed, 3 skipped, 22 subtests passed
- `ruff check`
- `ruff format --check`
- `python -m build`
