### PR TITLE
feat: add Facebook and Threads crossposting

### DIFF
--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -370,15 +370,22 @@ Upload medias to your feed. Common arguments:
 
 | Method                                                                                                                                 | Return  | Description
 | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------
-| photo_upload(path: Path, caption: str, upload_id: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)             | Media   | Upload photo (Support JPG files)
-| video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)            | Media   | Upload video (Support MP4 files)
-| album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None)                      | Media   | Upload Album (Support JPG/MP4 files)
+| photo_upload(path: Path, caption: str, upload_id: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None, share_to_facebook: bool = False, share_to_threads: bool = False)             | Media   | Upload photo (Support JPG files)
+| video_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None, share_to_facebook: bool = False, share_to_threads: bool = False)            | Media   | Upload video (Support MP4 files)
+| album_upload(paths: List[Path], caption: str, usertags: List[Usertag], location: Location, extra_data: Dict = {}, schedule_at: int \| datetime = None, coauthor_user_ids: List[int \| str] = None, share_to_facebook: bool = False, share_to_threads: bool = False)                      | Media   | Upload Album (Support JPG/MP4 files)
 | igtv_upload(path: Path, title: str, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}) | Media   | Upload IGTV (Support MP4 files)
-| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual", share_to_facebook: bool = False, topics: List[int \| str] = None, show_preview_in_feed: bool = True) | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts. Set `share_to_facebook=True` to cross-post to a linked Facebook destination. Pass Reel topic `fit_id` values with `topics=[...]`. Set `show_preview_in_feed=False` to hide the feed/profile grid preview
+| clip_upload(path: Path, caption: str, thumbnail: Path, usertags: List[Usertag], location: Location, extra_data: Dict = {}, trial: bool = False, trial_graduation_strategy: str = "manual", share_to_facebook: bool = False, topics: List[int \| str] = None, show_preview_in_feed: bool = True, share_to_threads: bool = False) | Media | Upload Reels Clip (Support MP4 files). Set `trial=True` to publish a Trial Reel on eligible accounts. Use `share_to_facebook=True` or `share_to_threads=True` to cross-post to a linked destination. Pass Reel topic `fit_id` values with `topics=[...]`. Set `show_preview_in_feed=False` to hide the feed/profile grid preview
 | clip_change_cover(media_pk: str, cover_path: Path) | bool | Change the cover image for a published Reel
 | clip_trial_eligible() | bool | Check whether Reel creation preflight reports Trial Reels enabled before uploading video bytes
 | clip_info_for_creation() | dict | Get Reel creation preflight configuration from the mobile API
 | clip_interest_topics() | List[dict] | Get Reel topic catalog items with `name` and `fit_id` values for `clip_upload(..., topics=...)`
+| media_share_to_fb_unified_config() | dict | Get Android's unified cross-posting configuration for Facebook destinations
+| media_share_to_fb_unified_destination(config: Dict = None) | dict | Resolve confirmed Facebook Feed destination fields from unified cross-posting configuration
+| media_share_to_fb_destination(config: Dict = None, destination_id: str = None, destination_type: Literal["USER", "PAGE"] = None) | dict | Resolve or validate Facebook Feed destination fields
+| media_share_to_fb_extra_data(config: Dict = None, destination_id: str = None, destination_type: Literal["USER", "PAGE"] = None) | dict | Build Facebook Feed cross-post configure fields for manual `extra_data`
+| media_share_to_threads_config() | dict | Get the Threads profile linked to the current Instagram account
+| media_share_to_threads_destination(config: Dict = None, destination_id: str = None) | dict | Resolve or validate the linked Threads destination id
+| media_share_to_threads_extra_data(config: Dict = None, destination_id: str = None) | dict | Build Threads cross-post configure fields for manual `extra_data`
 | clip_share_to_fb_config() | dict | Get Reel Facebook sharing configuration from the mobile API
 | clip_share_to_fb_unified_config() | dict | Get the Android cross-posting unified config used by the Reel composer
 | clip_share_to_fb_unified_destination(config: Dict = None) | dict | Resolve confirmed Reel Facebook destination fields from the unified cross-posting config
@@ -416,9 +423,18 @@ For regular Reels, pass `show_preview_in_feed=False` to hide the Reel preview fr
 
 Reel topics use Instagram's interest topic `fit_id` values. Call `clip_interest_topics()` to get the current catalog, then pass selected ids with `clip_upload(..., topics=[topic["fit_id"]])`; instagrapi sends them as the Android `interest_topics` configure field.
 
+Feed cross-posting is supported by `photo_upload()`, `video_upload()`, and `album_upload()`, including their feed-music wrappers. Set `share_to_facebook=True`, `share_to_threads=True`, or both. Unless you provide explicit destination values, instagrapi discovers the linked destinations before uploading media bytes and raises `ClientError` if the requested destination cannot be confirmed.
+
+Facebook Feed cross-posting requires a linked Facebook account or page and sends both a destination id and `fb_destination_type="USER"` or `"PAGE"`. Threads cross-posting requires a linked Threads profile and sends only its destination id; Threads does not use a destination type. Call `media_share_to_fb_destination()` or `media_share_to_threads_destination()` to inspect the normalized destination, or pass `fb_destination_id`, `fb_destination_type`, and `threads_destination_id` directly when discovery is unavailable. Validation bypass lists are available through `fb_validation_bypass` and `threads_validation_bypass` for callers reproducing a confirmed app payload.
+
+Explicit fields in `extra_data` take precedence over generated cross-posting fields. Upload responses preserve Instagram's cross-post status in `Media.crosspost`, `Media.crosspost_metadata`, and `Media.has_shared_to_fb` when those fields are returned.
+
 Facebook Reel sharing requires a Facebook account/page linked in the Instagram app. Modern Android app builds no longer use only `{"share_to_facebook": 1}` for Reels; they also send destination and cross-posting fields such as `share_to_fb_destination_id`, `share_to_fb_destination_type`, `no_token_crosspost`, and `attempt_id`.
 
 `clip_share_to_fb_config()` calls the lightweight Reel sharing preflight endpoint. On recent app versions this response contains availability flags, not the full Account Center destination state, and some linked accounts can still return `share_to_fb_unavailable=True` even when the Instagram app can cross-post manually. When `clip_upload(..., share_to_facebook=True)` has no manual destination override, instagrapi now falls back to Android's `CrosspostingUnifiedConfigsQuery` via `clip_share_to_fb_unified_config()` and uses `clip_share_to_fb_unified_destination()` only if that response contains confirmed Reel-to-Facebook destination fields. Use `clip_share_to_fb_destination()` when a config or captured app response already contains confirmed destination fields; it normalizes `destination_id`, `destination_type`, optional audience, and validation bypass values. For accounts where the app can cross-post manually but automatic discovery still has no destination, pass `fb_destination_id` and `fb_destination_type="USER"` or `"PAGE"` to `clip_upload(...)`, or build `extra_data` manually with `clip_share_to_fb_extra_data(...)`. The destination type is typed as `Literal["USER", "PAGE"]`, and those uppercase values are what the Reel configure payload sends to Instagram. If neither the preflight/unified config data nor the caller provides a destination, instagrapi raises `ClientError` before uploading video bytes. The Reel cross-post `attempt_id` is generated automatically; only pass it to `clip_share_to_fb_extra_data(...)` when replaying or testing a specific low-level payload.
