### PR TITLE
Fix pinned media filtering by profile

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -1324,22 +1324,21 @@ class MediaMixin:
         List[Media]
             A list of objects of Media
         """
-        default_nav = self.base_headers["X-IG-Nav-Chain"]
-        self.base_headers["X-IG-Nav-Chain"] = (
-            "MainFeedFragment:feed_timeline:12:main_home::,UserDetailFragment:profile:13:button::"
-        )
+        user_id = str(user_id)
+        nav_chain = "MainFeedFragment:feed_timeline:12:main_home::,UserDetailFragment:profile:13:button::"
         medias = self.private_request(
             f"feed/user/{user_id}/",
             params={
                 "exclude_comment": "true",
                 "only_fetch_first_carousel_media": "false",
             },
+            headers={"X-IG-Nav-Chain": nav_chain},
         )
         pinned_medias = []
         for media in medias["items"]:
-            if media.get("timeline_pinned_user_ids") is not None:
+            pinned_user_ids = media.get("timeline_pinned_user_ids") or ()
+            if user_id in map(str, pinned_user_ids):
                 pinned_medias.append(extract_media_v1(media))
-        self.base_headers["X-IG-Nav-Chain"] = default_nav
         return pinned_medias
 
     def user_medias(self, user_id: str, amount: int = 0, sleep: int = 0) -> List[Media]:

--- a/tests/regression/test_media.py
+++ b/tests/regression/test_media.py
@@ -734,6 +734,53 @@ class UserMediasPrivateFirstRegressionTestCase(unittest.TestCase):
         private_lookup.assert_not_called()
 
 
+class UserPinnedMediasRegressionTestCase(unittest.TestCase):
+    def test_user_pinned_medias_filters_by_requested_user_id(self):
+        client = Client()
+        response = {
+            "items": [
+                {"code": "target-int", "timeline_pinned_user_ids": [1349651722]},
+                {"code": "target-str", "timeline_pinned_user_ids": ["1349651722"]},
+                {"code": "other-user", "timeline_pinned_user_ids": [999]},
+                {"code": "ordinary", "timeline_pinned_user_ids": []},
+                {"code": "missing"},
+            ]
+        }
+
+        with mock.patch.object(client, "private_request", return_value=response):
+            with mock.patch(
+                "instagrapi.mixins.media.extract_media_v1",
+                side_effect=lambda media: media,
+            ):
+                medias = client.user_pinned_medias("1349651722")
+
+        self.assertEqual(
+            [media["code"] for media in medias],
+            ["target-int", "target-str"],
+        )
+
+    def test_user_pinned_medias_sends_profile_nav_chain(self):
+        client = Client()
+
+        with mock.patch.object(
+            client,
+            "private_request",
+            return_value={"items": []},
+        ) as private_request:
+            client.user_pinned_medias("1349651722")
+
+        private_request.assert_called_once_with(
+            "feed/user/1349651722/",
+            params={
+                "exclude_comment": "true",
+                "only_fetch_first_carousel_media": "false",
+            },
+            headers={
+                "X-IG-Nav-Chain": "MainFeedFragment:feed_timeline:12:main_home::,UserDetailFragment:profile:13:button::"
+            },
+        )
+
+
 class MediaShareToStoryRegressionTestCase(unittest.TestCase):
     def test_media_share_to_story_uses_existing_media_as_story_sticker(self):
         client = Client()


### PR DESCRIPTION
## Summary

- filter `user_pinned_medias()` by the requested profile ID instead of field presence
- normalize pinned user IDs to handle integer and string response variants
- pass the profile nav chain as a per-request header
- add regression coverage for empty, missing, mismatched, integer, and string ID cases

Closes #2761

Thanks @therapy for the report and suggested direction.

## Tests

- `python -m pytest -q tests/regression` (`688 passed`, `3 skipped`)
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m bandit -q -c pyproject.toml -r instagrapi`
- `python -m mkdocs build --strict`
- `python -m pre_commit run --all-files`
- live read on the issue profile: the method result exactly matched the server-marked pinned set and excluded ordinary posts
- live account round-trip on `sk.test`: temporary upload -> pin -> `user_pinned_medias()` readback -> unpin -> delete (passed; original pin state restored)
