### PR TITLE
fix: clarify bad password login context

### DIFF
--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -54,6 +54,10 @@ _DIRECT_MESSAGE_REQUESTS_DISABLED_MARKERS = (
 )
 
 _ACCOUNT_CONTACT_POINT_REQUIRED_MARKERS = ("need an email or confirmed phone number",)
+_LOGIN_CONTEXT_REJECTION_HINT = (
+    "This can also happen when Instagram rejects the proxy/IP, device fingerprint, "
+    "or login context, even if the password is correct."
+)
 
 
 def _private_message_text(message) -> str:
@@ -529,15 +533,14 @@ class PrivateRequestMixin:
                 elif error_type == "rate_limit_error":
                     raise RateLimitError(**last_json)
                 elif error_type == "bad_password":
-                    msg = last_json.get("message", "").strip()
-                    if msg:
-                        if not msg.endswith("."):
-                            msg = "%s." % msg
-                        msg = "%s " % msg
-                    last_json["message"] = (
-                        "%sIf you are sure that the password is correct, then change your IP address, "
-                        "because it is added to the blacklist of the Instagram Server"
-                    ) % msg
+                    last_json["message"] = " ".join(
+                        part
+                        for part in (
+                            last_json.get("message") or "Instagram rejected the login credentials.",
+                            _LOGIN_CONTEXT_REJECTION_HINT,
+                        )
+                        if part
+                    )
                     raise BadPassword(**last_json)
                 elif error_type == "two_factor_required":
                     if not last_json["message"]:

--- a/tests/regression/test_hardening.py
+++ b/tests/regression/test_hardening.py
@@ -1,4 +1,9 @@
-from instagrapi.exceptions import AccountContactPointRequired, AccountEditError, DirectMessageRequestsDisabled
+from instagrapi.exceptions import (
+    AccountContactPointRequired,
+    AccountEditError,
+    BadPassword,
+    DirectMessageRequestsDisabled,
+)
 from tests.helpers import *
 
 
@@ -102,6 +107,29 @@ class HardeningRegressionTestCase(unittest.TestCase):
         with mock.patch.object(client.private, "get", return_value=response):
             with self.assertRaises(ClientUnauthorizedError):
                 client._send_private_request("test/")
+
+    def test_send_private_request_preserves_bad_password_message_with_login_context_hint(self):
+        client = self._build_private_client()
+        raw_message = "The password you entered is incorrect. Please try again."
+        response = self._make_http_error_response(
+            400,
+            json_body={
+                "message": raw_message,
+                "status": "fail",
+                "error_type": "bad_password",
+                "exception_name": "UserInvalidCredentials",
+            },
+        )
+
+        with mock.patch.object(client.private, "post", return_value=response):
+            with self.assertRaises(BadPassword) as cm:
+                client._send_private_request("accounts/login/", data={"username": "example"}, login=True)
+
+        self.assertTrue(cm.exception.message.startswith(raw_message))
+        self.assertIn("proxy/IP", cm.exception.message)
+        self.assertIn("device fingerprint", cm.exception.message)
+        self.assertNotIn("change your IP", cm.exception.message)
+        self.assertNotIn("blacklist", cm.exception.message)
 
     def test_send_private_request_promotes_404_not_found_body_to_challenge(self):
         client = self._build_private_client()


### PR DESCRIPTION
## Summary
- keep the Instagram-provided `bad_password` text as the leading exception message
- add a neutral hint that this response can also come from rejected proxy/IP, device fingerprint, or login context
- remove the unsupported `change your IP` / `blacklist` diagnosis from every `BadPassword`
- add regression coverage for the clarified message

Refs #2732.

## Tests
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_hardening.py::HardeningRegressionTestCase::test_send_private_request_preserves_bad_password_message_with_login_context_hint -q`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_hardening.py tests/regression/test_auth_story.py -q`
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression -q`
- `ruff check instagrapi/mixins/private.py tests/regression/test_hardening.py`
- `ruff format --check instagrapi/mixins/private.py tests/regression/test_hardening.py`