+
+Threads sharing on Reels uses the same `share_to_threads`, `threads_destination_id`, and `threads_validation_bypass` options as feed uploads.
+
 `bloks_fxcal_link_reels_share()` exposes the raw Account Center Bloks link action seen on the Reel composer surface, but it starts an app linking flow and does not replace the interactive Facebook linking step in Instagram. Treat Account Center Bloks `fbid`, auth, and linking values as linking context, not as `fb_destination_id`; only use them as a Reel publish destination after verifying that the final Reel configure request sends the same value as `share_to_fb_destination_id`. See [#2556](https://github.com/subzeroid/instagrapi/issues/2556) for tracking automatic destination discovery.
 
 ### Example:
@@ -435,6 +451,23 @@ Facebook Reel sharing requires a Facebook account/page linked in the Instagram a
 ...     "/app/image.jpg",
 ...     "Scheduled photo",
 ...     schedule_at=int(time.time()) + 3600,
+... )
+
+>>> crossposted_photo = cl.photo_upload(
+...     "/app/image.jpg",
+...     "Cross-posting this photo",
+...     share_to_facebook=True,
+...     share_to_threads=True,
+... )
+
+>>> crossposted_photo = cl.photo_upload(
+...     "/app/image.jpg",
+...     "Cross-posting with explicit destinations",
+...     share_to_facebook=True,
+...     fb_destination_id="FACEBOOK_DESTINATION_ID",
+...     fb_destination_type="PAGE",
+...     share_to_threads=True,
+...     threads_destination_id="THREADS_PROFILE_ID",
 ... )
 
 >>> if cl.clip_trial_eligible():

--- a/instagrapi/__init__.py
+++ b/instagrapi/__init__.py
@@ -14,6 +14,7 @@ from instagrapi.mixins.challenge import ChallengeResolveMixin
 from instagrapi.mixins.clip import ClipMixin, DownloadClipMixin, UploadClipMixin
 from instagrapi.mixins.collection import CollectionMixin
 from instagrapi.mixins.comment import CommentMixin
+from instagrapi.mixins.crossposting import CrossPostingMixin
 from instagrapi.mixins.direct import DirectMixin
 from instagrapi.mixins.explore import ExploreMixin
 from instagrapi.mixins.fbsearch import FbSearchMixin
@@ -58,6 +59,7 @@ class Client(
     ChallengeResolveMixin,
     PrivateRequestMixin,
     PrivateGraphQLRequestMixin,
+    CrossPostingMixin,
     TopSearchesPublicMixin,
     ProfilePublicMixin,
     LoginMixin,

--- a/instagrapi/mixins/album.py
+++ b/instagrapi/mixins/album.py
@@ -9,6 +9,7 @@ from instagrapi.exceptions import (
     AlbumNotDownload,
     AlbumUnknownFormat,
 )
+from instagrapi.mixins.crossposting import FbDestinationType
 from instagrapi.types import Location, Media, Track, Usertag
 from instagrapi.utils.serialization import dumps
 from instagrapi.utils.timing import date_time_original
@@ -133,9 +134,16 @@ class UploadAlbumMixin:
         configure_handler=None,
         configure_exception=None,
         to_story=False,
-        extra_data: Dict[str, str] = {},
+        extra_data: Dict[str, object] = {},
         schedule_at: Optional[Union[int, datetime]] = None,
         coauthor_user_ids: Optional[List[Union[int, str]]] = None,
+        share_to_facebook: bool = False,
+        share_to_threads: bool = False,
+        fb_destination_id: Optional[str] = None,
+        fb_destination_type: Optional[FbDestinationType] = None,
+        fb_validation_bypass: Optional[List[str]] = None,
+        threads_destination_id: Optional[str] = None,
+        threads_validation_bypass: Optional[List[str]] = None,
     ) -> Media:
         """
         Upload album to feed
@@ -165,6 +173,20 @@ class UploadAlbumMixin:
             Unix timestamp in seconds or datetime when the album should be published.
         coauthor_user_ids: List[int | str], optional
             Instagram user IDs to invite as post coauthors.
+        share_to_facebook: bool, optional
+            Share this album to a linked Facebook account/page.
+        share_to_threads: bool, optional
+            Share this album to the linked Threads profile.
+        fb_destination_id: str, optional
+            Explicit Facebook destination id.
+        fb_destination_type: Literal["USER", "PAGE"], optional
+            Explicit Facebook destination type.
+        fb_validation_bypass: List[str], optional
+            Android Facebook cross-post validation bypass reasons.
+        threads_destination_id: str, optional
+            Explicit Threads profile id.
+        threads_validation_bypass: List[str], optional
+            Android Threads cross-post validation bypass reasons.
 
         Returns
         -------
@@ -175,6 +197,16 @@ class UploadAlbumMixin:
             raise AlbumUnknownFormat("Album upload requires at least one media path.")
         extra_data = with_coauthor_user_ids(extra_data, coauthor_user_ids)
         extra_data = self._scheduled_extra_data(extra_data, schedule_at)
+        extra_data = self._media_crossposting_extra_data(
+            extra_data,
+            share_to_facebook=share_to_facebook,
+            share_to_threads=share_to_threads,
+            fb_destination_id=fb_destination_id,
+            fb_destination_type=fb_destination_type,
+            fb_validation_bypass=fb_validation_bypass,
+            threads_destination_id=threads_destination_id,
+            threads_validation_bypass=threads_validation_bypass,
+        )
         children = []
         for path in paths:
             path = Path(path)
@@ -257,6 +289,7 @@ class UploadAlbumMixin:
         browse_session_id: Optional[str] = None,
         alacorn_session_id: Optional[str] = None,
         schedule_at: Optional[Union[int, datetime]] = None,
+        **kwargs,
     ) -> Media:
         """
         Upload a feed album/carousel with attached music.
@@ -296,6 +329,9 @@ class UploadAlbumMixin:
             Fetched automatically when omitted.
         schedule_at: int or datetime, optional
             Unix timestamp in seconds or datetime when the album should be published.
+        **kwargs
+            Additional options forwarded to :meth:`album_upload`, including
+            cross-posting options.
 
         Returns
         -------
@@ -321,6 +357,7 @@ class UploadAlbumMixin:
             to_story=to_story,
             extra_data=data,
             schedule_at=schedule_at,
