### PR TITLE
Fix saved session validation during login

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,17 @@ cl = Client()
 cl.login(USERNAME, PASSWORD)
 cl.dump_settings("session.json")
 
-# reload later without entering credentials again
+# reload later; the saved session is validated before reuse
 cl = Client()
 cl.load_settings("session.json")
 cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
 ```
+
+`login()` reuses a valid saved session. If Instagram rejects that session with
+`login_required`, instagrapi clears the stale authorization and logs in again
+with the supplied credentials. Dump the settings after login so a refreshed
+session is persisted.
 
 If you want more explicit control over the loaded session object:
 
@@ -110,6 +116,7 @@ from instagrapi import Client
 cl = Client()
 cl.set_settings(cl.load_settings("session.json"))
 cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
 ```
 
 ### Login using a sessionid

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,12 @@ from instagrapi import Client
 cl = Client()
 cl.load_settings("session.json")
 cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
 ```
+
+The saved session is validated during `login()`. If Instagram rejects it with
+`login_required`, instagrapi performs a fresh login with the supplied
+credentials. Saving the settings again persists any refreshed session.
 
 ## What's Next?
 

--- a/docs/usage-guide/best-practices.md
+++ b/docs/usage-guide/best-practices.md
@@ -215,10 +215,14 @@ from instagrapi import Client
 cl = Client()
 cl.load_settings("session.json")
 cl.login(USERNAME, PASSWORD)
-cl.get_timeline_feed()  # optional session validity check
+cl.dump_settings("session.json")
 ```
 
-You'll notice we do a call to `cl.get_timeline_feed()` to check if the session is valid. If it's not valid, you'll get an exception.
+`login()` validates the loaded session before reusing it. When Instagram
+returns `login_required`, instagrapi clears the rejected authorization and
+logs in again with the supplied credentials. Other errors still propagate so
+rate limits, challenges, and network failures are not mistaken for an expired
+session. Save the settings again in case the session was refreshed.
 
 If you want more explicit control over the loaded settings object:
 
@@ -229,63 +233,25 @@ cl = Client()
 session = cl.load_settings("session.json")
 cl.set_settings(session)
 cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
 ```
 
 Putting this all together, you can write a reusable login helper like this:
 
 ``` python
 from instagrapi import Client
-from instagrapi.exceptions import LoginRequired
-import logging
-
-logger = logging.getLogger()
+from pathlib import Path
 
 
 def login_user():
-    """
-    Attempts to login to Instagram using either the provided session information
-    or the provided username and password.
-    """
-
+    """Login with a saved session and refresh it only when required."""
+    session_file = Path("session.json")
     cl = Client()
-    session = cl.load_settings("session.json")
+    if session_file.exists():
+        cl.load_settings(session_file)
 
-    login_via_session = False
-    login_via_pw = False
-
-    if session:
-        try:
-            cl.set_settings(session)
-            cl.login(USERNAME, PASSWORD)
-
-            # check if session is valid
-            try:
-                cl.get_timeline_feed()
-            except LoginRequired:
-                logger.info("Session is invalid, need to login via username and password")
-
-                old_session = cl.get_settings()
-
-                # use the same device uuids across logins
-                cl.set_settings({})
-                cl.set_uuids(old_session["uuids"])
-
-                cl.login(USERNAME, PASSWORD)
-            login_via_session = True
-        except Exception as e:
-            logger.info("Couldn't login user using session information: %s" % e)
-
-    if not login_via_session:
-        try:
-            logger.info("Attempting to login via username and password. username: %s" % USERNAME)
-            if cl.login(USERNAME, PASSWORD):
-                login_via_pw = True
-        except Exception as e:
-            logger.info("Couldn't login user using username and password: %s" % e)
-
-    if not login_via_pw and not login_via_session:
-        raise Exception("Couldn't login user with either password or session")
-
+    cl.login(USERNAME, PASSWORD)
+    cl.dump_settings(session_file)
     return cl
 ```
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -146,9 +146,9 @@ Next time:
 
 ```python
 cl = Client()
-cl.set_settings(cl.load_settings("/tmp/dump.json"))
+cl.load_settings("/tmp/dump.json")
 cl.login(USERNAME, PASSWORD)
