### PR TITLE
feat: add account AI info disclosure toggle

### DIFF
--- a/instagrapi/mixins/account.py
+++ b/instagrapi/mixins/account.py
@@ -8,6 +8,7 @@ from instagrapi.utils.auth import gen_token, generate_signature
 from instagrapi.utils.serialization import dumps
 
 ProfessionalAccountType = Literal[2, 3]
+AIGM_UPDATE_ACCOUNT_LABEL_VISIBILITY_CLIENT_DOC_ID = "85502578717429613610069073956"
 
 
 class AccountMixin:
@@ -63,6 +64,38 @@ class AccountMixin:
         """
         result = self.private_request("accounts/current_user/?edit=true")
         return extract_account(result["user"])
+
+    def account_set_ai_info(self, enabled: bool) -> Account:
+        """
+        Set the account-level AI-generated disclosure label.
+
+        Parameters
+        ----------
+        enabled: bool
+            Whether the profile should be labeled as AI-generated.
+
+        Returns
+        -------
+        Account
+            The refreshed account.
+        """
+        data = {
+            "method": "post",
+            "format": "json",
+            "server_timestamps": "true",
+            "locale": "user",
+            "fb_api_req_friendly_name": "AIGMUpdateAccountLabelVisibilityMutation",
+            "enable_canonical_naming": "true",
+            "enable_canonical_variable_overrides": "true",
+            "enable_canonical_naming_ambiguous_type_prefixing": "true",
+            "client_doc_id": AIGM_UPDATE_ACCOUNT_LABEL_VISIBILITY_CLIENT_DOC_ID,
+            "variables": json.dumps({"is_enabled": enabled}, separators=(",", ":")),
+        }
+        self.private_graphql_request(
+            data,
+            headers={"X-Client-Doc-Id": AIGM_UPDATE_ACCOUNT_LABEL_VISIBILITY_CLIENT_DOC_ID},
+        )
+        return self.account_info()
 
     def account_convert_to_professional(
         self,

--- a/tests/live/test_account.py
+++ b/tests/live/test_account.py
@@ -3,6 +3,14 @@ from tests.helpers import *
 
 
 class ClientAccountTestCase(_helpers.ClientPrivateTestCase):
+    @unittest.skipUnless(os.getenv("IG_RUN_AI_INFO_LIVE"), "set IG_RUN_AI_INFO_LIVE=1 to run the account mutation test")
+    def test_account_set_ai_info(self):
+        enabled = self.cl.account_set_ai_info(True)
+        self.assertIsInstance(enabled, Account)
+
+        disabled = self.cl.account_set_ai_info(False)
+        self.assertIsInstance(disabled, Account)
+
     def test_account_edit(self):
         # current
         one = self.cl.user_info(self.cl.user_id)

--- a/tests/regression/test_account.py
+++ b/tests/regression/test_account.py
@@ -2,6 +2,34 @@ from tests.helpers import *
 
 
 class AccountRegressionTestCase(unittest.TestCase):
+    def test_account_set_ai_info_posts_visibility_mutation(self):
+        client = Client()
+        account = object()
+
+        with (
+            mock.patch.object(client, "private_graphql_request") as graphql_request,
+            mock.patch.object(client, "account_info", return_value=account) as account_info,
+        ):
+            result = client.account_set_ai_info(True)
+
+        self.assertIs(result, account)
+        graphql_request.assert_called_once_with(
+            {
+                "method": "post",
+                "format": "json",
+                "server_timestamps": "true",
+                "locale": "user",
+                "fb_api_req_friendly_name": "AIGMUpdateAccountLabelVisibilityMutation",
+                "enable_canonical_naming": "true",
+                "enable_canonical_variable_overrides": "true",
+                "enable_canonical_naming_ambiguous_type_prefixing": "true",
+                "client_doc_id": "85502578717429613610069073956",
+                "variables": '{"is_enabled":true}',
+            },
+            headers={"X-Client-Doc-Id": "85502578717429613610069073956"},
+        )
+        account_info.assert_called_once_with()
+
     def test_send_password_reset_posts_recovery_payload(self):
         client = Client()
 


### PR DESCRIPTION
## Summary
- Add `Client.account_set_ai_info(enabled)` for the account-level AI-generated disclosure label.
- Send Instagram's `AIGMUpdateAccountLabelVisibilityMutation` with the verified client document ID and `is_enabled` variable.
- Add regression coverage for the exact GraphQL payload and an opt-in live test that enables and restores the setting.

## Test Coverage
- `668 passed, 3 skipped` — full regression suite.
- `IG_RUN_AI_INFO_LIVE=1 .venv/bin/pytest -q tests/live/test_account.py -k account_set_ai_info` — `1 passed`.
- Ruff check passed for all changed files.

## Pre-Landing Review
No issues found. The live mutation test is opt-in to avoid changing accounts during ordinary live test runs.

## Notes
The repository manages package versions in separate release commits and has no `VERSION` or `CHANGELOG.md` on the base branch, so this feature PR does not change release metadata.