+            **kwargs,
         )
 
     def album_configure(

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -675,6 +675,9 @@ class UploadClipMixin:
         fb_validation_check_bypass: Optional[bool] = None,
         topics: Optional[List[Union[str, int]]] = None,
         show_preview_in_feed: bool = True,
+        share_to_threads: bool = False,
+        threads_destination_id: Optional[str] = None,
+        threads_validation_bypass: Optional[List[str]] = None,
     ) -> Media:
         """
         Upload CLIP to Instagram
@@ -722,6 +725,12 @@ class UploadClipMixin:
         show_preview_in_feed: bool, optional
             Show Reel preview in feed/profile grid, default is True.
             Sent to Instagram as ``"1"`` or ``"0"``.
+        share_to_threads: bool, optional
+            Share this Reel to the linked Threads profile.
+        threads_destination_id: str, optional
+            Explicit Threads profile id.
+        threads_validation_bypass: List[str], optional
+            Android Threads cross-post validation bypass reasons.
 
         Returns
         -------
@@ -747,6 +756,12 @@ class UploadClipMixin:
                 validation_check_bypass=fb_validation_check_bypass,
             )
             configure_extra_data = {**fb_extra_data, **configure_extra_data}
+        if share_to_threads:
+            threads_extra_data = self.media_share_to_threads_extra_data(
+                destination_id=threads_destination_id,
+                validation_bypass=threads_validation_bypass,
+            )
+            configure_extra_data = {**threads_extra_data, **configure_extra_data}
         if trial:
             feed_show = "0"
             configure_extra_data.setdefault(

--- a/instagrapi/mixins/crossposting.py
+++ b/instagrapi/mixins/crossposting.py
@@ -1,0 +1,490 @@
+import json
+from typing import Dict, Iterable, List, Literal, Optional
+from uuid import uuid4
+
+from instagrapi.exceptions import ClientError
+
+FB_CROSSPOSTING_UNIFIED_CONFIG_CLIENT_DOC_ID = "216179630714134719310007237117"
+FB_CROSSPOSTING_UNIFIED_CONFIG_FRIENDLY_NAME = "CrosspostingUnifiedConfigsQuery"
+FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD = "xcxp_unified_crossposting_configs_root"
+FB_STORY_CROSSPOSTING_SURFACE = {
+    "source_surface": "STORY",
+    "destination_app": "FB",
+    "destination_surface": "STORY",
+}
+FB_FEED_CROSSPOSTING_SURFACE = {
+    "source_surface": "FEED",
+    "destination_app": "FB",
+    "destination_surface": "FEED",
+}
+FB_REELS_CROSSPOSTING_SURFACE = {
+    "source_surface": "REELS",
+    "destination_app": "FB",
+    "destination_surface": "REELS",
+}
+FB_CROSSPOSTING_SURFACES = [
+    FB_STORY_CROSSPOSTING_SURFACE,
+    FB_FEED_CROSSPOSTING_SURFACE,
+    FB_REELS_CROSSPOSTING_SURFACE,
+]
+
+THREADS_LINKED_PROFILE_CLIENT_DOC_ID = "1294688273527445410149299611"
+THREADS_LINKED_PROFILE_FRIENDLY_NAME = "LinkedBarcelonaProfileQuery"
+THREADS_LINKED_PROFILE_ROOT_FIELD = "xcxp_fetch_linked_threads_profile"
+
+FbDestinationType = Literal["USER", "PAGE"]
+
+
+class CrossPostingMixin:
+    """Helpers shared by feed and Reel cross-post upload flows."""
+
+    def media_share_to_fb_unified_config(
+        self,
+        crosspost_app_surface_list: Optional[List[Dict[str, str]]] = None,
+    ) -> Dict:
+        """
+        Get Android's unified cross-posting configuration.
+
+        Parameters
+        ----------
+        crosspost_app_surface_list: List[Dict[str, str]], optional
+            Source/destination surfaces to request. Defaults to Story, Feed,
+            and Reels destinations.
+
+        Returns
+        -------
+        Dict
+            Private GraphQL response.
+        """
+        variables = {
+            "configs_request": {
+                "source_app": "IG",
+                "crosspost_app_surface_list": crosspost_app_surface_list or FB_CROSSPOSTING_SURFACES,
+            }
+        }
+        return self.private_graphql_query_request(
+            friendly_name=FB_CROSSPOSTING_UNIFIED_CONFIG_FRIENDLY_NAME,
+            root_field_name=FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD,
+            variables=variables,
+            client_doc_id=FB_CROSSPOSTING_UNIFIED_CONFIG_CLIENT_DOC_ID,
+            priority="u=3, i",
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
+        )
+
+    @staticmethod
+    def _crossposting_iter_dicts(value) -> Iterable[Dict[str, object]]:
+        if isinstance(value, dict):
+            yield value
+            for child in value.values():
+                yield from CrossPostingMixin._crossposting_iter_dicts(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from CrossPostingMixin._crossposting_iter_dicts(child)
+
+    @staticmethod
+    def _crossposting_candidate_value(config: Dict[str, object], keys) -> object:
+        for key in keys:
+            value = config.get(key)
+            if value not in (None, ""):
+                return value
+        return None
+
+    @staticmethod
+    def _crossposting_graphql_root(config: Dict[str, object], root_field: str) -> object:
+        data = (config or {}).get("data")
+        if isinstance(data, dict):
+            root = data.get(root_field)
+            if root is not None:
+                return root
+            for key, value in data.items():
+                if root_field in str(key):
+                    return value
+        return config or {}
+
+    @staticmethod
+    def _media_share_to_fb_feed_candidate(config: Dict[str, object]) -> bool:
+        source_surface = str(config.get("source_surface") or "").upper()
+        destination_surface = str(config.get("destination_surface") or "").upper()
+        destination_app = str(config.get("destination_app") or "").upper()
+        if source_surface and source_surface != "FEED":
+            return False
+        if destination_surface and destination_surface != "FEED":
+            return False
+        if destination_app and destination_app not in {"FB", "FACEBOOK"}:
+            return False
+        return source_surface == "FEED" or destination_surface == "FEED"
+
+    def _media_share_to_fb_unified_destination_candidates(
+        self,
+        config: Dict[str, object],
+    ) -> Iterable[Dict[str, object]]:
+        root = self._crossposting_graphql_root(config, FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD)
+        for service in self._crossposting_iter_dicts(root):
+            identity_mappings = service.get("identity_mapping")
+            if not isinstance(identity_mappings, list):
+                continue
+            custom_service_data = service.get("custom_service_data")
+            surface_config = custom_service_data if isinstance(custom_service_data, dict) else service
+            if not any(
+                self._media_share_to_fb_feed_candidate(candidate)
+                for candidate in self._crossposting_iter_dicts(surface_config)
+            ):
+                continue
+            for identity_mapping in identity_mappings:
+                if not isinstance(identity_mapping, dict):
+                    continue
+                destination_identities = identity_mapping.get("destination_identities")
+                if not isinstance(destination_identities, list):
+                    continue
+                for destination in destination_identities:
+                    if isinstance(destination, dict):
+                        yield {
+                            "source_surface": "FEED",
+                            "destination_app": "FB",
+                            "destination_surface": "FEED",
+                            **destination,
+                        }
+
+        for candidate in self._crossposting_iter_dicts(root):
+            if not self._media_share_to_fb_feed_candidate(candidate):
+                continue
+            merged = dict(candidate)
+            for key in (
+                "destination",
+                "fb_destination",
+                "feed_destination",
+                "crosspost_destination",
+                "crossposting_destination",
+                "xpost_destination",
+            ):
+                nested = candidate.get(key)
+                if isinstance(nested, dict):
+                    merged.update(nested)
+            yield merged
+
+    def _media_share_to_fb_unified_config_variants(self):
+        yield self.media_share_to_fb_unified_config()
+        yield self.media_share_to_fb_unified_config(crosspost_app_surface_list=[FB_FEED_CROSSPOSTING_SURFACE])
+
+    def media_share_to_fb_unified_destination(
+        self,
+        config: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        """
+        Resolve a confirmed Facebook Feed destination from unified config.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Response from :meth:`media_share_to_fb_unified_config`.
+
+        Returns
+        -------
+        Dict[str, object]
+            Normalized destination fields.
+        """
+        configs = (config,) if config is not None else self._media_share_to_fb_unified_config_variants()
+        for unified_config in configs:
+            for candidate in self._media_share_to_fb_unified_destination_candidates(unified_config or {}):
+                try:
+                    return self.media_share_to_fb_destination(
+                        config=candidate,
+                        use_unified_config=False,
+                    )
+                except ClientError:
+                    continue
+        raise ClientError("Facebook Feed sharing unified config has no confirmed Facebook destination")
+
+    @staticmethod
+    def _crossposting_validation_bypass(value) -> Optional[List[str]]:
+        if value in (None, "", []):
+            return None
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (TypeError, ValueError):
+                value = [value]
+        if isinstance(value, (tuple, set)):
+            value = list(value)
+        if not isinstance(value, list):
+            value = [value]
+        return [str(item) for item in value]
+
+    def media_share_to_fb_destination(
+        self,
+        config: Optional[Dict[str, object]] = None,
+        destination_id: Optional[str] = None,
+        destination_type: Optional[FbDestinationType] = None,
+        validation_bypass: Optional[List[str]] = None,
+        use_unified_config: bool = True,
+    ) -> Dict[str, object]:
+        """
+        Resolve the Facebook destination used by Feed configure requests.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Unified config response or a confirmed destination dictionary.
+        destination_id: str, optional
+            Explicit Facebook destination id.
+        destination_type: Literal["USER", "PAGE"], optional
+            Explicit Facebook destination type.
+        validation_bypass: List[str], optional
+            Android validation bypass reasons.
+        use_unified_config: bool, optional
+            Discover a Feed destination when no explicit config is supplied.
+
+        Returns
+        -------
+        Dict[str, object]
+            Normalized destination fields.
+        """
+        has_unified_root = bool(
+            config
+            and (
+                isinstance(config.get("data"), dict)
+                or any(FB_CROSSPOSTING_UNIFIED_CONFIG_ROOT_FIELD in str(key) for key in config)
+            )
+        )
+        if config is not None and has_unified_root:
+            candidates = list(self._media_share_to_fb_unified_destination_candidates(config))
+            if candidates:
+                for candidate in candidates:
+                    try:
+                        return self.media_share_to_fb_destination(
+                            config=candidate,
+                            destination_id=destination_id,
+                            destination_type=destination_type,
+                            validation_bypass=validation_bypass,
+                            use_unified_config=False,
+                        )
+                    except ClientError:
+                        continue
+
+        fb_config = config or {}
+        explicit_destination = bool(destination_id or destination_type)
+        if not fb_config and not explicit_destination and use_unified_config:
+            return self.media_share_to_fb_unified_destination()
+        if fb_config.get("enabled") is False or fb_config.get("is_account_linked") is False:
+            raise ClientError("Facebook Feed sharing is not enabled or no Facebook account is linked")
+
+        destination_id = destination_id or self._crossposting_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_id",
+                "obfuscated_identity_id",
+                "feed_destination_id",
+                "crosspost_destination_id",
+                "crossposting_destination_id",
+                "xpost_destination_id",
+                "destination_id",
+            ),
+        )
+        destination_type_value = destination_type or self._crossposting_candidate_value(
+            fb_config,
+            (
+                "share_to_fb_destination_type",
+                "identity_type",
+                "crosspost_destination_type",
+                "crossposting_destination_type",
+                "xpost_destination_type",
+                "destination_type",
+                "posting_type",
+            ),
+        )
+        destination_type_text = str(destination_type_value).upper() if destination_type_value is not None else ""
+        if destination_type_text.startswith("FB_"):
+            destination_type_text = destination_type_text[3:]
+
+        if validation_bypass is None:
+            validation_bypass = self._crossposting_candidate_value(
+                fb_config,
+                (
+                    "share_to_facebook_validation_bypass",
+                    "validation_bypass",
+                ),
+            )
+        validation_bypass = self._crossposting_validation_bypass(validation_bypass)
+
+        if not destination_id:
+            raise ClientError(
+                "Facebook Feed sharing configuration has no destination. "
+                "Link a Facebook account/page in the Instagram app or pass destination_id."
+            )
+        if not destination_type_text:
+            raise ClientError(
+                "Facebook Feed sharing configuration has no destination type. Pass destination_type as USER or PAGE."
+            )
+        if destination_type_text not in {"USER", "PAGE"}:
+            raise ClientError("Facebook Feed sharing destination type must be USER or PAGE")
+
+        destination = {
+            "destination_id": str(destination_id),
+            "destination_type": destination_type_text,
+        }
+        if validation_bypass:
+            destination["validation_bypass"] = validation_bypass
+        return destination
+
+    def media_share_to_fb_extra_data(
+        self,
+        config: Optional[Dict[str, object]] = None,
+        destination_id: Optional[str] = None,
+        destination_type: Optional[FbDestinationType] = None,
+        validation_bypass: Optional[List[str]] = None,
+        attempt_id: Optional[str] = None,
+    ) -> Dict[str, object]:
+        """
+        Build Feed configure fields for sharing to Facebook.
+
+        Returns
+        -------
+        Dict[str, object]
+            Extra configure data for feed upload methods.
+        """
+        destination = self.media_share_to_fb_destination(
+            config=config,
+            destination_id=destination_id,
+            destination_type=destination_type,
+            validation_bypass=validation_bypass,
+        )
+        data = {
+            "share_to_facebook": "1",
+            "share_to_fb_destination_id": destination["destination_id"],
+            "share_to_fb_destination_type": destination["destination_type"],
+            "no_token_crosspost": "1",  # nosec B105
+            "attempt_id": attempt_id or str(uuid4()),
+        }
+        if destination.get("validation_bypass"):
+            data["share_to_facebook_validation_bypass"] = destination["validation_bypass"]
+        return data
+
+    def media_share_to_threads_config(self) -> Dict:
+        """
+        Get the Threads profile linked to the current Instagram account.
+
+        Returns
+        -------
+        Dict
+            Private GraphQL response.
+        """
+        return self.private_graphql_query_request(
+            friendly_name=THREADS_LINKED_PROFILE_FRIENDLY_NAME,
+            root_field_name=THREADS_LINKED_PROFILE_ROOT_FIELD,
+            variables={},
+            client_doc_id=THREADS_LINKED_PROFILE_CLIENT_DOC_ID,
+            priority="u=3, i",
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
+        )
+
+    def media_share_to_threads_destination(
+        self,
+        config: Optional[Dict[str, object]] = None,
+        destination_id: Optional[str] = None,
+    ) -> Dict[str, object]:
+        """
+        Resolve the linked Threads profile used by configure requests.
+
+        Parameters
+        ----------
+        config: Dict[str, object], optional
+            Response from :meth:`media_share_to_threads_config`.
+        destination_id: str, optional
+            Explicit Threads profile id.
+
+        Returns
+        -------
+        Dict[str, object]
+            Normalized Threads destination fields.
+        """
+        threads_config = config
+        if threads_config is None and destination_id is None:
+            threads_config = self.media_share_to_threads_config()
+        profile = (
+            self._crossposting_graphql_root(
+                threads_config or {},
+                THREADS_LINKED_PROFILE_ROOT_FIELD,
+            )
+            if threads_config is not None
+            else {}
+        )
+        if not isinstance(profile, dict):
+            profile = {}
+
+        destination_id = destination_id or self._crossposting_candidate_value(
+            profile,
+            (
+                "id",
+                "strong_id__",
+                "destination_id",
+                "obfuscated_identity_id",
+            ),
+        )
+        if not destination_id:
+            raise ClientError(
+                "Threads sharing configuration has no linked Threads profile. "
+                "Link a Threads profile in the Instagram app or pass destination_id."
+            )
+
+        destination = {"destination_id": str(destination_id)}
+        for key in ("username", "profile_pic_url"):
+            if profile.get(key):
+                destination[key] = str(profile[key])
+        return destination
+
+    def media_share_to_threads_extra_data(
+        self,
+        config: Optional[Dict[str, object]] = None,
+        destination_id: Optional[str] = None,
+        validation_bypass: Optional[List[str]] = None,
+    ) -> Dict[str, object]:
+        """
+        Build configure fields for sharing media to Threads.
+
+        Returns
+        -------
+        Dict[str, object]
+            Extra configure data for feed or Reel upload methods.
+        """
+        destination = self.media_share_to_threads_destination(
+            config=config,
+            destination_id=destination_id,
+        )
+        data = {
+            "share_to_threads": "1",
+            "share_to_threads_destination_id": destination["destination_id"],
+        }
+        validation_bypass = self._crossposting_validation_bypass(validation_bypass)
+        if validation_bypass:
+            data["share_to_threads_validation_bypass"] = validation_bypass
+        return data
+
+    def _media_crossposting_extra_data(
+        self,
+        extra_data: Optional[Dict[str, object]] = None,
+        *,
+        share_to_facebook: bool = False,
+        share_to_threads: bool = False,
+        fb_destination_id: Optional[str] = None,
+        fb_destination_type: Optional[FbDestinationType] = None,
+        fb_validation_bypass: Optional[List[str]] = None,
+        threads_destination_id: Optional[str] = None,
+        threads_validation_bypass: Optional[List[str]] = None,
+    ) -> Dict[str, object]:
+        generated = {}
+        if share_to_facebook:
+            generated.update(
+                self.media_share_to_fb_extra_data(
+                    destination_id=fb_destination_id,
+                    destination_type=fb_destination_type,
+                    validation_bypass=fb_validation_bypass,
+                )
+            )
+        if share_to_threads:
+            generated.update(
+                self.media_share_to_threads_extra_data(
+                    destination_id=threads_destination_id,
+                    validation_bypass=threads_validation_bypass,
+                )
+            )
+        return {**generated, **dict(extra_data or {})}

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -17,6 +17,7 @@ from instagrapi.exceptions import (
     PhotoNotUpload,
 )
 from instagrapi.image_util import prepare_image, prepare_story_image_fit
+from instagrapi.mixins.crossposting import FbDestinationType
 from instagrapi.types import (
     Location,
     Media,
@@ -253,9 +254,16 @@ class UploadPhotoMixin:
         upload_id: str = "",
         usertags: List[Usertag] = [],
         location: Location = None,
-        extra_data: Dict[str, str] = {},
+        extra_data: Dict[str, object] = {},
         schedule_at: Optional[Union[int, datetime]] = None,
         coauthor_user_ids: Optional[List[Union[int, str]]] = None,
+        share_to_facebook: bool = False,
+        share_to_threads: bool = False,
+        fb_destination_id: Optional[str] = None,
+        fb_destination_type: Optional[FbDestinationType] = None,
+        fb_validation_bypass: Optional[List[str]] = None,
+        threads_destination_id: Optional[str] = None,
+        threads_validation_bypass: Optional[List[str]] = None,
     ) -> Media:
         """
         Upload photo and configure to feed
