### PR TITLE
Strip outer whitespace from login username

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -765,6 +765,8 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             self.password = password
         if self.username is None or self.password is None:
             raise BadCredentials("Both username and password must be provided.")
+        if isinstance(self.username, str):
+            self.username = self.username.strip()
 
         if relogin:
             self._clear_session_state(

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -94,6 +94,23 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         payload = client.private_request.call_args.args[1]
         self.assertEqual(payload["username"], "example")
 
+    def test_login_strips_outer_username_whitespace(self):
+        client = Client()
+        client.authorization_data = {}
+        client.last_response = Mock(headers={"ig-set-authorization": "Bearer token"})
+        client.parse_authorization = Mock(return_value={"sessionid": "abc"})
+        client.pre_login_flow = Mock(return_value=True)
+        client.private_request = Mock(return_value=True)
+        client.login_flow = Mock()
+        client.password_encrypt = Mock(return_value="enc-password")
+
+        result = client.login(" example ", "password")
+
+        self.assertTrue(result)
+        payload = client.private_request.call_args.args[1]
+        self.assertEqual(payload["username"], "example")
+        self.assertEqual(client.username, "example")
+
     def test_login_two_factor_requires_verification_code(self):
         client = Client()
         client.username = "example"


### PR DESCRIPTION
## Summary
- strip leading/trailing whitespace from `Client.login()` usernames before building the `accounts/login/` payload
- keep passwords unchanged because whitespace can be part of a valid password
- add a regression test for the sanitized login payload

## Context
This addresses one concrete signal from #2732 where Instagram echoed `login_user_input` with leading whitespace. It does not claim to bypass Instagram's `bad_password` / `UserInvalidCredentials` response for correctly normalized credentials.

## Tests
- `.venv/bin/python -m pytest tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase::test_login_strips_outer_username_whitespace -q`
- `.venv/bin/python -m pytest tests/regression/test_auth_story.py -q`
- `.venv/bin/python -m pytest tests/regression/test_auth_story.py tests/regression/test_hardening.py tests/regression/test_bloks.py -q`
- `.venv/bin/python -m pytest tests/regression -q`
