### PR TITLE
Raise AccountSuspended for suspended challenges

### DIFF
--- a/instagrapi/exceptions.py
+++ b/instagrapi/exceptions.py
@@ -186,6 +186,10 @@ class ChallengeRequired(ChallengeError):
         )
 
 
+class AccountSuspended(ClientError):
+    pass
+
+
 class ChallengeSelfieCaptcha(ChallengeError):
     pass
 

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -12,6 +12,7 @@ from instagrapi import config
 from instagrapi.exceptions import (
     AccountContactPointRequired,
     AccountEditError,
+    AccountSuspended,
     BadPassword,
     ChallengeRequired,
     ClientBadRequestError,
@@ -520,6 +521,9 @@ class PrivateRequestMixin:
                         last_json["error_type"] = "two_factor_required"
                     raise TwoFactorRequired(**last_json)
                 elif message == "challenge_required":
+                    challenge = last_json.get("challenge") or {}
+                    if "/suspended/" in (challenge.get("url") or ""):
+                        raise AccountSuspended(**last_json)
                     raise ChallengeRequired(**last_json)
                 elif message == "feedback_required":
                     raise FeedbackRequired(

--- a/tests/regression/test_hardening.py
+++ b/tests/regression/test_hardening.py
@@ -131,6 +131,28 @@ class HardeningRegressionTestCase(unittest.TestCase):
         self.assertNotIn("change your IP", cm.exception.message)
         self.assertNotIn("blacklist", cm.exception.message)
 
+    def test_send_private_request_promotes_suspended_challenge_to_account_suspended(self):
+        from instagrapi.exceptions import AccountSuspended
+
+        client = self._build_private_client()
+        payload = {
+            "message": "challenge_required",
+            "status": "fail",
+            "challenge": {"url": "https://i.instagram.com/challenge/action/123/suspended/"},
+        }
+        response = self._make_http_error_response(
+            400,
+            content=json.dumps(payload).encode(),
+            json_body=payload,
+        )
+
+        with mock.patch.object(client.private, "post", return_value=response):
+            with self.assertRaises(AccountSuspended) as cm:
+                client._send_private_request("accounts/login/", data={"username": "example"}, login=True)
+
+        self.assertEqual(cm.exception.message, "challenge_required")
+        self.assertEqual(cm.exception.challenge["url"], payload["challenge"]["url"])
+
     def test_send_private_request_promotes_404_not_found_body_to_challenge(self):
         client = self._build_private_client()
         response = self._make_http_error_response(404, content=b"Not Found")


### PR DESCRIPTION
Instagram can return `message=challenge_required` with a challenge URL that points at `/suspended/`. Treating that as a generic `ChallengeRequired` hides a terminal account-state response behind the normal challenge handler path.

Changes:
- add `AccountSuspended` exception
- map private API suspended challenge URLs to `AccountSuspended`
- add regression coverage for the private request error mapper

Verification:
- RED: new regression test first failed because `AccountSuspended` did not exist
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_hardening.py::HardeningRegressionTestCase::test_send_private_request_promotes_suspended_challenge_to_account_suspended -q` -> 1 passed
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_hardening.py -q` -> 19 passed
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m pytest tests/regression/test_challenge.py -q` -> 39 passed
- `/Users/colinfrl/work/sub/instagrapi/.venv/bin/python -m ruff check instagrapi/exceptions.py instagrapi/mixins/private.py tests/regression/test_hardening.py` -> passed