@@ -278,6 +286,20 @@ class UploadPhotoMixin:
             Unix timestamp in seconds or datetime when the photo should be published.
         coauthor_user_ids: List[int | str], optional
             Instagram user IDs to invite as post coauthors.
+        share_to_facebook: bool, optional
+            Share this photo to a linked Facebook account/page.
+        share_to_threads: bool, optional
+            Share this photo to the linked Threads profile.
+        fb_destination_id: str, optional
+            Explicit Facebook destination id.
+        fb_destination_type: Literal["USER", "PAGE"], optional
+            Explicit Facebook destination type.
+        fb_validation_bypass: List[str], optional
+            Android Facebook cross-post validation bypass reasons.
+        threads_destination_id: str, optional
+            Explicit Threads profile id.
+        threads_validation_bypass: List[str], optional
+            Android Threads cross-post validation bypass reasons.
 
         Returns
         -------
@@ -291,6 +313,16 @@ class UploadPhotoMixin:
 
         extra_data = with_coauthor_user_ids(extra_data, coauthor_user_ids)
         extra_data = self._scheduled_extra_data(extra_data, schedule_at)
+        extra_data = self._media_crossposting_extra_data(
+            extra_data,
+            share_to_facebook=share_to_facebook,
+            share_to_threads=share_to_threads,
+            fb_destination_id=fb_destination_id,
+            fb_destination_type=fb_destination_type,
+            fb_validation_bypass=fb_validation_bypass,
+            threads_destination_id=threads_destination_id,
+            threads_validation_bypass=threads_validation_bypass,
+        )
         previous_media_ids = self._current_media_ids()
         upload_id, width, height = self.photo_rupload(path, upload_id)
         for attempt in range(10):
