### PR TITLE
feat: paginate collection media lookups by name

### DIFF
--- a/docs/usage-guide/collection.md
+++ b/docs/usage-guide/collection.md
@@ -6,7 +6,7 @@ Saved posts, collections, and liked media.
 | --- | --- | --- |
 | collections() | List\[Collection] | Get all collections for the authenticated account |
 | collection_pk_by_name(name: str) | int | Resolve collection ID by collection name |
-| collection_medias_by_name(name: str) | List\[Media] | Get medias in a collection by collection name |
+| collection_medias_by_name(name: str, amount: int = 21, last_media_pk: int = 0) | List\[Media] | Get medias in a collection by collection name |
 | collection_medias(collection_pk: str, amount: int = 21, last_media_pk: int = 0) | List\[Media] | Get medias in a collection; use `amount=0` to keep paginating |
 | collection_medias_v1_chunk(collection_pk: str, max_id: str = "") | Tuple[List\[Media], str] | Low-level chunk fetch with raw `next_max_id` cursor |
 | liked_medias(amount: int = 21, last_media_pk: int = 0) | List\[Media] | Get media liked by the current account |

--- a/instagrapi/mixins/collection.py
+++ b/instagrapi/mixins/collection.py
@@ -59,7 +59,7 @@ class CollectionMixin:
                 return item.id
         raise CollectionNotFound(name=name)
 
-    def collection_medias_by_name(self, name: str) -> List[Collection]:
+    def collection_medias_by_name(self, name: str, amount: int = 21, last_media_pk: int = 0) -> List[Media]:
         """
         Get medias by collection name
 
@@ -67,14 +67,22 @@ class CollectionMixin:
         ----------
         name: str
             Name of the collection
+        amount: int, optional
+            Maximum number of media to return, default is 21
+        last_media_pk: int, optional
+            Last PK user has seen, function will return medias after this pk. Default is 0
 
         Returns
         -------
-        List[Collection]
-            A list of collections
+        List[Media]
+            A list of objects of Media
         """
 
-        return self.collection_medias(self.collection_pk_by_name(name))
+        return self.collection_medias(
+            self.collection_pk_by_name(name),
+            amount=amount,
+            last_media_pk=last_media_pk,
+        )
 
     def liked_medias(self, amount: int = 21, last_media_pk: int = 0) -> List[Media]:
         """

--- a/tests/live/test_collection.py
+++ b/tests/live/test_collection.py
@@ -13,9 +13,8 @@ class ClientCollectionTestCase(_helpers.ClientPrivateTestCase):
 
     def test_collection_medias_by_name(self):
         media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")
-        self.cl.media_unsave(media_pk)
+        self.assertTrue(self.cl.media_save(media_pk))
         try:
-            self.assertTrue(self.cl.media_save(media_pk))
             collection = next((item for item in self.cl.collections() if item.media_count), None)
             self.assertIsNotNone(collection)
 

--- a/tests/live/test_collection.py
+++ b/tests/live/test_collection.py
@@ -12,16 +12,25 @@ class ClientCollectionTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(hasattr(collection, field))
 
     def test_collection_medias_by_name(self):
-        medias = self.cl.collection_medias_by_name("Repost", amount=1)
-        self.assertEqual(len(medias), 1)
-        media = medias[0]
-        self.assertIsInstance(media, Media)
-        for field in REQUIRED_MEDIA_FIELDS:
-            self.assertTrue(hasattr(media, field))
-        self.assertEqual(
-            self.cl.collection_medias_by_name("Repost", amount=1, last_media_pk=media.pk),
-            [],
-        )
+        media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")
+        self.cl.media_unsave(media_pk)
+        try:
+            self.assertTrue(self.cl.media_save(media_pk))
+            collection = next((item for item in self.cl.collections() if item.media_count), None)
+            self.assertIsNotNone(collection)
+
+            medias = self.cl.collection_medias_by_name(collection.name, amount=1)
+            self.assertEqual(len(medias), 1)
+            media = medias[0]
+            self.assertIsInstance(media, Media)
+            for field in REQUIRED_MEDIA_FIELDS:
+                self.assertTrue(hasattr(media, field))
+            self.assertEqual(
+                self.cl.collection_medias_by_name(collection.name, amount=1, last_media_pk=media.pk),
+                [],
+            )
+        finally:
+            self.cl.media_unsave(media_pk)
 
     def test_media_save_to_collection(self):
         media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")

--- a/tests/live/test_collection.py
+++ b/tests/live/test_collection.py
@@ -12,7 +12,8 @@ class ClientCollectionTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(hasattr(collection, field))
 
     def test_collection_medias_by_name(self):
-        media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")
+        user_id = self.cl.user_id_from_username("instagram")
+        media_pk = self.cl.user_medias(user_id, amount=1)[0].pk
         self.assertTrue(self.cl.media_save(media_pk))
         try:
             collection = next((item for item in self.cl.collections() if item.media_count), None)

--- a/tests/live/test_collection.py
+++ b/tests/live/test_collection.py
@@ -12,12 +12,16 @@ class ClientCollectionTestCase(_helpers.ClientPrivateTestCase):
             self.assertTrue(hasattr(collection, field))
 
     def test_collection_medias_by_name(self):
-        medias = self.cl.collection_medias_by_name("Repost")
-        self.assertTrue(len(medias) > 0)
+        medias = self.cl.collection_medias_by_name("Repost", amount=1)
+        self.assertEqual(len(medias), 1)
         media = medias[0]
         self.assertIsInstance(media, Media)
         for field in REQUIRED_MEDIA_FIELDS:
             self.assertTrue(hasattr(media, field))
+        self.assertEqual(
+            self.cl.collection_medias_by_name("Repost", amount=1, last_media_pk=media.pk),
+            [],
+        )
 
     def test_media_save_to_collection(self):
         media_pk = self.cl.media_pk_from_url("https://www.instagram.com/p/B3mr1-OlWMG/")

--- a/tests/regression/test_collection.py
+++ b/tests/regression/test_collection.py
@@ -98,3 +98,15 @@ class CollectionRegressionTestCase(unittest.TestCase):
         self.assertEqual(client.private_request.call_count, 2)
         self.assertNotIn("max_id", client.private_request.call_args_list[0].kwargs["params"])
         self.assertEqual(client.private_request.call_args_list[1].kwargs["params"]["max_id"], "cursor-2")
+
+    def test_collection_medias_by_name_forwards_pagination_arguments(self):
+        client = Client()
+        expected_medias = [Mock()]
+        client.collection_pk_by_name = Mock(return_value="123")
+        client.collection_medias = Mock(return_value=expected_medias)
+
+        medias = client.collection_medias_by_name("Favorites", amount=50, last_media_pk=456)
+
+        self.assertIs(medias, expected_medias)
+        client.collection_pk_by_name.assert_called_once_with("Favorites")
+        client.collection_medias.assert_called_once_with("123", amount=50, last_media_pk=456)


### PR DESCRIPTION
## Summary
- add `amount` and `last_media_pk` to `collection_medias_by_name`
- correct the return annotation and collection API documentation
- add regression and live coverage for name resolution and pagination arguments

## Testing
- `pytest -q tests/regression`
- `pytest -q tests/live/test_collection.py::ClientCollectionTestCase::test_collection_medias_by_name` (live account)
- `ruff check --output-format=github .`
- `ruff format --check .`
- `mkdocs build --strict`

Closes #2748