-cl.get_timeline_feed()  # check session
+cl.dump_settings("/tmp/dump.json")
 ```
 
 ### Manage device, proxy and other account settings

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -20,6 +20,7 @@ from instagrapi.exceptions import (
     BadPassword,
     ClientError,
     ClientThrottledError,
+    LoginRequired,
     PleaseWaitFewMinutes,
     PrivateError,
     ReloginAttemptExceeded,
@@ -759,6 +760,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         -------
         bool
             A boolean value
+
+        Notes
+        -----
+        An existing session is validated before it is reused. If Instagram
+        rejects it, the saved authorization state is cleared and the supplied
+        credentials are used to log in again.
         """
         if username and password:
             self.username = username
@@ -782,7 +789,11 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         #     if time.time() - self.last_login < 60 * 60 * 24:
         #        return True  # already login
         if self.user_id and not relogin:
-            return True  # already login
+            try:
+                self.account_info()
+            except LoginRequired:
+                return self.login(relogin=True, verification_code=verification_code)
+            return True
         try:
             self.pre_login_flow()
         except (PleaseWaitFewMinutes, ClientThrottledError):

--- a/tests/live/test_client.py
+++ b/tests/live/test_client.py
@@ -1,7 +1,26 @@
+import tempfile
+
 from tests.helpers import *
 
 
 class ClientTestCase(unittest.TestCase):
+    @unittest.skipUnless(TEST_ACCOUNTS_URL, "TEST_ACCOUNTS_URL is required for saved session login tests")
+    def test_login_validates_saved_session_before_reuse(self):
+        original = fresh_test_account()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_file = Path(tmpdir) / "session.json"
+            original.dump_settings(session_file)
+
+            restored = Client(proxy=getattr(original, "proxy", None))
+            restored.load_settings(session_file)
+            with mock.patch.object(restored, "account_info", wraps=restored.account_info) as account_info:
+                result = restored.login(original.username, original.password)
+
+        self.assertTrue(result)
+        account_info.assert_called_once_with()
+        self.assertEqual(restored.user_id, original.user_id)
+
     def test_default_settings_are_not_shared_between_clients(self):
         first = Client()
         second = Client()

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -1,4 +1,4 @@
-from instagrapi.exceptions import BadPassword, ClientNotFoundError
+from instagrapi.exceptions import BadPassword, ClientNotFoundError, LoginRequired
 from tests.helpers import *
 
 
@@ -64,15 +64,56 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         self.assertEqual(client.private.cookies.get_dict(), {})
         self.assertEqual(client.public.cookies.get_dict(), {})
 
-    def test_login_returns_early_when_user_is_already_authorized(self):
+    def test_login_validates_existing_session_before_returning(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123"}
+        client.account_info = Mock(return_value=object())
         client.pre_login_flow = Mock()
         client.private_request = Mock()
 
         result = client.login("example", "password")
 
         self.assertTrue(result)
+        client.account_info.assert_called_once_with()
+        client.pre_login_flow.assert_not_called()
+        client.private_request.assert_not_called()
+
+    def test_login_refreshes_session_rejected_during_validation(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "123", "sessionid": "stale"}
+        client.private.cookies.set("sessionid", "stale")
+        client.public.cookies.set("sessionid", "public-stale")
+        client.private.headers["Authorization"] = "Bearer stale"
+        client.account_info = Mock(side_effect=LoginRequired())
+        client.last_response = Mock(headers={"ig-set-authorization": "Bearer fresh"})
+        client.parse_authorization = Mock(return_value={"ds_user_id": "123", "sessionid": "fresh"})
+        client.pre_login_flow = Mock(return_value=True)
+        client.password_encrypt = Mock(return_value="enc-password")
+        client.private_request = Mock(return_value=True)
+        client.login_flow = Mock()
+
+        result = client.login("example", "password")
+
+        self.assertTrue(result)
+        client.account_info.assert_called_once_with()
+        client.pre_login_flow.assert_called_once_with()
+        self.assertEqual(client.private_request.call_args.args[0], "accounts/login/")
+        self.assertNotIn("Authorization", client.private.headers)
+        self.assertEqual(client.private.cookies.get_dict(), {})
+        self.assertEqual(client.public.cookies.get_dict(), {})
+        self.assertEqual(client.authorization_data["sessionid"], "fresh")
+        self.assertEqual(client.relogin_attempt, 0)
+
+    def test_login_does_not_mask_other_session_validation_errors(self):
+        client = Client()
+        client.authorization_data = {"ds_user_id": "123"}
+        client.account_info = Mock(side_effect=PleaseWaitFewMinutes())
+        client.pre_login_flow = Mock()
+        client.private_request = Mock()
+
+        with self.assertRaises(PleaseWaitFewMinutes):
+            client.login("example", "password")
+
         client.pre_login_flow.assert_not_called()
         client.private_request.assert_not_called()
 


### PR DESCRIPTION
## Summary

- validate an existing private session before `login()` returns `True`
- retry with the supplied credentials only when Instagram rejects the saved session with `LoginRequired`
- document the refreshed session persistence flow and add regression/live coverage

## Tests

- `python -m pytest tests/regression -q` (`686 passed`, `3 skipped`)
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mkdocs build --strict`
- saved-session reload live test passed with a real test account
- Reel Facebook preflight returned `status=ok`; destination assertions skipped because the account had no linked Facebook destination

Fixes #2751