@@ -368,6 +400,7 @@ class UploadPhotoMixin:
         browse_session_id: Optional[str] = None,
         alacorn_session_id: Optional[str] = None,
         schedule_at: Optional[Union[int, datetime]] = None,
+        **kwargs,
     ) -> Media:
         """
         Upload a feed photo with attached music.
@@ -400,6 +433,9 @@ class UploadPhotoMixin:
             Fetched automatically when omitted.
         schedule_at: int or datetime, optional
             Unix timestamp in seconds or datetime when the photo should be published.
+        **kwargs
+            Additional options forwarded to :meth:`photo_upload`, including
+            cross-posting options.
 
         Returns
         -------
@@ -422,6 +458,7 @@ class UploadPhotoMixin:
             location=location,
             extra_data=data,
             schedule_at=schedule_at,
+            **kwargs,
         )
 
     @staticmethod

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -16,6 +16,7 @@ from instagrapi.exceptions import (
     VideoConfigureStoryError,
     VideoNotUpload,
 )
+from instagrapi.mixins.crossposting import FbDestinationType
 from instagrapi.story import StoryBuilder
 from instagrapi.types import (
     DirectMessage,
@@ -439,9 +440,16 @@ class UploadVideoMixin:
         thumbnail: Path = None,
         usertags: List[Usertag] = [],
         location: Location = None,
-        extra_data: Dict[str, str] = {},
+        extra_data: Dict[str, object] = {},
         schedule_at: Optional[Union[int, datetime]] = None,
         coauthor_user_ids: Optional[List[Union[int, str]]] = None,
+        share_to_facebook: bool = False,
+        share_to_threads: bool = False,
+        fb_destination_id: Optional[str] = None,
+        fb_destination_type: Optional[FbDestinationType] = None,
+        fb_validation_bypass: Optional[List[str]] = None,
+        threads_destination_id: Optional[str] = None,
+        threads_validation_bypass: Optional[List[str]] = None,
     ) -> Media:
         """
         Upload video and configure to feed
@@ -464,6 +472,20 @@ class UploadVideoMixin:
             Unix timestamp in seconds or datetime when the video should be published.
         coauthor_user_ids: List[int | str], optional
             Instagram user IDs to invite as post coauthors.
+        share_to_facebook: bool, optional
+            Share this video to a linked Facebook account/page.
+        share_to_threads: bool, optional
+            Share this video to the linked Threads profile.
+        fb_destination_id: str, optional
+            Explicit Facebook destination id.
+        fb_destination_type: Literal["USER", "PAGE"], optional
+            Explicit Facebook destination type.
+        fb_validation_bypass: List[str], optional
+            Android Facebook cross-post validation bypass reasons.
+        threads_destination_id: str, optional
+            Explicit Threads profile id.
+        threads_validation_bypass: List[str], optional
+            Android Threads cross-post validation bypass reasons.
 
         Returns
         -------
@@ -475,6 +497,16 @@ class UploadVideoMixin:
             thumbnail = Path(thumbnail)
         extra_data = with_coauthor_user_ids(extra_data, coauthor_user_ids)
         extra_data = self._scheduled_extra_data(extra_data, schedule_at)
+        extra_data = self._media_crossposting_extra_data(
+            extra_data,
+            share_to_facebook=share_to_facebook,
+            share_to_threads=share_to_threads,
+            fb_destination_id=fb_destination_id,
+            fb_destination_type=fb_destination_type,
+            fb_validation_bypass=fb_validation_bypass,
+            threads_destination_id=threads_destination_id,
+            threads_validation_bypass=threads_validation_bypass,
+        )
         upload_id, width, height, duration, thumbnail = self.video_rupload(path, thumbnail, to_story=False)
         for attempt in range(50):
             self.logger.debug(f"Attempt #{attempt} to configure Video: {path}")

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -552,6 +552,9 @@ class Media(TypesBaseModel):
     title: Optional[str] = ""
     resources: List[Resource] = []
     clips_metadata: Optional[Union[ClipsMetadata, dict]] = None
+    crosspost: List[str] = []
+    crosspost_metadata: Optional[dict] = None
+    has_shared_to_fb: Optional[int] = None
 
 
 class MediaXma(TypesBaseModel):

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -1011,3 +1011,108 @@ class ClientFacebookReelCrosspostLiveTestCase(_helpers.ClientPrivateTestCase):
         finally:
             if media:
                 self.assertTrue(self.cl.media_delete(media.id))
+
+
+class ClientFeedCrosspostLiveTestCase(_helpers.ClientPrivateTestCase):
+    photo_path = Path("examples/kanada.jpg")
+
+    def __init__(self, *args, **kwargs):
+        self.cl = None
+        return unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def setup_method(self, *args, **kwargs):
+        return None
+
+    def setUp(self):
+        if not TEST_ACCOUNTS_URL:
+            self.skipTest("TEST_ACCOUNTS_URL is required for feed crosspost live tests")
+        try:
+            self.cl = self.fresh_account()
+        except RuntimeError as exc:
+            self.skipTest(str(exc))
+
+    def cleanup_uploaded_media(self, media):
+        if media:
+            self.assertTrue(self.cl.media_delete(media.id))
+
+    def test_media_share_to_fb_unified_config_live(self):
+        config = self.cl.media_share_to_fb_unified_config()
+
+        self.assertIsInstance(config.get("data"), dict)
+
+    def test_media_share_to_fb_destination_live(self):
+        try:
+            destination = self.cl.media_share_to_fb_destination()
+        except ClientError as exc:
+            self.skipTest(f"No confirmed Facebook Feed destination available: {exc}")
+
+        self.assertTrue(destination["destination_id"])
+        self.assertIn(destination["destination_type"], {"USER", "PAGE"})
+
+    def test_media_share_to_threads_config_live(self):
+        config = self.cl.media_share_to_threads_config()
+
+        data = config.get("data")
+        self.assertIsInstance(data, dict)
+        self.assertIn("xcxp_fetch_linked_threads_profile", data)
+
+    def test_media_share_to_threads_destination_live(self):
+        try:
+            destination = self.cl.media_share_to_threads_destination()
+        except ClientError as exc:
+            self.skipTest(f"No linked Threads profile available: {exc}")
+
+        self.assertTrue(destination["destination_id"])
+
+    def test_photo_upload_share_to_facebook_live(self):
+        try:
+            destination = self.cl.media_share_to_fb_destination()
+        except ClientError as exc:
+            self.skipTest(f"No confirmed Facebook Feed destination available: {exc}")
+
+        media = None
+        try:
+            media = self.cl.photo_upload(
+                self.photo_path,
+                "Facebook Feed crosspost live test",
+                share_to_facebook=True,
+                fb_destination_id=destination["destination_id"],
+                fb_destination_type=destination["destination_type"],
+            )
+            self.assertUploadedMediaAccessible(
+                media,
+                media_type=1,
+                caption_text="Facebook Feed crosspost live test",
+            )
+            self.assertTrue(
+                "FB" in {str(item).upper() for item in media.crosspost} or bool(media.has_shared_to_fb),
+                "Instagram configure response did not confirm Facebook cross-posting",
+            )
+        finally:
+            self.cleanup_uploaded_media(media)
+
+    def test_photo_upload_share_to_threads_live(self):
+        try:
+            destination = self.cl.media_share_to_threads_destination()
+        except ClientError as exc:
+            self.skipTest(f"No linked Threads profile available: {exc}")
+
+        media = None
+        try:
+            media = self.cl.photo_upload(
+                self.photo_path,
+                "Threads crosspost live test",
+                share_to_threads=True,
+                threads_destination_id=destination["destination_id"],
+            )
+            self.assertUploadedMediaAccessible(
+                media,
+                media_type=1,
+                caption_text="Threads crosspost live test",
+            )
+            self.assertTrue(
+                {"THREADS", "BARCELONA"} & {str(item).upper() for item in media.crosspost},
+                "Instagram configure response did not confirm Threads cross-posting",
+            )
+        finally:
+            self.cleanup_uploaded_media(media)

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -84,6 +84,10 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assert_fb_destination_type_literal("clip_share_to_fb_destination", "destination_type")
         self.assert_fb_destination_type_literal("clip_share_to_fb_extra_data", "destination_type")
         self.assert_fb_destination_type_literal("clip_upload", "fb_destination_type")
+        self.assert_fb_destination_type_literal("media_share_to_fb_destination", "destination_type")
+        self.assert_fb_destination_type_literal("media_share_to_fb_extra_data", "destination_type")
+        for method_name in ("photo_upload", "video_upload", "album_upload"):
+            self.assert_fb_destination_type_literal(method_name, "fb_destination_type")
 
     def build_story(self, story_pk="10", media_type=1):
         return Story(
@@ -182,6 +186,257 @@ class UploadRegressionTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(result, expected)
+
+    def test_media_share_to_fb_destination_selects_feed_and_normalizes_identity_type(self):
+        client = self.build_client()
+        config = {
+            "data": {
+                "xcxp_unified_crossposting_configs_root": {
+                    "configs": [
+                        {
+                            "source_surface": "REELS",
+                            "destination_app": "FB",
+                            "destination_surface": "REELS",
+                            "destination": {
+                                "destination_id": "reels-destination",
+                                "destination_type": "USER",
+                            },
+                        },
+                        {
+                            "source_surface": "FEED",
+                            "destination_app": "FB",
+                            "destination_surface": "FEED",
+                            "destination": {
+                                "obfuscated_identity_id": "feed-destination",
+                                "identity_type": "FB_PAGE",
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+
+        destination = client.media_share_to_fb_destination(config=config)
+
+        self.assertEqual(
+            destination,
+            {
+                "destination_id": "feed-destination",
+                "destination_type": "PAGE",
+            },
+        )
+
+    def test_media_share_to_fb_destination_extracts_feed_service_identity_mapping(self):
+        client = self.build_client()
+        config = {
+            "data": {
+                "fx_service_cache": {
+                    "services": [
+                        {
+                            "custom_service_data": {
+                                "auto_xpost_setting": [
+                                    {
+                                        "is_auto_crosspost_enabled": True,
+                                        "source_surface": "STORY",
+                                    },
+                                    {
+                                        "is_auto_crosspost_enabled": True,
+                                        "source_surface": "FEED",
+                                    },
+                                ]
+                            },
+                            "identity_mapping": [
+                                {
+                                    "destination_identities": [
+                                        {
+                                            "obfuscated_identity_id": "feed-service-destination",
+                                            "identity_type": "FB_USER",
+                                        }
+                                    ]
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+
+        destination = client.media_share_to_fb_destination(config=config)
+
+        self.assertEqual(
+            destination,
+            {
+                "destination_id": "feed-service-destination",
+                "destination_type": "USER",
+            },
+        )
+
+    def test_media_share_to_fb_extra_data_builds_feed_crosspost_payload(self):
+        client = self.build_client()
+
+        extra_data = client.media_share_to_fb_extra_data(
+            destination_id="fb-destination",
+            destination_type="USER",
+            validation_bypass=["AUTO_CROSSPOST_SETTING"],
+            attempt_id="attempt-id",
+        )
+
+        self.assertEqual(
+            extra_data,
+            {
+                "share_to_facebook": "1",
+                "share_to_fb_destination_id": "fb-destination",
+                "share_to_fb_destination_type": "USER",
+                "share_to_facebook_validation_bypass": ["AUTO_CROSSPOST_SETTING"],
+                "no_token_crosspost": "1",
+                "attempt_id": "attempt-id",
+            },
+        )
+
+    def test_media_share_to_threads_config_requests_linked_profile_query(self):
+        client = self.build_client()
+        expected = {
+            "data": {
+                "xcxp_fetch_linked_threads_profile": {
+                    "id": "threads-destination",
+                    "username": "threads-user",
+                }
+            }
+        }
+
+        with mock.patch.object(client, "private_graphql_query_request", return_value=expected) as graphql_request:
+            result = client.media_share_to_threads_config()
+
+        graphql_request.assert_called_once_with(
+            friendly_name="LinkedBarcelonaProfileQuery",
+            root_field_name="xcxp_fetch_linked_threads_profile",
+            variables={},
+            client_doc_id="1294688273527445410149299611",
+            priority="u=3, i",
+            extra_headers={"X-FB-RMD": "state=URL_ELIGIBLE"},
+        )
+        self.assertEqual(result, expected)
+
+    def test_media_share_to_threads_destination_extracts_linked_profile_id(self):
+        client = self.build_client()
+
+        destination = client.media_share_to_threads_destination(
+            config={
+                "data": {
+                    "xcxp_fetch_linked_threads_profile": {
+                        "id": "threads-destination",
+                        "username": "threads-user",
+                        "profile_pic_url": "https://example.com/threads.jpg",
+                    }
+                }
+            }
+        )
+
+        self.assertEqual(
+            destination,
+            {
+                "destination_id": "threads-destination",
+                "username": "threads-user",
+                "profile_pic_url": "https://example.com/threads.jpg",
+            },
+        )
+
+    def test_media_share_to_threads_destination_rejects_unlinked_profile(self):
+        client = self.build_client()
+
+        with self.assertRaises(ClientError) as ctx:
+            client.media_share_to_threads_destination(config={"data": {"xcxp_fetch_linked_threads_profile": None}})
+
+        self.assertIn("no linked Threads profile", str(ctx.exception))
+
+    def test_media_share_to_threads_extra_data_builds_android_payload(self):
+        client = self.build_client()
+
+        extra_data = client.media_share_to_threads_extra_data(
+            destination_id="threads-destination",
+            validation_bypass=["AUTO_CROSSPOST_SETTING"],
+        )
+
+        self.assertEqual(
+            extra_data,
+            {
+                "share_to_threads": "1",
+                "share_to_threads_destination_id": "threads-destination",
+                "share_to_threads_validation_bypass": ["AUTO_CROSSPOST_SETTING"],
+            },
+        )
+
+    def test_media_crossposting_extra_data_combines_destinations_without_mutating_input(self):
+        client = self.build_client()
+        original = {"disable_comments": 1, "attempt_id": "caller-attempt"}
+
+        with mock.patch.object(
+            client,
+            "media_share_to_fb_extra_data",
+            return_value={"share_to_facebook": "1", "attempt_id": "generated-attempt"},
+        ) as facebook_extra:
+            with mock.patch.object(
+                client,
+                "media_share_to_threads_extra_data",
+                return_value={
+                    "share_to_threads": "1",
+                    "share_to_threads_destination_id": "threads-destination",
+                },
+            ) as threads_extra:
+                result = client._media_crossposting_extra_data(
+                    original,
+                    share_to_facebook=True,
+                    share_to_threads=True,
+                    fb_destination_id="fb-destination",
+                    fb_destination_type="PAGE",
+                    threads_destination_id="threads-destination",
+                )
+
+        self.assertEqual(original, {"disable_comments": 1, "attempt_id": "caller-attempt"})
+        self.assertEqual(
+            result,
+            {
+                "share_to_facebook": "1",
+                "share_to_threads": "1",
+                "share_to_threads_destination_id": "threads-destination",
+                "disable_comments": 1,
+                "attempt_id": "caller-attempt",
+            },
+        )
+        facebook_extra.assert_called_once_with(
+            destination_id="fb-destination",
+            destination_type="PAGE",
+            validation_bypass=None,
+        )
+        threads_extra.assert_called_once_with(
+            destination_id="threads-destination",
+            validation_bypass=None,
+        )
+
+    def test_extract_media_preserves_crosspost_metadata(self):
+        payload = self.build_media_payload(media_type=1)
+        payload.update(
+            {
+                "crosspost": ["FB", "IG", "THREADS"],
+                "crosspost_metadata": {
+                    "fb_crosspost_fbid": "fb-media-id",
+                    "threads_crosspost_id": "threads-media-id",
+                },
+                "has_shared_to_fb": 3,
+            }
+        )
+
+        media = extract_media_v1(payload)
+
+        self.assertEqual(media.crosspost, ["FB", "IG", "THREADS"])
+        self.assertEqual(
+            media.crosspost_metadata,
+            {
+                "fb_crosspost_fbid": "fb-media-id",
+                "threads_crosspost_id": "threads-media-id",
+            },
+        )
+        self.assertEqual(media.has_shared_to_fb, 3)
 
     def test_photo_rupload_sends_private_auth_headers(self):
         client = self.build_client()
@@ -716,6 +971,191 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(extra_data["publish_mode"], "scheduled")
         self.assertEqual(json.loads(extra_data["content_scheduling_metadata"]), {"scheduled_publish_time": schedule_at})
 
+    def test_photo_upload_adds_feed_crossposting_params_before_upload(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=1)
+        original = {"disable_comments": 1}
+        crosspost_data = {
+            "disable_comments": 1,
+            "share_to_facebook": "1",
+            "share_to_threads": "1",
+        }
+
+        with mock.patch.object(
+            client,
+            "_media_crossposting_extra_data",
+            return_value=crosspost_data,
+        ) as crossposting:
+            with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)) as photo_rupload:
+                with mock.patch.object(
+                    client,
+                    "photo_configure",
+                    return_value={"status": "ok", "media": media_payload},
+                ) as configure:
+                    with mock.patch("time.sleep"):
+                        media = client.photo_upload(
+                            Path("example.jpg"),
+                            "caption",
+                            extra_data=original,
+                            share_to_facebook=True,
+                            share_to_threads=True,
+                            fb_destination_id="fb-destination",
+                            fb_destination_type="PAGE",
+                            threads_destination_id="threads-destination",
+                        )
+
+        self.assertIsInstance(media, Media)
+        self.assertEqual(original, {"disable_comments": 1})
+        crossposting.assert_called_once_with(
+            {"disable_comments": 1},
+            share_to_facebook=True,
+            share_to_threads=True,
+            fb_destination_id="fb-destination",
+            fb_destination_type="PAGE",
+            fb_validation_bypass=None,
+            threads_destination_id="threads-destination",
+            threads_validation_bypass=None,
+        )
+        photo_rupload.assert_called_once()
+        self.assertEqual(configure.call_args.kwargs["extra_data"], crosspost_data)
+
+    def test_video_upload_adds_feed_crossposting_params_before_upload(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=2)
+        crosspost_data = {
+            "share_to_facebook": "1",
+            "share_to_threads": "1",
+        }
+
+        with mock.patch.object(
+            client,
+            "_media_crossposting_extra_data",
+            return_value=crosspost_data,
+        ) as crossposting:
+            with mock.patch.object(
+                client,
+                "video_rupload",
+                return_value=("1", 720, 1280, 5, Path("/tmp/thumb.jpg")),
+            ) as video_rupload:
+                with mock.patch.object(
+                    client,
+                    "video_configure",
+                    return_value={"status": "ok", "media": media_payload},
+                ) as configure:
+                    with mock.patch("time.sleep"):
+                        media = client.video_upload(
+                            Path("example.mp4"),
+                            "caption",
+                            share_to_facebook=True,
+                            share_to_threads=True,
+                            fb_destination_id="fb-destination",
+                            fb_destination_type="USER",
+                            threads_destination_id="threads-destination",
+                        )
+
+        self.assertIsInstance(media, Media)
+        crossposting.assert_called_once_with(
+            {},
+            share_to_facebook=True,
+            share_to_threads=True,
+            fb_destination_id="fb-destination",
+            fb_destination_type="USER",
+            fb_validation_bypass=None,
+            threads_destination_id="threads-destination",
+            threads_validation_bypass=None,
+        )
+        video_rupload.assert_called_once()
+        self.assertEqual(configure.call_args.kwargs["extra_data"], crosspost_data)
+
+    def test_album_upload_adds_feed_crossposting_params_before_upload(self):
+        client = self.build_client()
+        media_payload = self.build_media_payload(media_type=8)
+        media_payload["carousel_media"] = [self.build_media_payload(media_type=1)]
+        crosspost_data = {
+            "share_to_facebook": "1",
+            "share_to_threads": "1",
+        }
+
+        with mock.patch.object(
+            client,
+            "_media_crossposting_extra_data",
+            return_value=crosspost_data,
+        ) as crossposting:
+            with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)) as photo_rupload:
+                with mock.patch.object(
+                    client,
+                    "album_configure",
+                    return_value={"status": "ok", "media": media_payload},
+                ) as configure:
+                    with mock.patch("time.sleep"):
+                        media = client.album_upload(
+                            [Path("one.jpg")],
+                            "caption",
+                            share_to_facebook=True,
+                            share_to_threads=True,
+                            fb_destination_id="fb-destination",
+                            fb_destination_type="PAGE",
+                            threads_destination_id="threads-destination",
+                        )
+
+        self.assertIsInstance(media, Media)
+        crossposting.assert_called_once_with(
+            {},
+            share_to_facebook=True,
+            share_to_threads=True,
+            fb_destination_id="fb-destination",
+            fb_destination_type="PAGE",
+            fb_validation_bypass=None,
+            threads_destination_id="threads-destination",
+            threads_validation_bypass=None,
+        )
+        photo_rupload.assert_called_once()
+        self.assertEqual(configure.call_args.kwargs["extra_data"], crosspost_data)
+
+    def test_feed_crossposting_preflight_fails_before_uploading_bytes(self):
+        cases = (
+            (
+                "photo",
+                "photo_rupload",
+                lambda client: client.photo_upload(
+                    Path("example.jpg"),
+                    "caption",
+                    share_to_threads=True,
+                ),
+            ),
+            (
+                "video",
+                "video_rupload",
+                lambda client: client.video_upload(
+                    Path("example.mp4"),
+                    "caption",
+                    share_to_threads=True,
+                ),
+            ),
+            (
+                "album",
+                "photo_rupload",
+                lambda client: client.album_upload(
+                    [Path("one.jpg")],
+                    "caption",
+                    share_to_threads=True,
+                ),
+            ),
+        )
+
+        for label, upload_method, invoke in cases:
+            with self.subTest(label=label):
+                client = self.build_client()
+                with mock.patch.object(
+                    client,
+                    "_media_crossposting_extra_data",
+                    side_effect=ClientError("no linked Threads profile"),
+                ):
+                    with mock.patch.object(client, upload_method) as upload:
+                        with self.assertRaises(ClientError):
+                            invoke(client)
+                upload.assert_not_called()
+
     def test_album_upload_with_music_forwards_schedule_at_without_mutating_extra_data(self):
         client = self.build_client()
         track = {
@@ -741,6 +1181,47 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(result, "uploaded")
         self.assertEqual(extra_data, {"disable_comments": 1})
         self.assertEqual(album_upload.call_args.kwargs["schedule_at"], schedule_at)
+
+    def test_feed_music_uploads_forward_crossposting_options(self):
+        client = self.build_client()
+        track = {
+            "id": "track-id",
+            "audio_cluster_id": "cluster-id",
+            "highlight_start_times_in_ms": [12000],
+            "title": "Crosspost song",
+            "display_artist": "Crosspost artist",
+        }
+        options = {
+            "share_to_facebook": True,
+            "share_to_threads": True,
+            "fb_destination_id": "fb-destination",
+            "fb_destination_type": "USER",
+            "threads_destination_id": "threads-destination",
+        }
+
+        with mock.patch.object(client, "photo_upload", return_value="photo") as photo_upload:
+            result = client.photo_upload_with_music(
+                Path("one.jpg"),
+                "caption",
+                track,
+                alacorn_session_id="alacorn-1",
+                **options,
+            )
+        self.assertEqual(result, "photo")
+        for key, value in options.items():
+            self.assertEqual(photo_upload.call_args.kwargs[key], value)
+
+        with mock.patch.object(client, "album_upload", return_value="album") as album_upload:
+            result = client.album_upload_with_music(
+                [Path("one.jpg"), Path("two.jpg")],
+                "caption",
+                track,
+                alacorn_session_id="alacorn-1",
+                **options,
+            )
+        self.assertEqual(result, "album")
+        for key, value in options.items():
+            self.assertEqual(album_upload.call_args.kwargs[key], value)
 
     def test_photo_upload_adds_coauthor_user_ids_without_mutating_extra_data(self):
         client = self.build_client()
@@ -1680,6 +2161,54 @@ class UploadRegressionTestCase(unittest.TestCase):
         self.assertEqual(configure_extra["share_to_fb_destination_id"], "fb-destination-id")
         self.assertTrue(configure_extra["share_to_facebook_reels"])
         self.assertEqual(configure_extra["xpost_surface"], "IG_REELS_COMPOSER")
+
+    def test_clip_upload_share_to_threads_adds_crosspost_params_before_upload(self):
+        client = self.build_client()
+        client.last_json = {"media": self.build_media_payload()}
+        ok_response = Mock(status_code=200)
+        threads_extra = {
+            "share_to_threads": "1",
+            "share_to_threads_destination_id": "threads-destination",
+        }
+
+        with mock.patch.object(
+            client,
+            "media_share_to_threads_extra_data",
+            return_value=threads_extra,
+        ) as share_to_threads_extra:
+            with mock.patch(
+                "instagrapi.mixins.clip.analyze_video",
+                return_value=(Path("/tmp/thumb.jpg"), 720, 1280, 6.023),
+            ):
+                with mock.patch.object(client.private, "get", return_value=ok_response):
+                    with mock.patch.object(
+                        client.private,
+                        "post",
+                        side_effect=[ok_response, ok_response],
+                    ):
+                        with mock.patch.object(
+                            client,
+                            "clip_configure",
+                            return_value={"status": "ok"},
+                        ) as clip_configure:
+                            with mock.patch(
+                                "builtins.open",
+                                mock.mock_open(read_data=b"video-bytes"),
+                            ):
+                                with mock.patch("time.sleep"):
+                                    client.clip_upload(
+                                        Path("example.mp4"),
+                                        "caption",
+                                        share_to_threads=True,
+                                        threads_destination_id="threads-destination",
+                                    )
+
+        share_to_threads_extra.assert_called_once_with(
+            destination_id="threads-destination",
+            validation_bypass=None,
+        )
+        configure_extra = clip_configure.call_args.kwargs["extra_data"]
+        self.assertEqual(configure_extra, threads_extra)
 
     def test_video_story_upload_falls_back_to_recent_story_when_configure_has_no_media(self):
         client = self.build_client()


### PR DESCRIPTION
## Summary

- add Facebook Feed and Threads destination discovery using current mobile GraphQL flows
- add `share_to_facebook` and `share_to_threads` options to photo, video, album, feed-music, and Reel uploads
- preserve cross-posting status fields in `Media` and document explicit destination overrides
- cover both unified mobile config responses and the service/identity mapping shape reported in the issue

## Behavior

Feed uploads resolve requested linked destinations before uploading media bytes. Callers can provide `fb_destination_id`, `fb_destination_type`, or `threads_destination_id` when discovery is unavailable, and explicit `extra_data` fields retain precedence over generated values.

## Testing

- `ruff check .`
- `ruff format --check .`
- `pytest -q tests/regression` (684 passed, 3 skipped, 25 subtests passed)
- `bandit -c pyproject.toml -r instagrapi`
- `mkdocs build --strict`
- `pre-commit run --all-files`
- targeted live discovery tests against current Instagram endpoints (2 passed; 4 publish/destination tests skipped because linked destinations were unavailable)

Closes #2747
